### PR TITLE
trymito.io: add coming soon features, reorg for easy adding

### DIFF
--- a/trymito.io/components/FeatureRow/FeatureRow.tsx
+++ b/trymito.io/components/FeatureRow/FeatureRow.tsx
@@ -60,9 +60,7 @@ const FeatureRow = (props: {
                             </div>
                             
                         )
-                    }
-                    // TODO: handle if a boolean
-                    
+                    }                    
                 })} 
             </div>
         )

--- a/trymito.io/components/FeatureRow/FeatureRow.tsx
+++ b/trymito.io/components/FeatureRow/FeatureRow.tsx
@@ -6,34 +6,15 @@ import FeatureIncludedDot from '../../public/FeatureIncludedDot.png'
 import FeatureNotIncludedDot from '../../public/FeatureNotIncludedDot.png'
 
 
-const FeatureRow = (props: {rowLabel: string, featureRowContent: boolean[] | string[], lastFeature: boolean}): JSX.Element => {
-    const typeOfFeatureRow = typeof props.featureRowContent[0] === 'boolean' ? 'Feature' : 'Label'
+const FeatureRow = (props: {
+    isHeader?: boolean,
+    rowLabel: string, 
+    featureRowContent: (boolean | string)[], 
+    lastFeature?: boolean
+}): JSX.Element => {
     const displayBottomBorderClass = props.lastFeature ? '' : featureRowStyles.display_bottom_border
  
-    if (typeOfFeatureRow === 'Feature') {
-        return (
-            <div className={featureRowStyles.feature_row_container + ' ' + displayBottomBorderClass}> 
-                <p className={featureRowStyles.row_label}>
-                    {props.rowLabel}
-                </p>
-                {props.featureRowContent.map((frc, idx) => {
-                    const imageSrc = frc ? FeatureIncludedDot : FeatureNotIncludedDot
-                    const imageAlt = frc ? 'feature included' : 'feature not included'
-
-                    return (
-                        <div className={featureRowStyles.feature_row_content} key={idx}>
-                            <Image
-                                src={imageSrc}
-                                alt={imageAlt}
-                                width={15}
-                                height={15}
-                            />
-                        </div>
-                    )
-                })} 
-            </div>
-        )
-    } else {
+    if (props.isHeader) {
         return (
             <div className={featureRowStyles.feature_row_container + ' ' + displayBottomBorderClass + ' ' + featureRowStyles.section_header}> 
                 <p className={featureRowStyles.row_label}>
@@ -45,6 +26,43 @@ const FeatureRow = (props: {rowLabel: string, featureRowContent: boolean[] | str
                             {frc}
                         </p>
                     )
+                })} 
+            </div>
+        )
+    } else {
+        return (
+            <div className={featureRowStyles.feature_row_container + ' ' + displayBottomBorderClass}> 
+                <p className={featureRowStyles.row_label}>
+                    {props.rowLabel}
+                </p>
+                {props.featureRowContent.map((frc, idx) => {
+
+                    if (typeof frc === 'boolean') {
+                        const imageSrc = frc ? FeatureIncludedDot : FeatureNotIncludedDot
+                        const imageAlt = frc ? 'feature included' : 'feature not included'
+
+                        return (
+                            <div className={featureRowStyles.feature_row_content} key={idx}>
+                                <Image
+                                    src={imageSrc}
+                                    alt={imageAlt}
+                                    width={15}
+                                    height={15}
+                                />
+                            </div>
+                        )
+                    } else {
+                        return (
+                            <div className={featureRowStyles.feature_row_content} key={idx}>
+                                <p>
+                                    {frc}
+                                </p>
+                            </div>
+                            
+                        )
+                    }
+                    // TODO: handle if a boolean
+                    
                 })} 
             </div>
         )

--- a/trymito.io/components/FeatureSection/FeatureSection.tsx
+++ b/trymito.io/components/FeatureSection/FeatureSection.tsx
@@ -1,0 +1,54 @@
+import { Feature, PlanType } from "../../pages/plans"
+import FeatureRow from "../FeatureRow/FeatureRow"
+
+const FeatureSection = (props: {
+    sectionTitle: string,
+    mobilePlanDisplayed?: PlanType
+    features: Feature[],
+}): JSX.Element => {
+    const mobilePlanDisplayed = props.mobilePlanDisplayed;
+
+    if (mobilePlanDisplayed !== undefined) {
+        return (
+            <>
+                <FeatureRow
+                    isHeader
+                    rowLabel={props.sectionTitle} 
+                    featureRowContent={[mobilePlanDisplayed]}
+                />
+                {props.features.map((f, idx) => {
+                    return (
+                    <FeatureRow
+                        key={idx}
+                        rowLabel={f.feature} 
+                        featureRowContent={[f.planSupport[mobilePlanDisplayed]]}
+                        lastFeature={idx == props.features.length - 1}
+                    />
+                    )
+                })}
+            </>
+        )
+    } else {
+        return (
+            <>
+                <FeatureRow
+                    isHeader
+                    rowLabel={props.sectionTitle} 
+                    featureRowContent={['Open Source', 'Pro', 'Enterprise']}
+                />
+                {props.features.map((f, idx) => {
+                    return (
+                    <FeatureRow
+                        key={idx}
+                        rowLabel={f.feature} 
+                        featureRowContent={[f.planSupport['Open Source'], f.planSupport['Pro'], f.planSupport['Enterprise']]}
+                        lastFeature={idx == props.features.length - 1}
+                    />
+                    )
+                })}
+            </>
+        )
+    }
+}
+
+export default FeatureSection; 

--- a/trymito.io/pages/plans.tsx
+++ b/trymito.io/pages/plans.tsx
@@ -22,168 +22,218 @@ import TextButton from '../components/TextButton/TextButton'
 const PRO_PLAN_ID = "pro-plan"
 const PRIVATE_TELEMTRY_FAQ_ID = 'private-telemetry-faq'
 
-type PlanType = 'Open Source' | 'Pro' | 'Enterprise'
-interface PlanFeatures {
-  'Integration': Record<PlanType, string>,
-  'JupyterLab 2 & 3': Record<PlanType, boolean>,
-  'CSV, XLSX Import': Record<PlanType, boolean>,
-  'Dataframe Import': Record<PlanType, boolean>,
-  'Exploration': Record<PlanType, string>,
-  'Plotly Graph Generation': Record<PlanType, boolean>,
-  'Summary Statistics': Record<PlanType, boolean>,
-  'Search Functionality': Record<PlanType, boolean>,
-  'Transformation': Record<PlanType, string>,
-  'Pivot Tables': Record<PlanType, boolean>,
-  'Filtering and Sorting': Record<PlanType, boolean>,
-  'Merge (Lookups)': Record<PlanType, boolean>,
-  'Type Handling': Record<PlanType, boolean>,
-  'Add/Remove Columns': Record<PlanType, boolean>,
-  'Excel-Style Formulas': Record<PlanType, boolean>,
-  'Deduplication': Record<PlanType, boolean>,
-  'Privacy': Record<PlanType, string>,
-  'Local Extension': Record<PlanType, boolean>,
-  'Turn off Telemetry': Record<PlanType, boolean>,
-  'Support': Record<PlanType, string>,
-  'Customer Support': Record<PlanType, boolean>,
-  'Success Manager': Record<PlanType, boolean>,
-  'Onboarding Program': Record<PlanType, boolean>,
-  'Custom Features': Record<PlanType, boolean>,
-  'Custom Integration': Record<PlanType, boolean>,
+type PlanType = 'Open Source' | 'Pro' | 'Enterprise';
+interface Feature {
+  feature: string,
+  planSupport: Record<PlanType, string | boolean>
 }
 
-const planFeatures: PlanFeatures = {
-  'Integration': {
-    'Open Source': 'Open Source',
-    'Pro': 'Pro',
-    'Enterprise': 'Enterprise' 
+const INTEGRATION_FEATURES: Feature[] = [
+  {
+    feature: 'JupyterLab 2 & 3',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
   },
-  'JupyterLab 2 & 3': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
+  {
+    feature: 'CSV, XLSX Import',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
   },
-  'CSV, XLSX Import': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
+  {
+    feature: 'Dataframe Import',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
   },
-  'Dataframe Import': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
+  {
+    feature: 'CSV, XLSX Export',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
   },
-  'Exploration': {
-    'Open Source': 'Open Source',
-    'Pro': 'Pro',
-    'Enterprise': 'Enterprise' 
+  {
+    feature: 'Formatting Export',
+    planSupport: {
+      'Open Source': false,
+      'Pro': 'Coming soon!',
+      'Enterprise': 'Coming soon!' 
+    }
   },
-  'Plotly Graph Generation': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
-  },
-  'Summary Statistics': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
-  },
-  'Search Functionality': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
-  },
-  'Transformation': {
-    'Open Source': 'Open Source',
-    'Pro': 'Pro',
-    'Enterprise': 'Enterprise' 
-  },
-  'Pivot Tables': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
-  },
-  'Filtering and Sorting': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
-  },
-  'Merge (Lookups)': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
-  },
-  'Type Handling': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
-  },
-  'Add/Remove Columns': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
-  },
-  'Excel-Style Formulas': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
-  },
-  'Deduplication': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
-  },
-  'Privacy': {
-    'Open Source': 'Open Source',
-    'Pro': 'Pro',
-    'Enterprise': 'Enterprise' 
-  },
-  'Local Extension': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
-  },
-  'Turn off Telemetry': {
-    'Open Source': false,
-    'Pro': true,
-    'Enterprise': true 
-  },
-  'Support': {
-    'Open Source': 'Open Source',
-    'Pro': 'Pro',
-    'Enterprise': 'Enterprise' 
-  },
-  'Customer Support': {
-    'Open Source': true,
-    'Pro': true,
-    'Enterprise': true 
-  },
-  'Success Manager': {
-    'Open Source': false,
-    'Pro': true,
-    'Enterprise': true 
-  },
-  'Onboarding Program': {
-    'Open Source': false,
-    'Pro': false,
-    'Enterprise': true 
-  },
-  'Custom Features': {
-    'Open Source': false,
-    'Pro': false,
-    'Enterprise': true 
-  },
-  'Custom Integration': {
-    'Open Source': false,
-    'Pro': false,
-    'Enterprise': true 
-  },
-}
+]
 
+const EXPLORATION_FEATURES: Feature[] = [
+  {
+    feature: 'Summary Statistics',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Search Functionality',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Cell Formatting',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Plotly Graph Generation',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Graph Formatting',
+    planSupport: {
+      'Open Source': false,
+      'Pro': 'Coming soon!',
+      'Enterprise': 'Coming soon!' 
+    }
+  },
+]
 
-// We keep track of the last features in each section as a bit of a hacky workaround
-// to not display the separator line in the plans feature grid
-// when the feature is the last feature in the section.
-const LAST_FEATURES_IN_SECTION = ['Custom Integration', 'Turn off Telemetry', 'Deduplication', 'Search Functionality', 'Dataframe Import']
+const TRANSFORMATION_FEATURES: Feature[] = [
+  {
+    feature: 'Pivot Tables',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Filtering and Sorting',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Merge (Lookups)',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Type Handling',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Add/Remove Columns',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Excel-Style Formulas',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Deduplication',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+]
+
+const PRIVACY_FEATURES: Feature[] = [
+  {
+    feature: 'Local Extension',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Turn off Telemetry',
+    planSupport: {
+      'Open Source': false,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+]
+
+const SUPPORT_FEATURES: Feature[] = [
+  {
+    feature: 'Customer Support',
+    planSupport: {
+      'Open Source': true,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Success Manager',
+    planSupport: {
+      'Open Source': false,
+      'Pro': true,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Onboarding Program',
+    planSupport: {
+      'Open Source': false,
+      'Pro': false,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Custom Features',
+    planSupport: {
+      'Open Source': false,
+      'Pro': false,
+      'Enterprise': true 
+    }
+  },
+  {
+    feature: 'Custom Integration',
+    planSupport: {
+      'Open Source': false,
+      'Pro': false,
+      'Enterprise': true 
+    }
+  },
+]
 
 const Plans: NextPage = () => {
 
@@ -369,26 +419,155 @@ const Plans: NextPage = () => {
             </section>
 
             <section className={pageStyles.suppress_section_margin_top + ' display-mobile-only'}>
-              {Object.entries(planFeatures).map(([key, value], idx) => {
+              <FeatureRow
+                isHeader
+                rowLabel={'Integration'} 
+                featureRowContent={[mobilePlanDisplayed]}
+              />
+              {INTEGRATION_FEATURES.map((f, idx) => {
                 return (
-                  <FeatureRow 
+                  <FeatureRow
                     key={idx}
-                    rowLabel={key} 
-                    featureRowContent={[value[mobilePlanDisplayed]]}
-                    lastFeature={LAST_FEATURES_IN_SECTION.includes(key)}
+                    rowLabel={f.feature} 
+                    featureRowContent={[f.planSupport[mobilePlanDisplayed]]}
+                    lastFeature={idx == INTEGRATION_FEATURES.length - 1}
+                  />
+                )
+              })}
+              <FeatureRow
+                isHeader
+                rowLabel={'Exploration'} 
+                featureRowContent={[mobilePlanDisplayed]}
+              />
+              {EXPLORATION_FEATURES.map((f, idx) => {
+                return (
+                  <FeatureRow
+                    key={idx}
+                    rowLabel={f.feature} 
+                    featureRowContent={[f.planSupport[mobilePlanDisplayed]]}
+                    lastFeature={idx == EXPLORATION_FEATURES.length - 1}
+                  />
+                )
+              })}
+              <FeatureRow
+                isHeader
+                rowLabel={'Transformation'} 
+                featureRowContent={[mobilePlanDisplayed]}
+              />
+              {TRANSFORMATION_FEATURES.map((f, idx) => {
+                return (
+                  <FeatureRow
+                    key={idx}
+                    rowLabel={f.feature} 
+                    featureRowContent={[f.planSupport[mobilePlanDisplayed]]}
+                    lastFeature={idx == TRANSFORMATION_FEATURES.length - 1}
+                  />
+                )
+              })}
+              <FeatureRow
+                isHeader
+                rowLabel={'Privacy'} 
+                featureRowContent={[mobilePlanDisplayed]}
+              />
+              {PRIVACY_FEATURES.map((f, idx) => {
+                return (
+                  <FeatureRow
+                    key={idx}
+                    rowLabel={f.feature} 
+                    featureRowContent={[f.planSupport[mobilePlanDisplayed]]}
+                    lastFeature={idx == PRIVACY_FEATURES.length - 1}
+                  />
+                )
+              })}
+              <FeatureRow
+                isHeader
+                rowLabel={'Support'} 
+                featureRowContent={[mobilePlanDisplayed]}
+              />
+              {SUPPORT_FEATURES.map((f, idx) => {
+                return (
+                  <FeatureRow
+                    key={idx}
+                    rowLabel={f.feature} 
+                    featureRowContent={[f.planSupport[mobilePlanDisplayed]]}
+                    lastFeature={idx == SUPPORT_FEATURES.length - 1}
                   />
                 )
               })}
             </section>
             <section className={pageStyles.suppress_section_margin_top + ' ' + plansStyles.plan_feature_grid_container + ' display-desktop-only-inline-block'}>
-              {Object.entries(planFeatures).map(([key, value], idx) => {
-                const values: string[] | boolean [] = [value['Open Source'], value['Pro'], value['Enterprise']]
+              <FeatureRow
+                isHeader
+                rowLabel={'Integration'} 
+                featureRowContent={['Open Source', 'Pro', 'Enterprise']}
+              />
+              {INTEGRATION_FEATURES.map((f, idx) => {
                 return (
-                  <FeatureRow 
+                  <FeatureRow
                     key={idx}
-                    rowLabel={key} 
-                    featureRowContent={values}
-                    lastFeature={LAST_FEATURES_IN_SECTION.includes(key)}
+                    rowLabel={f.feature} 
+                    featureRowContent={[f.planSupport['Open Source'], f.planSupport['Pro'], f.planSupport['Enterprise']]}
+                    lastFeature={idx == INTEGRATION_FEATURES.length - 1}
+                  />
+                )
+              })}
+              <FeatureRow
+                isHeader
+                rowLabel={'Exploration'} 
+                featureRowContent={['Open Source', 'Pro', 'Enterprise']}
+              />
+              {EXPLORATION_FEATURES.map((f, idx) => {
+                return (
+                  <FeatureRow
+                    key={idx}
+                    rowLabel={f.feature} 
+                    featureRowContent={[f.planSupport['Open Source'], f.planSupport['Pro'], f.planSupport['Enterprise']]}
+                    lastFeature={idx == EXPLORATION_FEATURES.length - 1}
+                  />
+                )
+              })}
+              <FeatureRow
+                isHeader
+                rowLabel={'Transformation'} 
+                featureRowContent={['Open Source', 'Pro', 'Enterprise']}
+              />
+              {TRANSFORMATION_FEATURES.map((f, idx) => {
+                return (
+                  <FeatureRow
+                    key={idx}
+                    rowLabel={f.feature} 
+                    featureRowContent={[f.planSupport['Open Source'], f.planSupport['Pro'], f.planSupport['Enterprise']]}
+                    lastFeature={idx == TRANSFORMATION_FEATURES.length - 1}
+                  />
+                )
+              })}
+              <FeatureRow
+                isHeader
+                rowLabel={'Privacy'} 
+                featureRowContent={['Open Source', 'Pro', 'Enterprise']}
+              />
+              {PRIVACY_FEATURES.map((f, idx) => {
+                return (
+                  <FeatureRow
+                    key={idx}
+                    rowLabel={f.feature} 
+                    featureRowContent={[f.planSupport['Open Source'], f.planSupport['Pro'], f.planSupport['Enterprise']]}
+                    lastFeature={idx == PRIVACY_FEATURES.length - 1}
+                  />
+                )
+              })}
+              <FeatureRow
+                isHeader
+                rowLabel={'Support'} 
+                featureRowContent={['Open Source', 'Pro', 'Enterprise']}
+              />
+              {SUPPORT_FEATURES.map((f, idx) => {
+                return (
+                  <FeatureRow
+                    key={idx}
+                    rowLabel={f.feature} 
+                    featureRowContent={[f.planSupport['Open Source'], f.planSupport['Pro'], f.planSupport['Enterprise']]}
+                    lastFeature={idx == SUPPORT_FEATURES.length - 1}
                   />
                 )
               })}

--- a/trymito.io/pages/plans.tsx
+++ b/trymito.io/pages/plans.tsx
@@ -309,7 +309,7 @@ const Plans: NextPage = () => {
                   $10 a month
                 </p>
                 <p className={plansStyles.plan_description}>
-                  Mito’s analysis tools, with no telemetry and advanced support.
+                  Mito’s analysis tools, with no telemetry, advanced features, and personal support.
                 </p>
                 <div className={plansStyles.plan_bullets_container}> 
                   <PlanBullet>
@@ -324,12 +324,12 @@ const Plans: NextPage = () => {
                   </PlanBullet>
                   <PlanBullet>
                     <p>
-                      Dedicated customer support
+                      Advanced features
                     </p>
                   </PlanBullet>
                   <PlanBullet>
                     <p>
-                      Future Pro functionality
+                      Dedicated customer support
                     </p>
                   </PlanBullet>
                 </div>

--- a/trymito.io/pages/plans.tsx
+++ b/trymito.io/pages/plans.tsx
@@ -11,10 +11,10 @@ import PlanBullet from '../components/PlanBullet/PlanBullet';
 import TranslucentButton from '../components/TranslucentButton/TranslucentButton';
 import DropdownItem from '../components/DropdownItem/DropdownItem';
 import Dropdown from '../components/Dropdown/Dropdown';
-import FeatureRow from '../components/FeatureRow/FeatureRow'
 import FAQCard from '../components/FAQCard/FAQCard'
 import CTACard from '../components/CTACard/CTACard'
 import TextButton from '../components/TextButton/TextButton'
+import FeatureSection from '../components/FeatureSection/FeatureSection'
 
 /* 
   Labels used to scroll to specific location of the page
@@ -22,8 +22,8 @@ import TextButton from '../components/TextButton/TextButton'
 const PRO_PLAN_ID = "pro-plan"
 const PRIVATE_TELEMTRY_FAQ_ID = 'private-telemetry-faq'
 
-type PlanType = 'Open Source' | 'Pro' | 'Enterprise';
-interface Feature {
+export type PlanType = 'Open Source' | 'Pro' | 'Enterprise';
+export interface Feature {
   feature: string,
   planSupport: Record<PlanType, string | boolean>
 }
@@ -419,158 +419,53 @@ const Plans: NextPage = () => {
             </section>
 
             <section className={pageStyles.suppress_section_margin_top + ' display-mobile-only'}>
-              <FeatureRow
-                isHeader
-                rowLabel={'Integration'} 
-                featureRowContent={[mobilePlanDisplayed]}
+              <FeatureSection
+                mobilePlanDisplayed={mobilePlanDisplayed}
+                sectionTitle='Integration'
+                features={INTEGRATION_FEATURES}
               />
-              {INTEGRATION_FEATURES.map((f, idx) => {
-                return (
-                  <FeatureRow
-                    key={idx}
-                    rowLabel={f.feature} 
-                    featureRowContent={[f.planSupport[mobilePlanDisplayed]]}
-                    lastFeature={idx == INTEGRATION_FEATURES.length - 1}
-                  />
-                )
-              })}
-              <FeatureRow
-                isHeader
-                rowLabel={'Exploration'} 
-                featureRowContent={[mobilePlanDisplayed]}
+              <FeatureSection
+                mobilePlanDisplayed={mobilePlanDisplayed}
+                sectionTitle='Exploration'
+                features={EXPLORATION_FEATURES}
               />
-              {EXPLORATION_FEATURES.map((f, idx) => {
-                return (
-                  <FeatureRow
-                    key={idx}
-                    rowLabel={f.feature} 
-                    featureRowContent={[f.planSupport[mobilePlanDisplayed]]}
-                    lastFeature={idx == EXPLORATION_FEATURES.length - 1}
-                  />
-                )
-              })}
-              <FeatureRow
-                isHeader
-                rowLabel={'Transformation'} 
-                featureRowContent={[mobilePlanDisplayed]}
+              <FeatureSection
+                mobilePlanDisplayed={mobilePlanDisplayed}
+                sectionTitle='Transformation'
+                features={TRANSFORMATION_FEATURES}
               />
-              {TRANSFORMATION_FEATURES.map((f, idx) => {
-                return (
-                  <FeatureRow
-                    key={idx}
-                    rowLabel={f.feature} 
-                    featureRowContent={[f.planSupport[mobilePlanDisplayed]]}
-                    lastFeature={idx == TRANSFORMATION_FEATURES.length - 1}
-                  />
-                )
-              })}
-              <FeatureRow
-                isHeader
-                rowLabel={'Privacy'} 
-                featureRowContent={[mobilePlanDisplayed]}
+              <FeatureSection
+                mobilePlanDisplayed={mobilePlanDisplayed}
+                sectionTitle='Privacy'
+                features={PRIVACY_FEATURES}
               />
-              {PRIVACY_FEATURES.map((f, idx) => {
-                return (
-                  <FeatureRow
-                    key={idx}
-                    rowLabel={f.feature} 
-                    featureRowContent={[f.planSupport[mobilePlanDisplayed]]}
-                    lastFeature={idx == PRIVACY_FEATURES.length - 1}
-                  />
-                )
-              })}
-              <FeatureRow
-                isHeader
-                rowLabel={'Support'} 
-                featureRowContent={[mobilePlanDisplayed]}
+              <FeatureSection
+                mobilePlanDisplayed={mobilePlanDisplayed}
+                sectionTitle='Support'
+                features={SUPPORT_FEATURES}
               />
-              {SUPPORT_FEATURES.map((f, idx) => {
-                return (
-                  <FeatureRow
-                    key={idx}
-                    rowLabel={f.feature} 
-                    featureRowContent={[f.planSupport[mobilePlanDisplayed]]}
-                    lastFeature={idx == SUPPORT_FEATURES.length - 1}
-                  />
-                )
-              })}
             </section>
             <section className={pageStyles.suppress_section_margin_top + ' ' + plansStyles.plan_feature_grid_container + ' display-desktop-only-inline-block'}>
-              <FeatureRow
-                isHeader
-                rowLabel={'Integration'} 
-                featureRowContent={['Open Source', 'Pro', 'Enterprise']}
+            <FeatureSection
+                sectionTitle='Integration'
+                features={INTEGRATION_FEATURES}
               />
-              {INTEGRATION_FEATURES.map((f, idx) => {
-                return (
-                  <FeatureRow
-                    key={idx}
-                    rowLabel={f.feature} 
-                    featureRowContent={[f.planSupport['Open Source'], f.planSupport['Pro'], f.planSupport['Enterprise']]}
-                    lastFeature={idx == INTEGRATION_FEATURES.length - 1}
-                  />
-                )
-              })}
-              <FeatureRow
-                isHeader
-                rowLabel={'Exploration'} 
-                featureRowContent={['Open Source', 'Pro', 'Enterprise']}
+              <FeatureSection
+                sectionTitle='Exploration'
+                features={EXPLORATION_FEATURES}
               />
-              {EXPLORATION_FEATURES.map((f, idx) => {
-                return (
-                  <FeatureRow
-                    key={idx}
-                    rowLabel={f.feature} 
-                    featureRowContent={[f.planSupport['Open Source'], f.planSupport['Pro'], f.planSupport['Enterprise']]}
-                    lastFeature={idx == EXPLORATION_FEATURES.length - 1}
-                  />
-                )
-              })}
-              <FeatureRow
-                isHeader
-                rowLabel={'Transformation'} 
-                featureRowContent={['Open Source', 'Pro', 'Enterprise']}
+              <FeatureSection
+                sectionTitle='Transformation'
+                features={TRANSFORMATION_FEATURES}
               />
-              {TRANSFORMATION_FEATURES.map((f, idx) => {
-                return (
-                  <FeatureRow
-                    key={idx}
-                    rowLabel={f.feature} 
-                    featureRowContent={[f.planSupport['Open Source'], f.planSupport['Pro'], f.planSupport['Enterprise']]}
-                    lastFeature={idx == TRANSFORMATION_FEATURES.length - 1}
-                  />
-                )
-              })}
-              <FeatureRow
-                isHeader
-                rowLabel={'Privacy'} 
-                featureRowContent={['Open Source', 'Pro', 'Enterprise']}
+              <FeatureSection
+                sectionTitle='Privacy'
+                features={PRIVACY_FEATURES}
               />
-              {PRIVACY_FEATURES.map((f, idx) => {
-                return (
-                  <FeatureRow
-                    key={idx}
-                    rowLabel={f.feature} 
-                    featureRowContent={[f.planSupport['Open Source'], f.planSupport['Pro'], f.planSupport['Enterprise']]}
-                    lastFeature={idx == PRIVACY_FEATURES.length - 1}
-                  />
-                )
-              })}
-              <FeatureRow
-                isHeader
-                rowLabel={'Support'} 
-                featureRowContent={['Open Source', 'Pro', 'Enterprise']}
+              <FeatureSection
+                sectionTitle='Support'
+                features={SUPPORT_FEATURES}
               />
-              {SUPPORT_FEATURES.map((f, idx) => {
-                return (
-                  <FeatureRow
-                    key={idx}
-                    rowLabel={f.feature} 
-                    featureRowContent={[f.planSupport['Open Source'], f.planSupport['Pro'], f.planSupport['Enterprise']]}
-                    lastFeature={idx == SUPPORT_FEATURES.length - 1}
-                  />
-                )
-              })}
             </section>
               
             <section>


### PR DESCRIPTION
This PR adds our two features that are coming soon, and labels them as such for clear communication. 

Also peep how I reorged the plans page data structures. Makes it easier to insert items into the feature sections, which I think is pleasant as it's gonna be a common modification. Previously, you had to modify two variables to do this. It's not a huge win, but I prefer it. 