### PR TITLE
actions: add testing and linting workflows for mitosheet

### DIFF
--- a/.github/workflows/lint-mitosheet-typescript.yml
+++ b/.github/workflows/lint-mitosheet-typescript.yml
@@ -1,0 +1,40 @@
+name: Lint Mitosheet TypeScript
+
+on:
+  push:
+    branches: [ dev ]
+    paths:
+      - 'mitosheet/**'
+  pull_request:
+    branches: [ dev ]
+    paths:
+      - 'mitosheet/**'
+
+jobs:
+  lint-mitosheet-typescript:
+    name: Run linters
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.7.0
+        with:
+          access_token: ${{ github.token }}
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install Node.js dependencies
+        run: | 
+          cd mitosheet
+          python3 -m pip install jupyterlab
+          npm install
+      - name: Run Linters
+        run: |
+          cd mitosheet
+          npm run lint:check
+
+

--- a/.github/workflows/test-mitoinstaller.yml
+++ b/.github/workflows/test-mitoinstaller.yml
@@ -1,0 +1,38 @@
+name: Test mitoinstaller
+
+on:
+  push:
+    branches: [ dev ]
+    paths:
+      - 'mitosheet/installer/**'
+  pull_request:
+    branches: [ dev ]
+    paths:
+      - 'mitosheet/installer/**'
+
+jobs:
+  test-mitoinstaller:
+    strategy:
+      matrix:
+        python-version: [3.6, 3.8]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.7.0
+      with:
+        access_token: ${{ github.token }}
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        cd mitosheet/installer
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Test with pytest
+      run: |
+        cd mitosheet/installer
+        pytest

--- a/.github/workflows/test-mitosheet-mypy.yml
+++ b/.github/workflows/test-mitosheet-mypy.yml
@@ -1,0 +1,38 @@
+name: Test mitosheet types
+
+on:
+  push:
+    branches: [ dev ]
+    paths:
+      - 'mitosheet/**'
+  pull_request:
+    branches: [ dev ]
+    paths:
+      - 'mitosheet/**'
+
+jobs:
+  test-mitosheet-mypy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.7.0
+      with:
+        access_token: ${{ github.token }}
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        cd mitosheet
+        python -m pip install --upgrade pip
+        pip install -e ".[test, deploy]"
+    - name: Check types with MyPY
+      run: |
+        cd mitosheet
+        mypy mitosheet/ --ignore-missing-imports

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -1,0 +1,45 @@
+name: Run pytest Mitosheet tests
+
+on:
+  push:
+    branches: [ dev ]
+    paths:
+      - 'mitosheet/**'
+  pull_request:
+    branches: [ dev ]
+    paths:
+      - 'mitosheet/**'
+
+jobs:
+  test-mitosheet-python:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.7.0
+      with:
+        access_token: ${{ github.token }}
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        cd mitosheet
+        python -m pip install --upgrade pip
+        pip install -e ".[test, deploy]"
+    - name: Lint with flake8
+      run: |
+        cd mitosheet
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        cd mitosheet
+        pytest


### PR DESCRIPTION
This just adds the actions that test and lint the mitosheet package. Notably, the deployment scripts are not included in here. 