### PR TITLE
mitosheet: add deployment scripts and workflow

### DIFF
--- a/.github/workflows/deploy-mitosheet-mitoinstaller.yml
+++ b/.github/workflows/deploy-mitosheet-mitoinstaller.yml
@@ -1,0 +1,156 @@
+name: Deploy mitosheet and mitoinstaller
+on:
+  push:
+    branches:
+      - dev
+      - main
+
+jobs:
+  deploy-mitosheet:
+    name: Deploy mitosheet and mitosheet3
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.extract_branch.outputs.branch }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup Auth for PyPi
+        run: |
+          echo -e "[distutils]" >> ~/.pypirc
+          echo -e "index-servers =" >> ~/.pypirc
+          echo -e "    pypi" >> ~/.pypirc
+          echo -e "    testpypi" >> ~/.pypirc
+          echo -e "[pypi]" >> ~/.pypirc
+          echo -e "repository = https://pypi.python.org/pypi" >> ~/.pypirc
+          echo -e "username = __token__" >> ~/.pypirc
+          echo -e "password = ${{ secrets.PYPI_API_TOKEN }}" >> ~/.pypirc
+          echo -e "" >> ~/.pypirc
+          echo -e "[testpypi]" >> ~/.pypirc
+          echo -e "repository = https://test.pypi.org/legacy/" >> ~/.pypirc
+          echo -e "username = __token__" >> ~/.pypirc
+          echo -e "password = ${{ secrets.TEST_PYPI_API_TOKEN }}" >> ~/.pypirc
+      - name: Setup mitosheet
+        run: |
+          cd mito
+          python3 -m venv venv
+          source venv/bin/activate
+          python switch.py mitosheet
+          python deployment/bump_version.py mitosheet ${{ steps.extract_branch.outputs.branch }}
+          python -m pip install -e ".[test, deploy]"
+      - name: Deploy mitosheet
+        run: |
+          cd mito
+          source venv/bin/activate
+          python deployment/deploy.py ${{ steps.extract_branch.outputs.branch }}
+  deploy-mitosheet3:
+    name: Deploy mitosheet3
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.extract_branch.outputs.branch }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup Auth for PyPi
+        run: |
+          echo -e "[distutils]" >> ~/.pypirc
+          echo -e "index-servers =" >> ~/.pypirc
+          echo -e "    pypi" >> ~/.pypirc
+          echo -e "    testpypi" >> ~/.pypirc
+          echo -e "[pypi]" >> ~/.pypirc
+          echo -e "repository = https://pypi.python.org/pypi" >> ~/.pypirc
+          echo -e "username = __token__" >> ~/.pypirc
+          echo -e "password = ${{ secrets.PYPI_API_TOKEN }}" >> ~/.pypirc
+          echo -e "" >> ~/.pypirc
+          echo -e "[testpypi]" >> ~/.pypirc
+          echo -e "repository = https://test.pypi.org/legacy/" >> ~/.pypirc
+          echo -e "username = __token__" >> ~/.pypirc
+          echo -e "password = ${{ secrets.TEST_PYPI_API_TOKEN }}" >> ~/.pypirc
+      - name: Setup mitosheet3
+        run: |
+          cd mito
+          rm -rf venv
+          python3 -m venv venv
+          source venv/bin/activate
+          python switch.py mitosheet3
+          python deployment/bump_version.py mitosheet3 ${{ steps.extract_branch.outputs.branch }}
+          python -m pip install -e ".[test, deploy]"          
+      - name: Deploy mitosheet3
+        run: |
+          cd mito
+          source venv/bin/activate
+          python deployment/deploy.py ${{ steps.extract_branch.outputs.branch }}
+  deploy-mitoinstaller:
+    name: Deploy mitoinstaller
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.extract_branch.outputs.branch }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup Auth for PyPi
+        run: |
+          echo -e "[distutils]" >> ~/.pypirc
+          echo -e "index-servers =" >> ~/.pypirc
+          echo -e "    pypi" >> ~/.pypirc
+          echo -e "    testpypi" >> ~/.pypirc
+          echo -e "[pypi]" >> ~/.pypirc
+          echo -e "repository = https://pypi.python.org/pypi" >> ~/.pypirc
+          echo -e "username = __token__" >> ~/.pypirc
+          echo -e "password = ${{ secrets.PYPI_API_TOKEN }}" >> ~/.pypirc
+          echo -e "" >> ~/.pypirc
+          echo -e "[testpypi]" >> ~/.pypirc
+          echo -e "repository = https://test.pypi.org/legacy/" >> ~/.pypirc
+          echo -e "username = __token__" >> ~/.pypirc
+          echo -e "password = ${{ secrets.TEST_PYPI_API_TOKEN }}" >> ~/.pypirc
+      - name: Setup mitoinstaller
+        run: |
+          cd mito
+          python3 -m venv venv
+          source venv/bin/activate
+          python deployment/bump_version.py mitoinstaller ${{ steps.extract_branch.outputs.branch }}
+          cd installer
+          pip install -r requirements.txt
+      - name: Deploy mitoinstaller on testpypi
+        if: github.ref == 'refs/heads/dev'
+        run: |
+          cd mito
+          source venv/bin/activate
+          cd installer 
+          python setup.py sdist upload --repository testpypi
+      - name: Deploy mitoinstaller on testpypi
+        if: github.ref == 'refs/heads/main'
+        run: |
+          cd mito
+          source venv/bin/activate
+          cd installer
+          python setup.py sdist upload

--- a/mitosheet/deployment/README.md
+++ b/mitosheet/deployment/README.md
@@ -1,0 +1,3 @@
+# Deployment
+
+This folder contains files helpful in bumping the version of the current package, and for deploying this to PyPi (or TestPyPi).

--- a/mitosheet/deployment/bump_version.py
+++ b/mitosheet/deployment/bump_version.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Mito.
+# Distributed under the terms of the Modified BSD License.
+
+"""
+Contains utilities for bumping the version of a Mito project, across
+all the files where it needs to be bumped. 
+"""
+
+import json
+from typing import Tuple, Union
+import urllib.request
+
+
+def get_pypi_version(package_name: str, on_dev: bool=None) -> Union[None, str]:
+    """
+    Utilities for getting the most recently deployed
+    version of a Python package on a specific PyPi index.
+
+    We use these to set the version of the Mito package
+    before we deploy it. We do not store this information
+    locally so that we don't need to commit it back to the
+    repo. 
+
+    Commiting it caused all sorts of issues, mostly
+    with the versions getting out of date, and causing
+    merge conflicts, etc.
+    """
+
+    if on_dev:
+        url = f'https://test.pypi.org/project/{package_name}/'
+    else:
+        url = f'https://pypi.org/project/{package_name}/'
+
+    contents = urllib.request.urlopen(url).read().decode().split('\n')
+    tag = f'<a class="card release__card" href="/project/{package_name}/'
+    contents_with_package_link = [c for c in contents if tag in c]
+    last_version = contents_with_package_link[0].strip().split(tag)[1][:-3]
+    return last_version
+
+def version_string_to_tuple(version_string: str) -> Tuple[int, int, int]:
+    return tuple(map(int, version_string.split('.')))
+
+def get_next_version(package: str, on_dev: bool) -> Tuple[int, int, int]:
+    last_pypi_version = get_pypi_version(package, on_dev=on_dev)
+    (x, y, z) = version_string_to_tuple(last_pypi_version)
+    return (x, y, z + 1)
+
+def bump_version_mitoinstaller(on_dev: bool):
+    with open('installer/mitoinstaller/__init__.py', 'r+') as f:
+        current_version_string = get_pypi_version('mitoinstaller', on_dev)
+    (x, y, z) = version_string_to_tuple(current_version_string)
+    new_version = (x, y, z + 1)
+    with open('installer/mitoinstaller/__init__.py', 'w+') as f:
+        f.write(f'__version__ = \'{".".join(map(str, new_version))}\'')
+
+def bump_version(package, deploy_location: str, new_version: Tuple[int, int, int]=None):
+    """
+    Bumps the version of the Mito project to the next minor logical version. Must pass
+    the package as `mitosheet` or `mitosheet3`, so we know which version to bump.
+
+    Alternatively, can bump the version of `mitoinstaller` by passing `mitoinstaller`, 
+    which does not pass through the package.json.
+
+    If a new_version is given, then will bump to that version specificially. new_version
+    should be a tuple of the form (x, y, z).
+    """
+    on_dev = deploy_location == 'dev'
+
+    if package == 'mitoinstaller':
+        bump_version_mitoinstaller(on_dev)
+        return
+
+    if new_version is None:
+        new_version = get_next_version(package, on_dev)
+
+    # We just need to change the version in the package.json
+    with open('package.json', 'r+') as f:
+        package_obj = json.loads(f.read())
+        # Sanity check that we are bumping the version of the package
+        assert package_obj['name'] == package
+        package_obj['version'] = '.'.join(map(str, new_version))
+
+        # Rewind to start of file, to write
+        f.seek(0)
+        f.write(json.dumps(package_obj, indent=2))
+
+    print(f'Bump {package} version to {new_version}')
+
+if __name__ == '__main__':
+    import sys
+    bump_version(sys.argv[1], sys.argv[2])

--- a/mitosheet/deployment/deploy.py
+++ b/mitosheet/deployment/deploy.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Mito.
+# Distributed under the terms of the Modified BSD License.
+
+"""
+File that contains utilities for deploying a new version of Mito to PyPi,
+assuming the correct PyPi credentials are on the machine.
+"""
+import subprocess
+import sys
+
+
+def deploy_current_mito_version_to_pypi(on_dev: bool):
+    """
+    Deploys the current local version of Mito to PyPi.
+    """
+    cmd = []
+    if on_dev:
+        cmd = ["python3", "setup.py", "sdist", "bdist_wheel", "upload", "--repository", "testpypi"]
+    else:
+        cmd = ["python3", "setup.py", "sdist", "bdist_wheel", "upload"]
+
+    deploy_results = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE, 
+        stderr=subprocess.PIPE,
+        universal_newlines=True
+    )
+    if deploy_results.returncode != 0:
+        raise Exception("Failed to deploy to PyPi with output:", deploy_results.stdout, deploy_results.stderr)
+
+
+def main():
+    """
+    Deploy to PyPi with `python3 deployment/deploy.py [dev | main]`.
+
+    Note that it will deploy whatever package is currently the defined package
+    in the package.json, which could either be mitosheet or mitosheet3. 
+    """
+
+    # We either deploy app or staging, default staging
+    if len(sys.argv) > 1:
+        deploy_location = sys.argv[1]
+    else:
+        raise Exception(f'Please choose a valid deploy location: dev | main')
+        
+    if deploy_location not in ['dev', 'main']:
+        raise Exception(f'Invalid deploy location: {deploy_location}. Please choose from dev | main.')
+
+    # Then, we actually deploy Mito to PyPi, if it has not been deployed yet
+    deploy_current_mito_version_to_pypi(deploy_location == 'dev')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
# Description

Adds deployment scripts, and deployment action. 

Before merging this, we need to add the secrets to this Github repo that allow these actions to post to PyPi. Since I don't have access to PyPi rn, @aarondr77 the task falls to you. To do so:
1. Go to the Github secrets for our org here: https://github.com/organizations/mito-ds/settings/secrets/actions
2. Create a new org secret called `PYPI_API_TOKEN`. Set it equal to the value you get from PyPi (instructions here: https://pypi.org/help/#apitoken). Make sure to give it enough permissions to upload packages.
3. Add another secret, called `TEST_PYPI_API_TOKEN`, which you can get from test pypi. Otherwise, the same.

Then, you should be good to merge, and this should run correctly.

# Testing

We'll have to test this once we merge it for the first time!

# Documentation

No.