### PR TITLE
mitosheet: add explicit types for ColumnHeader and ColumnID, for clarity

### DIFF
--- a/mitosheet/mitosheet/api/graph/bar.py
+++ b/mitosheet/mitosheet/api/graph/bar.py
@@ -12,9 +12,10 @@ from mitosheet.mito_analytics import log
 from mitosheet.sheet_functions.types.utils import get_mito_type
 from mitosheet.transpiler.transpile_utils import \
     column_header_to_transpiled_code
+from mitosheet.types import ColumnHeader
 
 
-def get_bar_chart(df: pd.DataFrame, x_axis_column_headers: List[Any], y_axis_column_headers: List[Any]) -> go.Figure:
+def get_bar_chart(df: pd.DataFrame, x_axis_column_headers: List[ColumnHeader], y_axis_column_headers: List[ColumnHeader]) -> go.Figure:
     """
     Returns a bar chart using the following heuristic:
     - Graphs the first BAR_CHART_MAX_NUMBER_OF_ROWS rows. 
@@ -93,8 +94,8 @@ def get_bar_chart(df: pd.DataFrame, x_axis_column_headers: List[Any], y_axis_col
 
 def get_bar_code(
         df: pd.DataFrame, 
-        x_axis_column_headers: List[str], 
-        y_axis_column_headers: List[str],
+        x_axis_column_headers: List[ColumnHeader], 
+        y_axis_column_headers: List[ColumnHeader],
         df_name: str
     ) -> str:
     """

--- a/mitosheet/mitosheet/api/graph/box.py
+++ b/mitosheet/mitosheet/api/graph/box.py
@@ -1,11 +1,12 @@
 from typing import Any, List
 import pandas as pd
+from mitosheet.types import ColumnHeader
 import plotly.graph_objects as go
 from mitosheet.mito_analytics import log
 from mitosheet.api.graph.graph_utils import BOX, CREATE_FIG_CODE, SHOW_FIG_CODE, X, filter_df_to_safe_size, get_graph_title, is_all_number_series
 
 
-def get_box_plot(axis: str, df: pd.DataFrame, column_headers: List[Any]) -> go.Figure: 
+def get_box_plot(axis: str, df: pd.DataFrame, column_headers: List[ColumnHeader]) -> go.Figure: 
     """
     Returns a box plot using the following heuristic:
 
@@ -55,7 +56,7 @@ def get_box_plot(axis: str, df: pd.DataFrame, column_headers: List[Any]) -> go.F
 def get_box_code(
         axis: str, 
         df: pd.DataFrame, 
-        column_headers: List[str],
+        column_headers: List[ColumnHeader],
         df_name: str
     ) -> str:
     """

--- a/mitosheet/mitosheet/api/graph/get_graph.py
+++ b/mitosheet/mitosheet/api/graph/get_graph.py
@@ -2,6 +2,7 @@ import json
 from typing import Any, Dict, List
 
 import pandas as pd
+from mitosheet.types import ColumnHeader
 import plotly.express as px
 import plotly.graph_objects as go
 from mitosheet.api.graph.bar import get_bar_chart, get_bar_code
@@ -18,14 +19,14 @@ from mitosheet.sheet_functions.types.utils import NUMBER_SERIES, get_mito_type
 from mitosheet.steps_manager import StepsManager
 
 
-def get_column_summary_graph(axis: str, df: pd.DataFrame, axis_data_array: List[Any]) -> go.Figure:
+def get_column_summary_graph(axis: str, df: pd.DataFrame, axis_data_array: List[ColumnHeader]) -> go.Figure:
     """
     One Axis Graphs heuristics:
     1. Number Column - we do no filtering. These graphs are pretty efficient up to 1M rows
     2. Non-number column. We filter to the top 10k values, as the graphs get pretty laggy 
        beyond that
     """
-    column_header: str = axis_data_array[0]
+    column_header = axis_data_array[0]
     series: pd.Series = df[column_header]
     mito_type = get_mito_type(series)
 

--- a/mitosheet/mitosheet/api/graph/graph_utils.py
+++ b/mitosheet/mitosheet/api/graph/graph_utils.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import pandas as pd
 import plotly.graph_objects as go
 from mitosheet.sheet_functions.types.utils import NUMBER_SERIES, get_mito_type
+from mitosheet.types import ColumnHeader
 
 # We have a variety of heuristics to make sure that we never send too much data
 # to the frontend to display to the user. See comments below in the file for 
@@ -64,7 +65,7 @@ fig = go.Figure()
 # and JLab 3, and renders in line.
 SHOW_FIG_CODE = 'fig.show(renderer="iframe")'
 
-def is_all_number_series(df: pd.DataFrame, column_headers: List[Any]) -> bool:
+def is_all_number_series(df: pd.DataFrame, column_headers: List[ColumnHeader]) -> bool:
     """
     Returns True if the Mito type of each series with the header column_header
     in column_headers is a NUMBER_SERIES. Returns False otherwise. 
@@ -75,7 +76,7 @@ def is_all_number_series(df: pd.DataFrame, column_headers: List[Any]) -> bool:
             return False
     return True
 
-def get_graph_title(x_axis_column_headers: List[Any], y_axis_column_headers: List[Any], filtered: bool, graph_type: str, special_title: str=None) -> str:
+def get_graph_title(x_axis_column_headers: List[ColumnHeader], y_axis_column_headers: List[ColumnHeader], filtered: bool, graph_type: str, special_title: str=None) -> str:
     """
     Helper function for determing the title of the graph for the scatter plot and bar chart
     """
@@ -102,7 +103,7 @@ def get_graph_title(x_axis_column_headers: List[Any], y_axis_column_headers: Lis
     return (' ').join(graph_title_components)
 
 
-def get_graph_labels(x_axis_column_headers: List[Any], y_axis_column_headers: List[Any]) -> Tuple[str, str]:
+def get_graph_labels(x_axis_column_headers: List[ColumnHeader], y_axis_column_headers: List[ColumnHeader]) -> Tuple[str, str]:
     """
     Helper function for determining the x and y axis titles, 
     for the scatter plot and bar chart. 
@@ -159,8 +160,8 @@ def filter_df_to_top_unique_values_in_series(
 def filter_df_to_safe_size(
         graph_type: str, 
         df: pd.DataFrame, 
-        column_headers: List[str],
-        other_axis_column_headers: List[str]=None
+        column_headers: List[ColumnHeader],
+        other_axis_column_headers: List[ColumnHeader]=None
     ) -> pd.DataFrame:
     """
     A helper function that filters a dataframe down to a safe size

--- a/mitosheet/mitosheet/api/graph/histogram.py
+++ b/mitosheet/mitosheet/api/graph/histogram.py
@@ -1,13 +1,16 @@
 from typing import Any, List
+
 import pandas as pd
 import plotly.graph_objects as go
-
+from mitosheet.api.graph.graph_utils import (CREATE_FIG_CODE, HISTOGRAM,
+                                             SHOW_FIG_CODE, X, get_graph_title)
 from mitosheet.mito_analytics import log
-from mitosheet.api.graph.graph_utils import CREATE_FIG_CODE, HISTOGRAM, SHOW_FIG_CODE, X, get_graph_title
-from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_code
+from mitosheet.transpiler.transpile_utils import \
+    column_header_to_transpiled_code
+from mitosheet.types import ColumnHeader
 
 
-def get_histogram(axis: str, df: pd.DataFrame, column_headers: List[Any]) -> go.Figure:
+def get_histogram(axis: str, df: pd.DataFrame, column_headers: List[ColumnHeader]) -> go.Figure:
     """
     Returns a histogram using the following heuristic:
 
@@ -50,7 +53,7 @@ def get_histogram(axis: str, df: pd.DataFrame, column_headers: List[Any]) -> go.
 def get_histogram_code(
         axis: str, 
         df: pd.DataFrame, 
-        column_headers: List[str], 
+        column_headers: List[ColumnHeader], 
         df_name: str
     ) -> str:
     """

--- a/mitosheet/mitosheet/api/graph/scatter.py
+++ b/mitosheet/mitosheet/api/graph/scatter.py
@@ -1,5 +1,6 @@
 from typing import Any, List
 import pandas as pd
+from mitosheet.types import ColumnHeader
 import plotly.graph_objects as go
 from mitosheet.mito_analytics import log
 from mitosheet.sheet_functions.types.utils import get_mito_type
@@ -7,7 +8,7 @@ from mitosheet.api.graph.graph_utils import BAR, CREATE_FIG_CODE, SCATTER, SHOW_
 from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_code
 
 
-def get_scatter_plot(df: pd.DataFrame, x_axis_column_headers: List[Any], y_axis_column_headers: List[Any]) -> go.Figure:
+def get_scatter_plot(df: pd.DataFrame, x_axis_column_headers: List[ColumnHeader], y_axis_column_headers: List[ColumnHeader]) -> go.Figure:
     """
     Returns a scatter plot using the following heuristic:
 
@@ -97,8 +98,8 @@ def get_scatter_plot(df: pd.DataFrame, x_axis_column_headers: List[Any], y_axis_
 
 def get_scatter_code(
         df: pd.DataFrame, 
-        x_axis_column_headers: List[str], 
-        y_axis_column_headers: List[str],
+        x_axis_column_headers: List[ColumnHeader], 
+        y_axis_column_headers: List[ColumnHeader],
         df_name: str
     ) -> str:
     """

--- a/mitosheet/mitosheet/column_headers.py
+++ b/mitosheet/mitosheet/column_headers.py
@@ -13,12 +13,14 @@ themselves.
 """
 import random
 from typing import Any, Collection, Dict, List
+
 import pandas as pd
 
 from mitosheet.errors import make_no_column_error
+from mitosheet.types import ColumnHeader, ColumnID
 
 
-def flatten_column_header(column_header: Any) -> Any:
+def flatten_column_header(column_header: ColumnHeader) -> ColumnHeader:
     """
     Given a pandas column header, if it is a list or tuple, it will
     flatten this header into a string. 
@@ -37,7 +39,7 @@ def flatten_column_header(column_header: Any) -> Any:
 
     return column_header
 
-def get_column_header_display(column_header: Any) -> str:
+def get_column_header_display(column_header: ColumnHeader) -> str:
     """
     Turns the column header into a string that is the same as how
     the string is displayed on the front-end. 
@@ -56,12 +58,12 @@ def get_column_header_display(column_header: Any) -> str:
     return str(column_header)
 
 
-def get_column_header_ids(column_headers: List[Any]) -> List[str]:
+def get_column_header_ids(column_headers: List[ColumnHeader]) -> List[ColumnID]:
     return [
         get_column_header_id(column_header) for column_header in column_headers
     ]
 
-def get_column_header_id(column_header: Any, use_deprecated_id_algorithm: bool=False) -> str:
+def get_column_header_id(column_header: ColumnHeader, use_deprecated_id_algorithm: bool=False) -> ColumnID:
     """
     Returns the ID that represents this column header, which is
     used to refer to the column as long as it is used in the 
@@ -84,7 +86,7 @@ def get_column_header_id(column_header: Any, use_deprecated_id_algorithm: bool=F
     else:
         return str(column_header)
 
-def try_make_new_header_valid_if_multi_index_headers(column_headers: List[Any], new_column_header: Any) -> Any:
+def try_make_new_header_valid_if_multi_index_headers(column_headers: List[ColumnHeader], new_column_header: ColumnHeader) -> ColumnHeader:
     """
     Helper function for when you're adding a column to a
     dataframe that has multi-index headers. 
@@ -113,8 +115,8 @@ class ColumnIDMap():
     """
 
     def __init__(self, dfs: Collection[pd.DataFrame]):
-        self.column_id_to_column_header: List[Dict[str, Any]] = [dict() for _ in range(len(dfs))]
-        self.column_header_to_column_id: List[Dict[Any, str]] = [dict() for _ in range(len(dfs))]
+        self.column_id_to_column_header: List[Dict[ColumnID, ColumnHeader]] = [dict() for _ in range(len(dfs))]
+        self.column_header_to_column_id: List[Dict[ColumnHeader, ColumnID]] = [dict() for _ in range(len(dfs))]
 
         for sheet_index, df in enumerate(dfs):
             for column_header in df.keys():
@@ -122,7 +124,7 @@ class ColumnIDMap():
                 self.column_id_to_column_header[sheet_index][column_id] = column_header
                 self.column_header_to_column_id[sheet_index][column_header] = column_id
 
-    def set_column_header(self, sheet_index: int, column_id: str, column_header: Any) -> None:
+    def set_column_header(self, sheet_index: int, column_id: ColumnID, column_header: ColumnHeader) -> None:
         """
         Sets a column id and column header to match to eachother. 
 
@@ -145,7 +147,7 @@ class ColumnIDMap():
         self.column_id_to_column_header[sheet_index][column_id] = column_header
         self.column_header_to_column_id[sheet_index][column_header] = column_id
 
-    def add_df(self, df: pd.DataFrame, sheet_index: int=None, use_deprecated_id_algorithm: bool=False) -> Dict[str, Any]:
+    def add_df(self, df: pd.DataFrame, sheet_index: int=None, use_deprecated_id_algorithm: bool=False) -> Dict[str, ColumnHeader]:
         """
         Adds all of the keys for the new dataframe to the column id 
         mappings.
@@ -177,7 +179,7 @@ class ColumnIDMap():
         self.column_id_to_column_header.pop(sheet_index)
         self.column_header_to_column_id.pop(sheet_index)
     
-    def add_column_header(self, sheet_index: int, column_header: Any) -> str:
+    def add_column_header(self, sheet_index: int, column_header: ColumnHeader) -> str:
         """
         NOTE: this should only be called when adding a column to the dataframe,
         and not when renaming a column, as it creates a new id for the column
@@ -196,12 +198,12 @@ class ColumnIDMap():
 
         return column_id
     
-    def delete_column_id(self, sheet_index: int, column_id: str) -> None:
+    def delete_column_id(self, sheet_index: int, column_id: ColumnID) -> None:
         column_header = self.get_column_header_by_id(sheet_index, column_id)
         del self.column_id_to_column_header[sheet_index][column_id]
         self.column_header_to_column_id[sheet_index][column_header]
 
-    def get_column_ids(self, sheet_index: int, column_headers: Collection[Any]=None) -> List[str]:
+    def get_column_ids(self, sheet_index: int, column_headers: Collection[ColumnHeader]=None) -> List[str]:
         if column_headers is None:
             return list(self.column_id_to_column_header[sheet_index].keys())
         try:
@@ -212,16 +214,16 @@ class ColumnIDMap():
         except:
             raise make_no_column_error(column_headers)
 
-    def get_column_ids_map(self, sheet_index: int) -> Dict[str, Any]:
+    def get_column_ids_map(self, sheet_index: int) -> Dict[str, ColumnHeader]:
         return self.column_id_to_column_header[sheet_index]
 
-    def get_column_id_by_header(self, sheet_index: int, column_header: Any) -> str:
+    def get_column_id_by_header(self, sheet_index: int, column_header: ColumnHeader) -> str:
         return self.column_header_to_column_id[sheet_index][column_header]
 
-    def get_column_header_by_id(self, sheet_index: int, column_id: str) -> Any:
+    def get_column_header_by_id(self, sheet_index: int, column_id: ColumnID) -> ColumnHeader:
         return self.column_id_to_column_header[sheet_index][column_id]
 
-    def get_column_headers_by_ids(self, sheet_index: int, column_ids: List[str]) -> List[Any]:
+    def get_column_headers_by_ids(self, sheet_index: int, column_ids: List[ColumnID]) -> List[ColumnHeader]:
         return [
             self.column_id_to_column_header[sheet_index][column_id] 
             for column_id in column_ids
@@ -233,7 +235,8 @@ class ColumnIDMap():
         purpose of backwards compability. This simulates a preprocessing 
         step.
         """
-        from mitosheet.step_performers.bulk_old_rename.deprecated_utils import make_valid_header
+        from mitosheet.step_performers.bulk_old_rename.deprecated_utils import \
+            make_valid_header
         for sheet_index in range(len(self.column_id_to_column_header)):
             column_id_to_column_header_map = self.column_id_to_column_header[sheet_index]
 

--- a/mitosheet/mitosheet/column_headers.py
+++ b/mitosheet/mitosheet/column_headers.py
@@ -17,7 +17,7 @@ from typing import Any, Collection, Dict, List
 import pandas as pd
 
 from mitosheet.errors import make_no_column_error
-from mitosheet.types import ColumnHeader, ColumnID
+from mitosheet.types import ColumnHeader, ColumnID, MultiLevelColumnHeader
 
 
 def flatten_column_header(column_header: ColumnHeader) -> ColumnHeader:
@@ -95,11 +95,10 @@ def try_make_new_header_valid_if_multi_index_headers(column_headers: List[Column
     that is the length of the multi-index headers, so
     this function helps you make such a header
     """
-    if not isinstance(new_column_header, tuple) and len(column_headers) > 0:
+    if (not isinstance(new_column_header, tuple) and not isinstance(new_column_header, list)) and len(column_headers) > 0:
         other_column_header = random.choice(list(column_headers))
         if isinstance(other_column_header, tuple):
-            ending_list = ['' for _ in range(len(other_column_header) - 1)]
-            ending_list.insert(0, new_column_header)
+            ending_list: MultiLevelColumnHeader = [new_column_header] + ['' for _ in range(len(other_column_header) - 1)]
             return tuple(ending_list)
 
     # If we don't need to change the column header, don't change it

--- a/mitosheet/mitosheet/errors.py
+++ b/mitosheet/mitosheet/errors.py
@@ -17,6 +17,8 @@ https://stackoverflow.com/questions/16138232/is-it-a-good-practice-to-use-try-ex
 import traceback
 from typing import Any, Collection, Set, List
 
+from mitosheet.types import ColumnHeader
+
 
 class MitoError(Exception):
     """
@@ -98,7 +100,7 @@ def make_no_column_error(column_headers: Collection[str], error_modal: bool=True
         error_modal=error_modal
     )
 
-def make_column_exists_error(column_header: Any) -> MitoError:
+def make_column_exists_error(column_header: ColumnHeader) -> MitoError:
     """
     Helper function for creating a column_exists_error.
 
@@ -158,7 +160,7 @@ def make_circular_reference_error(error_modal: bool=True) -> MitoError:
         error_modal=error_modal
     )
 
-def make_wrong_column_metatype_error(column_header: Any, error_modal: bool=True) -> MitoError:
+def make_wrong_column_metatype_error(column_header: ColumnHeader, error_modal: bool=True) -> MitoError:
     """
     Helper function for creating a wrong_column_metatype_error.
 
@@ -172,7 +174,7 @@ def make_wrong_column_metatype_error(column_header: Any, error_modal: bool=True)
         error_modal=error_modal
     )
 
-def make_invalid_column_headers_error(column_headers: List[Any]) -> MitoError:
+def make_invalid_column_headers_error(column_headers: List[ColumnHeader]) -> MitoError:
     """
     Helper function for creating a invalid_column_headers_error.
 
@@ -252,7 +254,7 @@ def make_unsupported_function_error(functions: Set[str], error_modal: bool=True)
         error_modal=error_modal
     )
 
-def make_invalid_column_delete_error(column_headers: Any, dependents: Collection[Any]) -> MitoError:
+def make_invalid_column_delete_error(column_headers: Collection[ColumnHeader], dependents: Collection[ColumnHeader]) -> MitoError:
     """
     Helper function for creating a invalid_column_delete_error.
 
@@ -317,7 +319,7 @@ def make_invalid_filter_error(filter_value: Any, correct_type: str) -> MitoError
         f'Sorry, the value {filter_value} is not a valid value for that {correct_type} filter. Please enter a value {correct_format}!'
     )
 
-def make_invalid_sort_error(column_header: Any) -> MitoError:
+def make_invalid_sort_error(column_header: ColumnHeader) -> MitoError:
     """
     Helper function for creating a invalid_sort_error.
 
@@ -347,7 +349,7 @@ def make_df_exists_error(df_name: str) -> MitoError:
         f'Sorry, the dataframe {df_name} already exists. Please pick a different name.'
     )
 
-def make_invalid_column_type_change_error(column_header: Any, old_dtype: str, new_dtype: str) -> MitoError:
+def make_invalid_column_type_change_error(column_header: ColumnHeader, old_dtype: str, new_dtype: str) -> MitoError:
     """
     Helper function for creating a invalid_column_type_change_error.
 

--- a/mitosheet/mitosheet/errors.py
+++ b/mitosheet/mitosheet/errors.py
@@ -82,7 +82,7 @@ def make_incompatible_merge_key_error(error_modal: bool=True) -> MitoError:
         error_modal=error_modal
     )
 
-def make_no_column_error(column_headers: Collection[str], error_modal: bool=True) -> MitoError:
+def make_no_column_error(column_headers: Collection[ColumnHeader], error_modal: bool=True) -> MitoError:
     """
     Helper function for creating a no_column_error.
 
@@ -91,7 +91,7 @@ def make_no_column_error(column_headers: Collection[str], error_modal: bool=True
     if len(column_headers) == 1:
         to_fix = f'Sorry, there is no column with the name {next(iter(column_headers))}. Did you type it correctly?'
     else:
-        to_fix = f'Sorry, there are no column with the names {", ".join(column_headers)}. Did you type them correctly?'
+        to_fix = f'Sorry, there are no column with the names {", ".join(map(str, column_headers))}. Did you type them correctly?'
 
     return MitoError(
         'no_column_error', 
@@ -181,7 +181,7 @@ def make_invalid_column_headers_error(column_headers: List[ColumnHeader]) -> Mit
     Occurs when:
     -  a user creates (or renames) a column(s) that has an invalid name.
     """
-    to_fix = f'All headers in the dataframe must contain at least one letter and no symbols other than numbers and "_". Invalid headers: {", ".join(column_headers)}'
+    to_fix = f'All headers in the dataframe must contain at least one letter and no symbols other than numbers and "_". Invalid headers: {", ".join(map(str, column_headers))}'
 
     return MitoError(
         'invalid_column_header_error',
@@ -261,13 +261,11 @@ def make_invalid_column_delete_error(column_headers: Collection[ColumnHeader], d
     Occurs when:
     -  the user deletes a column that is referenced by other columns
     """
-    # We make sure it's a list, for easy accessing!
-    dependents = list(dependents)
 
     return MitoError(
         'invalid_column_delete_error',
         'Column Has Dependents',
-        f'{(", ").join(column_headers)} cannot be deleted, as {"they are" if len(column_headers) > 1 else "it is"} referenced in {(", ".join(dependents))}. Please remove these references before deleting.'
+        f'{(", ").join(map(str, column_headers))} cannot be deleted, as {"they are" if len(column_headers) > 1 else "it is"} referenced in {(", ".join(map(str, dependents)))}. Please remove these references before deleting.'
     )
 
 def make_invalid_arguments_error(function: str) -> MitoError:

--- a/mitosheet/mitosheet/parser.py
+++ b/mitosheet/mitosheet/parser.py
@@ -15,6 +15,7 @@ from typing import Any, Collection, List, Optional, Set, Tuple, Union
 from mitosheet.column_headers import get_column_header_display
 from mitosheet.errors import make_invalid_formula_error
 from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_code
+from mitosheet.types import ColumnHeader
 
 def is_quote(char: str) -> bool:
     """
@@ -69,7 +70,7 @@ def match_covered_by_matches( # type: ignore
 def safe_contains(
         formula: str, 
         substring: str,
-        column_headers: List[Any],
+        column_headers: List[ColumnHeader],
     ) -> bool:
     """
     Returns true if the formula contains substring. However, will not count
@@ -94,7 +95,7 @@ def safe_contains(
 def safe_contains_function(
         formula: str, 
         function: str,
-        column_headers: List[Any]
+        column_headers: List[ColumnHeader]
     ) -> bool:
     """
     Checks if a function is called in a formula. Returns False if the function
@@ -145,7 +146,7 @@ def safe_replace(
         formula: str, 
         old_column_header: str, 
         new_column_header: str,
-        column_headers: List[Any]
+        column_headers: List[ColumnHeader]
     ) -> str:
     """
     Given a raw spreadsheet formula, will replace all instances of old_column_header
@@ -177,7 +178,7 @@ def safe_replace(
 
 def check_common_errors(
         formula: str,
-        column_headers: List[Any]
+        column_headers: List[ColumnHeader]
     ) -> None:
     """
     Helper function for checking a formula for common errors, for better
@@ -219,16 +220,16 @@ def check_common_errors(
 
 def get_column_header_match_tuples(
         formula: str,
-        column_headers: List[Any],
+        column_headers: List[ColumnHeader],
         string_matches: List
-    ) -> List[Tuple[Any, Any]]:
+    ) -> List[Tuple[ColumnHeader, Any]]:
     """
     Returns a list of the column header that is matched, as well as the 
     match object where it was found. Note that the returned matches are
     sorted from the last match to the first, so you can easily iterate
     over them and replace.
     """
-    column_header_match_tuples: List[Tuple[Any, Any]] = []
+    column_header_match_tuples: List[Tuple[ColumnHeader, Any]] = []
 
     # We look for column headers from longest to shortest, to enable us
     # to issues if one column header is a substring of another
@@ -282,7 +283,7 @@ def get_column_header_match_tuples(
                 
 def replace_column_headers(
         formula: str,
-        column_headers: List[Any],
+        column_headers: List[ColumnHeader],
         string_matches: List
     ) -> Tuple[str, Set[str]]:
     """
@@ -352,10 +353,10 @@ def replace_functions(
 
 def parse_formula(
         formula: Optional[str], 
-        column_header: Any, 
-        column_headers: List[Any],
+        column_header: ColumnHeader, 
+        column_headers: List[ColumnHeader],
         throw_errors: bool=True
-    ) -> Tuple[str, Set[str], Set[Any]]:
+    ) -> Tuple[str, Set[str], Set[ColumnHeader]]:
     """
     Returns a representation of the formula that is easy to handle, specifically
     by returning (python_code, functions, column_header_dependencies), where column_headers

--- a/mitosheet/mitosheet/parser.py
+++ b/mitosheet/mitosheet/parser.py
@@ -144,8 +144,8 @@ def safe_count_function(formula: str, substring: str) -> int:
 
 def safe_replace(
         formula: str, 
-        old_column_header: str, 
-        new_column_header: str,
+        old_column_header: ColumnHeader, 
+        new_column_header: ColumnHeader,
         column_headers: List[ColumnHeader]
     ) -> str:
     """
@@ -209,8 +209,9 @@ def check_common_errors(
     # we throw an error if we're sure that it's unmatched
     if safe_count_function(formula, '\(') != safe_count_function(formula, '\)'):
         for column_header in column_headers:
-            if '(' in column_header or ')' in column_header:
-                pass
+            if isinstance(column_headers, str):
+                if '(' in column_header or ')' in column_header:
+                    pass
         
         raise make_invalid_formula_error(
             formula,
@@ -285,7 +286,7 @@ def replace_column_headers(
         formula: str,
         column_headers: List[ColumnHeader],
         string_matches: List
-    ) -> Tuple[str, Set[str]]:
+    ) -> Tuple[str, Set[ColumnHeader]]:
     """
     Returns a modified formula, where the column headers in the string
     have been replaced with references to the dataframe.
@@ -366,7 +367,7 @@ def parse_formula(
         return '', set(), set()
 
     if throw_errors:
-        check_common_errors(formula, column_header)
+        check_common_errors(formula, column_headers)
 
     # Chop off the =, if it exists. We also accept formulas
     # that don't have an equals

--- a/mitosheet/mitosheet/step.py
+++ b/mitosheet/mitosheet/step.py
@@ -5,6 +5,7 @@ from mitosheet.step_performers.column_steps.set_column_formula import SetColumnF
 from mitosheet.step_performers.filter import FilterStepPerformer
 from mitosheet.state import State
 from mitosheet.step_performers import STEP_TYPE_TO_STEP_PERFORMER
+from mitosheet.types import ColumnHeader, ColumnID
 
 
 class Step:
@@ -191,21 +192,21 @@ class Step:
 
         return step_indexes_to_skip
 
-    def get_column_headers_by_ids(self, sheet_index: int, column_ids: List[str]) -> List[Any]:
+    def get_column_headers_by_ids(self, sheet_index: int, column_ids: List[ColumnID]) -> List[Any]:
         """
         Utility for getting the column headers from column ids in a step.
         First attempts to get them from the prev state, but if not 
         """
         return self.final_defined_state.column_ids.get_column_headers_by_ids(sheet_index, column_ids)
             
-    def get_column_header_by_id(self, sheet_index: int, column_id: str) -> Any:
+    def get_column_header_by_id(self, sheet_index: int, column_id: ColumnID) -> Any:
         """
         Utility for getting the column header from a column id in a step.
         First attempts to get them from the prev state, but if not 
         """
         return self.final_defined_state.column_ids.get_column_header_by_id(sheet_index, column_id)
 
-    def get_column_id_by_header(self, sheet_index: int, column_header: Any) -> str:
+    def get_column_id_by_header(self, sheet_index: int, column_header: ColumnHeader) -> str:
         """
         Utility for getting the column id from a column header in a step.
         First attempts to get them from the prev state, but if not 

--- a/mitosheet/mitosheet/step_performers/bulk_old_rename/bulk_old_rename.py
+++ b/mitosheet/mitosheet/step_performers/bulk_old_rename/bulk_old_rename.py
@@ -49,7 +49,7 @@ class BulkOldRenameStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute(
+    def execute( # type: ignore
         cls,
         prev_state: State,
         move_to_deprecated_id_algorithm: bool=False,

--- a/mitosheet/mitosheet/step_performers/bulk_old_rename/deprecated_utils.py
+++ b/mitosheet/mitosheet/step_performers/bulk_old_rename/deprecated_utils.py
@@ -13,6 +13,8 @@ import pandas as pd
 import warnings
 import functools
 
+from mitosheet.types import ColumnHeader
+
 def deprecated(func: Callable) -> Callable:
     """
     This is a decorator which can be used to mark functions
@@ -35,7 +37,7 @@ def deprecated(func: Callable) -> Callable:
     return new_func
 
 
-def make_valid_header(column_header: Any) -> str:
+def make_valid_header(column_header: ColumnHeader) -> str:
     """
     Takes a header, and performs replaces against common characters
     to make the column_header valid!
@@ -91,7 +93,7 @@ def make_valid_header(column_header: Any) -> str:
 make_valid_header_external = deprecated(make_valid_header)
 
 
-def is_valid_header(column_header: Any) -> bool:
+def is_valid_header(column_header: ColumnHeader) -> bool:
     """
     A header is valid if it is a string that is made up of all word characters,
     with at least one non numeric char, and has at least one char.
@@ -122,7 +124,7 @@ def get_invalid_headers(df: pd.DataFrame) -> List[Any]:
         if not is_valid_header(header)
     ]
 
-def get_header_renames(column_headers: List[Any]) -> Dict[Any, str]:
+def get_header_renames(column_headers: List[ColumnHeader]) -> Dict[Any, str]:
     """
     Given a list of column headers, returns a mapping from old, invalid headers to
     new, valid headers. Empty if no renames are necessary.

--- a/mitosheet/mitosheet/step_performers/bulk_old_rename/deprecated_utils.py
+++ b/mitosheet/mitosheet/step_performers/bulk_old_rename/deprecated_utils.py
@@ -37,7 +37,7 @@ def deprecated(func: Callable) -> Callable:
     return new_func
 
 
-def make_valid_header(column_header: ColumnHeader) -> str:
+def make_valid_header(column_header: Any) -> str:
     """
     Takes a header, and performs replaces against common characters
     to make the column_header valid!

--- a/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
@@ -27,6 +27,7 @@ from mitosheet.step_performers.column_steps.set_column_formula import (
     refresh_dependant_columns, transpile_dependant_columns)
 from mitosheet.step_performers.step_performer import StepPerformer
 from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_code
+from mitosheet.types import ColumnID
 
 
 class ChangeColumnDtypeStepPerformer(StepPerformer):
@@ -66,7 +67,7 @@ class ChangeColumnDtypeStepPerformer(StepPerformer):
         cls,
         prev_state: State,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         old_dtype: str,
         new_dtype: str,
         **params
@@ -227,7 +228,7 @@ class ChangeColumnDtypeStepPerformer(StepPerformer):
         post_state: State,
         execution_data: Optional[Dict[str, Any]],
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         old_dtype: str,
         new_dtype: str
     ) -> List[str]:
@@ -350,7 +351,7 @@ class ChangeColumnDtypeStepPerformer(StepPerformer):
     def describe( # type: ignore
         cls,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         old_dtype: str,
         new_dtype: str,
         df_names=None,
@@ -362,7 +363,7 @@ class ChangeColumnDtypeStepPerformer(StepPerformer):
     def get_modified_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         old_dtype: str,
         new_dtype: str,
         **params

--- a/mitosheet/mitosheet/step_performers/column_steps/change_column_format.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/change_column_format.py
@@ -8,6 +8,7 @@ from copy import copy, deepcopy
 from typing import Any, Dict, List, Optional, Set, Tuple
 from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.types import ColumnID
 
 class ChangeColumnFormatStepPerformer(StepPerformer):
     """"
@@ -39,7 +40,7 @@ class ChangeColumnFormatStepPerformer(StepPerformer):
         cls,
         prev_state: State,
         sheet_index: int,
-        column_ids: List[str],
+        column_ids: List[ColumnID],
         format_type: Dict[str, str],
         **params
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
@@ -61,7 +62,7 @@ class ChangeColumnFormatStepPerformer(StepPerformer):
         post_state: State,
         execution_data: Optional[Dict[str, Any]],
         sheet_index: int,
-        column_ids: List[str],
+        column_ids: List[ColumnID],
         format_type: Dict[str, str]
     ) -> List[str]:
         # Formatting columns only effects the display in Mito, not the generated code.
@@ -71,7 +72,7 @@ class ChangeColumnFormatStepPerformer(StepPerformer):
     def describe( # type: ignore
         cls,
         sheet_index: int,
-        column_ids: List[str],
+        column_ids: List[ColumnID],
         format_type: Dict[str,str],
         df_names=None,
         **params
@@ -83,7 +84,7 @@ class ChangeColumnFormatStepPerformer(StepPerformer):
     def get_modified_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
-        column_ids: List[str],
+        column_ids: List[ColumnID],
         **params
     ) -> Set[int]:
         return {sheet_index}
@@ -91,7 +92,7 @@ class ChangeColumnFormatStepPerformer(StepPerformer):
 def update_column_id_format(
     post_state: State,
     sheet_index: int,
-    column_id: str,
+    column_id: ColumnID,
     format_type: Dict[str, str]
 ) -> State: 
     post_state.column_format_types[sheet_index][column_id] = format_type

--- a/mitosheet/mitosheet/step_performers/column_steps/change_column_format.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/change_column_format.py
@@ -41,7 +41,7 @@ class ChangeColumnFormatStepPerformer(StepPerformer):
         prev_state: State,
         sheet_index: int,
         column_ids: List[ColumnID],
-        format_type: Dict[str, str],
+        format_type: Dict[str, Any],
         **params
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
 
@@ -63,7 +63,7 @@ class ChangeColumnFormatStepPerformer(StepPerformer):
         execution_data: Optional[Dict[str, Any]],
         sheet_index: int,
         column_ids: List[ColumnID],
-        format_type: Dict[str, str]
+        format_type: Dict[str, Any]
     ) -> List[str]:
         # Formatting columns only effects the display in Mito, not the generated code.
         return []
@@ -73,7 +73,7 @@ class ChangeColumnFormatStepPerformer(StepPerformer):
         cls,
         sheet_index: int,
         column_ids: List[ColumnID],
-        format_type: Dict[str,str],
+        format_type: Dict[str, Any],
         df_names=None,
         **params
     ) -> str:
@@ -93,7 +93,7 @@ def update_column_id_format(
     post_state: State,
     sheet_index: int,
     column_id: ColumnID,
-    format_type: Dict[str, str]
+    format_type: Dict[str, Any]
 ) -> State: 
     post_state.column_format_types[sheet_index][column_id] = format_type
     return post_state

--- a/mitosheet/mitosheet/step_performers/column_steps/delete_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/delete_column.py
@@ -12,6 +12,7 @@ from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
 from mitosheet.topological_sort import topological_sort_columns
 from mitosheet.transpiler.transpile_utils import column_header_list_to_transpiled_code
+from mitosheet.types import ColumnID
 
 
 class DeleteColumnStepPerformer(StepPerformer):
@@ -44,7 +45,7 @@ class DeleteColumnStepPerformer(StepPerformer):
         cls,
         prev_state: State,
         sheet_index: int,
-        column_ids: List[str],
+        column_ids: List[ColumnID],
         **params
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
 
@@ -64,7 +65,7 @@ class DeleteColumnStepPerformer(StepPerformer):
         post_state: State,
         execution_data: Optional[Dict[str, Any]],
         sheet_index: int,
-        column_ids: List[str]
+        column_ids: List[ColumnID]
     ) -> List[str]:
 
         df_name = post_state.df_names[sheet_index]
@@ -78,7 +79,7 @@ class DeleteColumnStepPerformer(StepPerformer):
     def describe( # type: ignore
         cls,
         sheet_index: int,
-        column_ids: List[str],
+        column_ids: List[ColumnID],
         df_names=None,
         **params
     ) -> str:
@@ -92,7 +93,7 @@ class DeleteColumnStepPerformer(StepPerformer):
     def get_modified_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
-        column_ids: List[str],
+        column_ids: List[ColumnID],
         **params
     ) -> Set[int]:
         return {sheet_index}
@@ -100,7 +101,7 @@ class DeleteColumnStepPerformer(StepPerformer):
 def delete_column_ids(
     state: State,
     sheet_index: int,
-    column_ids: List[str],
+    column_ids: List[ColumnID],
 ) -> State:
 
     # Put the columns in a topological sorting so we delete columns that reference
@@ -131,7 +132,7 @@ def delete_column_ids(
 def _delete_column_id( 
     state: State,
     sheet_index: int,
-    column_id: str
+    column_id: ColumnID
 ) -> Tuple[State, bool]:
     
     column_header = state.column_ids.get_column_header_by_id(sheet_index, column_id)

--- a/mitosheet/mitosheet/step_performers/column_steps/rename_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/rename_column.py
@@ -14,6 +14,7 @@ from mitosheet.step_performers.column_steps.set_column_formula import \
     _update_column_formula_in_step
 from mitosheet.step_performers.step_performer import StepPerformer
 from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_code
+from mitosheet.types import ColumnHeader, ColumnID
 
 
 class RenameColumnStepPerformer(StepPerformer):
@@ -50,7 +51,7 @@ class RenameColumnStepPerformer(StepPerformer):
         cls,
         prev_state: State,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         new_column_header: str,
         level=None,
         **params
@@ -86,7 +87,7 @@ class RenameColumnStepPerformer(StepPerformer):
         post_state: State,
         execution_data: Optional[Dict[str, Any]],
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         new_column_header: str,
         level=None
     ) -> List[str]:
@@ -118,7 +119,7 @@ class RenameColumnStepPerformer(StepPerformer):
     def describe( # type: ignore
         cls,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         new_column_header: str,
         level=None,
         df_names=None,
@@ -136,7 +137,7 @@ class RenameColumnStepPerformer(StepPerformer):
     def get_modified_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         new_column_header: str,
         level=None,
         **params
@@ -147,10 +148,10 @@ class RenameColumnStepPerformer(StepPerformer):
 def rename_column_headers_in_state(
         post_state: State,
         sheet_index: int,
-        column_id: str,
-        new_column_header: Any,
+        column_id: ColumnID,
+        new_column_header: ColumnHeader,
         level: Union[None, int]
-    ) -> Any:
+    ) -> ColumnHeader:
     """
     A helper function for updating a column header in the state, which is useful
     for both this rename step and for the bulk rename step.

--- a/mitosheet/mitosheet/step_performers/column_steps/rename_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/rename_column.py
@@ -151,7 +151,7 @@ def rename_column_headers_in_state(
         column_id: ColumnID,
         new_column_header: ColumnHeader,
         level: Union[None, int]
-    ) -> ColumnHeader:
+    ) -> Optional[ColumnHeader]:
     """
     A helper function for updating a column header in the state, which is useful
     for both this rename step and for the bulk rename step.
@@ -165,6 +165,9 @@ def rename_column_headers_in_state(
     old_new_column_headers_to_update: Set[Tuple[str, Any, Any]] = set()
 
     if level is not None:
+        if not isinstance(old_column_header, tuple) and not isinstance(old_column_header, list):
+            raise ValueError(f'Error, cannot set level {level} on column header {old_column_header}')
+
         # If we have a level set, do the rename on the level value, rather than the column header
         # so that it matches the specific value in the dataframe
         old_level_value = old_column_header[level]

--- a/mitosheet/mitosheet/step_performers/column_steps/reorder_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/reorder_column.py
@@ -12,6 +12,7 @@ from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
 from mitosheet.transpiler.transpile_utils import \
     column_header_to_transpiled_code
+from mitosheet.types import ColumnHeader, ColumnID
 
 
 def get_valid_index(dfs: List[pd.DataFrame], sheet_index: int, new_column_index: int) -> int:
@@ -56,7 +57,7 @@ class ReorderColumnStepPerformer(StepPerformer):
         cls,
         prev_state: State,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         new_column_index: int,
         **params
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
@@ -84,7 +85,7 @@ class ReorderColumnStepPerformer(StepPerformer):
         post_state: State,
         execution_data: Optional[Dict[str, Any]],
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         new_column_index: int
     ) -> List[str]:
         column_header = prev_state.column_ids.get_column_header_by_id(sheet_index, column_id)
@@ -108,7 +109,7 @@ class ReorderColumnStepPerformer(StepPerformer):
     def describe( # type: ignore
         cls,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         new_column_index: int,
         df_names=None,
         **params
@@ -122,14 +123,14 @@ class ReorderColumnStepPerformer(StepPerformer):
     def get_modified_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         new_column_index: int,
         **params
     ) -> Set[int]:
         return {sheet_index}
 
 
-def _execute_reorder_column(df: pd.DataFrame, column_header: Any, new_column_index: int) -> pd.DataFrame:
+def _execute_reorder_column(df: pd.DataFrame, column_header: ColumnHeader, new_column_index: int) -> pd.DataFrame:
     """
     Helper function for reordering a column in the dataframe
     """

--- a/mitosheet/mitosheet/step_performers/column_steps/set_column_formula.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/set_column_formula.py
@@ -24,6 +24,7 @@ from mitosheet.errors import (
     make_unsupported_function_error, 
     make_wrong_column_metatype_error
 )
+from mitosheet.types import ColumnHeader, ColumnID
 
 class SetColumnFormulaStepPerformer(StepPerformer):
     """
@@ -75,7 +76,7 @@ class SetColumnFormulaStepPerformer(StepPerformer):
         cls,
         prev_state: State,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         old_formula: str,
         new_formula: str,
         **params
@@ -161,7 +162,7 @@ class SetColumnFormulaStepPerformer(StepPerformer):
         post_state: State,
         execution_data: Optional[Dict[str, Any]],
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         old_formula: str,
         new_formula: str
     ) -> List[str]:
@@ -174,7 +175,7 @@ class SetColumnFormulaStepPerformer(StepPerformer):
     def describe( # type: ignore
         cls,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         old_formula: str,
         new_formula: str,
         df_names=None,
@@ -189,7 +190,7 @@ class SetColumnFormulaStepPerformer(StepPerformer):
     def get_modified_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         old_formula: str,
         new_formula: str,
         **params
@@ -200,7 +201,7 @@ class SetColumnFormulaStepPerformer(StepPerformer):
 def _update_column_formula_in_step(
         post_state: State,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         old_formula: str,
         new_formula: str,
         update_from_rename: bool=False
@@ -244,8 +245,8 @@ def _update_column_formula_in_step(
 
 def _get_fixed_invalid_formula(
         new_formula: str, 
-        column_header: Any, 
-        column_headers: List[Any]
+        column_header: ColumnHeader, 
+        column_headers: List[ColumnHeader]
     ) -> str:
     """
     A helper function that, given a formula, will try and fix
@@ -367,7 +368,7 @@ def refresh_dependant_columns(post_state: State, df: pd.DataFrame, sheet_index: 
 def transpile_dependant_columns(
         post_state: State, 
         sheet_index: int, 
-        column_id: str
+        column_id: ColumnID
     ) -> List[str]: 
     """
     Use this helper function when making a change to a column and you want to transpile

--- a/mitosheet/mitosheet/step_performers/drop_duplicates.py
+++ b/mitosheet/mitosheet/step_performers/drop_duplicates.py
@@ -15,6 +15,7 @@ from mitosheet.errors import (
     make_invalid_sort_error
 )
 from mitosheet.transpiler.transpile_utils import column_header_list_to_transpiled_code, column_header_to_transpiled_code
+from mitosheet.types import ColumnID
 
 # CONSTANTS USED IN THE SORT STEP ITSELF
 ASCENDING = 'ascending'
@@ -50,7 +51,7 @@ class DropDuplicatesStepPerformer(StepPerformer):
         cls,
         prev_state: State,
         sheet_index: int,
-        column_ids: List[str],
+        column_ids: List[ColumnID],
         keep: Union[str, bool],
         **params
     ):
@@ -81,7 +82,7 @@ class DropDuplicatesStepPerformer(StepPerformer):
         post_state: State,
         execution_data: Optional[Dict[str, Any]],
         sheet_index: int,
-        column_ids: List[str],
+        column_ids: List[ColumnID],
         keep: Union[str, bool],
     ) -> List[str]:
 
@@ -113,7 +114,7 @@ class DropDuplicatesStepPerformer(StepPerformer):
     def describe( # type: ignore
         cls,
         sheet_index: int,
-        column_ids: List[str],
+        column_ids: List[ColumnID],
         keep: str,
         df_names=None,
         **params
@@ -127,7 +128,7 @@ class DropDuplicatesStepPerformer(StepPerformer):
     def get_modified_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
-        column_ids: List[str],
+        column_ids: List[ColumnID],
         keep: str,
         **params
     ) -> Set[int]:

--- a/mitosheet/mitosheet/step_performers/filter.py
+++ b/mitosheet/mitosheet/step_performers/filter.py
@@ -23,6 +23,7 @@ from mitosheet.errors import (
     make_invalid_filter_error
 )
 from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_code, list_to_string_without_internal_quotes
+from mitosheet.types import ColumnHeader, ColumnID
 
 # SOME CONSTANTS USED IN THE FILTER STEP ITSELF
 FC_EMPTY = 'empty'
@@ -227,7 +228,7 @@ class FilterStepPerformer(StepPerformer):
         return 'filter_column_edit'
 
     @classmethod
-    def saturate(cls, prev_state: State, params: Any) -> Dict[str, str]:
+    def saturate(cls, prev_state: State, params: Dict[str, Any]) -> Dict[str, Any]:
         """
         Saturates the filter event with a `has_non_empty_filter` - which is useful
         for for logging
@@ -250,7 +251,7 @@ class FilterStepPerformer(StepPerformer):
         cls,
         prev_state: State,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         operator: str,
         filters,
         **params
@@ -284,7 +285,7 @@ class FilterStepPerformer(StepPerformer):
         post_state: State,
         execution_data: Optional[Dict[str, Any]],
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         operator: str,
         filters,
         **params
@@ -338,7 +339,7 @@ class FilterStepPerformer(StepPerformer):
     def describe( # type: ignore
         cls,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         operator: str,
         filters,
         df_names=None,
@@ -353,7 +354,7 @@ class FilterStepPerformer(StepPerformer):
     def get_modified_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         operator: str,
         filters,
         **params
@@ -361,7 +362,7 @@ class FilterStepPerformer(StepPerformer):
         return {sheet_index}
 
 
-def get_applied_filter(df: pd.DataFrame, column_header: Any, filter_: Dict[str, Any]) -> pd.Series:
+def get_applied_filter(df: pd.DataFrame, column_header: ColumnHeader, filter_: Dict[str, Any]) -> pd.Series:
     """
     Given a filter triple, returns the filter indexes for that
     actual dataframe
@@ -467,7 +468,7 @@ def combine_filters(operator: str, filters: pd.Series) -> pd.Series:
 
 def _execute_filter(
         df: pd.DataFrame, 
-        column_header: Any,
+        column_header: ColumnHeader,
         operator: str,
         filters: List[Dict[str, Any]]
     ) -> pd.DataFrame:
@@ -504,7 +505,7 @@ def _execute_filter(
         return df
 
 
-def get_single_filter_string(df_name: str, column_header: Any, filter_: Dict[str, Any]) -> str:
+def get_single_filter_string(df_name: str, column_header: ColumnHeader, filter_: Dict[str, Any]) -> str:
     """
     Transpiles a specific filter to a fitler string, to be used
     in constructing the final transpiled code
@@ -520,7 +521,7 @@ def get_single_filter_string(df_name: str, column_header: Any, filter_: Dict[str
         value=value
     )
 
-def get_multiple_filter_string(df_name: str, column_header: Any, original_operator: str, condition: str, column_mito_type: str, filters: List[Dict[str, Any]]) -> str:
+def get_multiple_filter_string(df_name: str, column_header: ColumnHeader, original_operator: str, condition: str, column_mito_type: str, filters: List[Dict[str, Any]]) -> str:
     """
     Transpiles a list of filters with the same filter condition to a filter string. 
     """
@@ -573,7 +574,7 @@ def combine_filter_strings(operator: str, filter_strings: List[str], split_lines
 
         return filter_string
 
-def create_filter_string_for_condition(condition: str, mito_filters: List[Dict[str, Any]], df_name: str, column_header: Any, operator: str, column_mito_type: str) -> str:
+def create_filter_string_for_condition(condition: str, mito_filters: List[Dict[str, Any]], df_name: str, column_header: ColumnHeader, operator: str, column_mito_type: str) -> str:
     """
     Returns a list of all the filter clauses for a specific filter condition in the list of passed filters
     Note: We use the nomenclature "mito_filters" here so the compiler doesn't get confused when we use the filter function 

--- a/mitosheet/mitosheet/step_performers/merge.py
+++ b/mitosheet/mitosheet/step_performers/merge.py
@@ -15,6 +15,7 @@ from mitosheet.state import DATAFRAME_SOURCE_MERGED, State
 from mitosheet.step_performers.step_performer import StepPerformer
 from mitosheet.transpiler.transpile_utils import (
     column_header_list_to_transpiled_code, column_header_to_transpiled_code)
+from mitosheet.types import ColumnHeader, ColumnID
 
 LOOKUP = 'lookup'
 UNIQUE_IN_LEFT = 'unique in left'
@@ -42,7 +43,7 @@ class MergeStepPerformer(StepPerformer):
         return 'merge_edit'
 
     @classmethod
-    def saturate(cls, prev_state: State, params: Any) -> Dict[str, str]:
+    def saturate(cls, prev_state: State, params: Dict[str, Any]) -> Dict[str, Any]:
         return params
 
     @classmethod
@@ -51,11 +52,11 @@ class MergeStepPerformer(StepPerformer):
         prev_state: State,
         how: str,
         sheet_index_one: int,
-        merge_key_column_id_one: str,
-        selected_column_ids_one: List[str],
+        merge_key_column_id_one: ColumnID,
+        selected_column_ids_one: List[ColumnID],
         sheet_index_two: int,
-        merge_key_column_id_two: str,
-        selected_column_ids_two: List[str],
+        merge_key_column_id_two: ColumnID,
+        selected_column_ids_two: List[ColumnID],
         **params
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
 
@@ -93,11 +94,11 @@ class MergeStepPerformer(StepPerformer):
         execution_data: Optional[Dict[str, Any]],
         how: str,
         sheet_index_one: int,
-        merge_key_column_id_one: str,
-        selected_column_ids_one: List[str],
+        merge_key_column_id_one: ColumnID,
+        selected_column_ids_one: List[ColumnID],
         sheet_index_two: int,
-        merge_key_column_id_two: str,
-        selected_column_ids_two: List[str],
+        merge_key_column_id_two: ColumnID,
+        selected_column_ids_two: List[ColumnID],
     ) -> List[str]:
 
         merge_key_one = prev_state.column_ids.get_column_header_by_id(sheet_index_one, merge_key_column_id_one)
@@ -167,11 +168,11 @@ class MergeStepPerformer(StepPerformer):
         cls,
         how: str,
         sheet_index_one: int,
-        merge_key_column_id_one: str,
-        selected_column_ids_one: List[str],
+        merge_key_column_id_one: ColumnID,
+        selected_column_ids_one: List[ColumnID],
         sheet_index_two: int,
-        merge_key_column_id_two: str,
-        selected_column_ids_two: List[str],
+        merge_key_column_id_two: ColumnID,
+        selected_column_ids_two: List[ColumnID],
         df_names=None,
         **params
     ) -> str:
@@ -186,11 +187,11 @@ class MergeStepPerformer(StepPerformer):
         cls, 
         how: str,
         sheet_index_one: int,
-        merge_key_column_id_one: str,
-        selected_column_ids_one: List[str],
+        merge_key_column_id_one: ColumnID,
+        selected_column_ids_one: List[ColumnID],
         sheet_index_two: int,
-        merge_key_column_id_two: str,
-        selected_column_ids_two: List[str],
+        merge_key_column_id_two: ColumnID,
+        selected_column_ids_two: List[ColumnID],
     ) -> Set[int]:
         return {-1}
 
@@ -199,11 +200,11 @@ def _execute_merge(
         df_names: List[str],
         how: str,
         sheet_index_one: int,
-        merge_key_one: Any, 
-        selected_columns_one: List[Any],
+        merge_key_one: ColumnHeader, 
+        selected_columns_one: List[ColumnHeader],
         sheet_index_two: int,
-        merge_key_two: Any,
-        selected_columns_two: List[Any]
+        merge_key_two: ColumnHeader,
+        selected_columns_two: List[ColumnHeader]
     ) -> pd.DataFrame:
     """
     Executes a merge on the sheets with the given indexes, merging on the 

--- a/mitosheet/mitosheet/step_performers/pivot.py
+++ b/mitosheet/mitosheet/step_performers/pivot.py
@@ -235,12 +235,12 @@ class PivotStepPerformer(StepPerformer):
     
 
 
-def values_to_functions(values: Dict[str, Collection[str]]) -> Dict[str, List[Callable]]:
+def values_to_functions(values: Dict[ColumnID, Collection[str]]) -> Dict[ColumnID, List[Callable]]:
     """
     Helper function for turning the values mapping sent by the frontend to 
     the value map of functions that can actually be passed to the pandas pivot function
     """
-    new_values: Dict[str, List[Callable]] = dict()
+    new_values: Dict[ColumnID, List[Callable]] = dict()
 
     for column_header, aggregation_function_names in values.items():
         new_values[column_header] = []
@@ -306,7 +306,7 @@ def _execute_pivot(
 
     return pivot_table
 
-def values_to_functions_code(values: Dict[str, Collection[str]]) -> str:
+def values_to_functions_code(values: Dict[ColumnID, Collection[str]]) -> str:
     """
     Helper function for turning the values mapping sent by the frontend to the values
     mapping that works in generated code. Namely, needs to replay Count Unique with the
@@ -320,7 +320,7 @@ def values_to_functions_code(values: Dict[str, Collection[str]]) -> str:
 def build_args_code(
         pivot_rows: List[ColumnHeader],
         pivot_columns: List[ColumnHeader],
-        values: Dict[str, Collection[str]]
+        values: Dict[ColumnID, Collection[str]]
     ) -> str:
     """
     Helper function for building an arg string, while leaving

--- a/mitosheet/mitosheet/step_performers/pivot.py
+++ b/mitosheet/mitosheet/step_performers/pivot.py
@@ -15,6 +15,8 @@ from mitosheet.state import DATAFRAME_SOURCE_PIVOTED, State
 from mitosheet.step_performers.step_performer import StepPerformer
 from pandas.core.base import DataError
 
+from mitosheet.types import ColumnHeader, ColumnID
+
 # Aggregation types pivot supports
 PA_COUNT_UNIQUE = 'count unique'
 PIVOT_AGGREGATION_TYPES = [
@@ -59,7 +61,7 @@ class PivotStepPerformer(StepPerformer):
         return 'pivot_edit'
 
     @classmethod
-    def saturate(cls, prev_state: State, params: Any) -> Dict[str, str]:
+    def saturate(cls, prev_state: State, params: Dict[str, Any]) -> Dict[str, Any]:
         """
         Saturates the pivot table with just a `created_non_empty_dataframe` key, which
         is useful for logging.
@@ -88,9 +90,9 @@ class PivotStepPerformer(StepPerformer):
         cls,
         prev_state: State,
         sheet_index: int,
-        pivot_rows_column_ids: List[str],
-        pivot_columns_column_ids: List[str],
-        values_column_ids_map: Dict[str, Collection[str]],
+        pivot_rows_column_ids: List[ColumnID],
+        pivot_columns_column_ids: List[ColumnID],
+        values_column_ids_map: Dict[ColumnID, Collection[str]],
         flatten_column_headers: bool,
         destination_sheet_index: int=None,
         use_deprecated_id_algorithm: bool=False,
@@ -150,9 +152,9 @@ class PivotStepPerformer(StepPerformer):
         post_state: State,
         execution_data: Optional[Dict[str, Any]],
         sheet_index: int,
-        pivot_rows_column_ids: List[str],
-        pivot_columns_column_ids: List[str],
-        values_column_ids_map: Dict[str, Collection[str]],
+        pivot_rows_column_ids: List[ColumnID],
+        pivot_columns_column_ids: List[ColumnID],
+        values_column_ids_map: Dict[ColumnID, Collection[str]],
         flatten_column_headers: bool,
         destination_sheet_index: int=None,
         use_deprecated_id_algorithm: bool=False,
@@ -257,9 +259,9 @@ def values_to_functions(values: Dict[str, Collection[str]]) -> Dict[str, List[Ca
 
 def _execute_pivot(
         df: pd.DataFrame, 
-        pivot_rows: List[str], 
-        pivot_columns: List[str], 
-        values: Dict[str, Collection[str]],
+        pivot_rows: List[ColumnID], 
+        pivot_columns: List[ColumnID], 
+        values: Dict[ColumnID, Collection[str]],
         flatten_column_headers: bool
     ) -> pd.DataFrame:
     """
@@ -316,8 +318,8 @@ def values_to_functions_code(values: Dict[str, Collection[str]]) -> str:
     return string_values.replace('\'count unique\'', 'pd.Series.nunique')
 
 def build_args_code(
-        pivot_rows: List[Any],
-        pivot_columns: List[Any],
+        pivot_rows: List[ColumnHeader],
+        pivot_columns: List[ColumnHeader],
         values: Dict[str, Collection[str]]
     ) -> str:
     """

--- a/mitosheet/mitosheet/step_performers/pivot.py
+++ b/mitosheet/mitosheet/step_performers/pivot.py
@@ -235,12 +235,12 @@ class PivotStepPerformer(StepPerformer):
     
 
 
-def values_to_functions(values: Dict[ColumnID, Collection[str]]) -> Dict[ColumnID, List[Callable]]:
+def values_to_functions(values: Dict[ColumnHeader, Collection[str]]) -> Dict[ColumnHeader, List[Callable]]:
     """
     Helper function for turning the values mapping sent by the frontend to 
     the value map of functions that can actually be passed to the pandas pivot function
     """
-    new_values: Dict[ColumnID, List[Callable]] = dict()
+    new_values: Dict[ColumnHeader, List[Callable]] = dict()
 
     for column_header, aggregation_function_names in values.items():
         new_values[column_header] = []
@@ -259,9 +259,9 @@ def values_to_functions(values: Dict[ColumnID, Collection[str]]) -> Dict[ColumnI
 
 def _execute_pivot(
         df: pd.DataFrame, 
-        pivot_rows: List[ColumnID], 
-        pivot_columns: List[ColumnID], 
-        values: Dict[ColumnID, Collection[str]],
+        pivot_rows: List[ColumnHeader], 
+        pivot_columns: List[ColumnHeader], 
+        values: Dict[ColumnHeader, Collection[str]],
         flatten_column_headers: bool
     ) -> pd.DataFrame:
     """
@@ -306,7 +306,7 @@ def _execute_pivot(
 
     return pivot_table
 
-def values_to_functions_code(values: Dict[ColumnID, Collection[str]]) -> str:
+def values_to_functions_code(values: Dict[ColumnHeader, Collection[str]]) -> str:
     """
     Helper function for turning the values mapping sent by the frontend to the values
     mapping that works in generated code. Namely, needs to replay Count Unique with the
@@ -320,7 +320,7 @@ def values_to_functions_code(values: Dict[ColumnID, Collection[str]]) -> str:
 def build_args_code(
         pivot_rows: List[ColumnHeader],
         pivot_columns: List[ColumnHeader],
-        values: Dict[ColumnID, Collection[str]]
+        values: Dict[ColumnHeader, Collection[str]]
     ) -> str:
     """
     Helper function for building an arg string, while leaving

--- a/mitosheet/mitosheet/step_performers/set_cell_value.py
+++ b/mitosheet/mitosheet/step_performers/set_cell_value.py
@@ -6,6 +6,7 @@
 
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from mitosheet.types import ColumnID
 import numpy as np
 
 from mitosheet.errors import make_cast_value_to_type_error, make_no_column_error
@@ -66,7 +67,7 @@ class SetCellValueStepPerformer(StepPerformer):
         cls,
         prev_state: State,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         row_index: int,
         old_value: str,
         new_value: Union[str, None],
@@ -109,7 +110,7 @@ class SetCellValueStepPerformer(StepPerformer):
         post_state: State,
         execution_data: Optional[Dict[str, Any]],
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         row_index: int,
         old_value: str,
         new_value: Union[str, None],
@@ -148,7 +149,7 @@ class SetCellValueStepPerformer(StepPerformer):
     def describe( # type: ignore
         cls,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         row_index: int,
         old_value: str,
         new_value: Union[str, None],
@@ -167,7 +168,7 @@ class SetCellValueStepPerformer(StepPerformer):
     def get_modified_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         row_index: int,
         old_value: str,
         new_value: Union[str, None],

--- a/mitosheet/mitosheet/step_performers/sort.py
+++ b/mitosheet/mitosheet/step_performers/sort.py
@@ -13,6 +13,7 @@ from mitosheet.errors import (
     make_invalid_sort_error
 )
 from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_code
+from mitosheet.types import ColumnID
 
 # CONSTANTS USED IN THE SORT STEP ITSELF
 ASCENDING = 'ascending'
@@ -41,7 +42,7 @@ class SortStepPerformer(StepPerformer):
         return 'sort_edit'
 
     @classmethod
-    def saturate(cls, prev_state: State, params: Any) -> Dict[str, str]:
+    def saturate(cls, prev_state: State, params: Dict[str, Any]) -> Dict[str, Any]:
         return params
 
     @classmethod
@@ -49,7 +50,7 @@ class SortStepPerformer(StepPerformer):
         cls,
         prev_state: State,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         sort_direction: str,
         **params
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
@@ -83,7 +84,7 @@ class SortStepPerformer(StepPerformer):
         post_state: State,
         execution_data: Optional[Dict[str, Any]],
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         sort_direction: str
     ) -> List[str]:
         df_name = post_state.df_names[sheet_index]
@@ -100,7 +101,7 @@ class SortStepPerformer(StepPerformer):
     def describe( # type: ignore
         cls,
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         sort_direction: str,
         df_names=None,
         **params
@@ -114,7 +115,7 @@ class SortStepPerformer(StepPerformer):
     def get_modified_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
-        column_id: str,
+        column_id: ColumnID,
         sort_direction: str,
         **params
     ) -> Set[int]:

--- a/mitosheet/mitosheet/step_performers/step_performer.py
+++ b/mitosheet/mitosheet/step_performers/step_performer.py
@@ -44,7 +44,7 @@ class StepPerformer(ABC, object):
         pass
 
     @classmethod
-    def saturate(cls, prev_state: State, params: Any) -> Dict[str, str]:
+    def saturate(cls, prev_state: State, params: Dict[str, Any]) -> Dict[str, Any]:
         """
         Given the parameters of the step, will saturate the event with
         more parameters based on the passed prev_state. 
@@ -54,7 +54,7 @@ class StepPerformer(ABC, object):
 
     @classmethod
     @abstractmethod
-    def execute(cls, prev_state: State, **params: Any) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, **params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
         """
         Execute always returns the post_state, and optionally returns a dictionary
         of execution_data, which is data that may be useful to the transpiler in
@@ -64,7 +64,7 @@ class StepPerformer(ABC, object):
 
     @classmethod
     @abstractmethod
-    def transpile(cls, prev_state: State, post_state: State, **params: Any) -> List[str]:
+    def transpile(cls, prev_state: State, post_state: State, **params: Dict[str, Any]) -> List[str]:
         """
         Returns a list of the Python code lines that corresponds to this 
         step being executed.

--- a/mitosheet/mitosheet/step_performers/step_performer.py
+++ b/mitosheet/mitosheet/step_performers/step_performer.py
@@ -44,7 +44,7 @@ class StepPerformer(ABC, object):
         pass
 
     @classmethod
-    def saturate(cls, prev_state: State, params: Dict[str, Any]) -> Dict[str, Any]:
+    def saturate(cls, prev_state: State, params: Any) -> Dict[str, str]:
         """
         Given the parameters of the step, will saturate the event with
         more parameters based on the passed prev_state. 
@@ -54,7 +54,7 @@ class StepPerformer(ABC, object):
 
     @classmethod
     @abstractmethod
-    def execute(cls, prev_state: State, **params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, **params: Any) -> Tuple[State, Optional[Dict[str, Any]]]:
         """
         Execute always returns the post_state, and optionally returns a dictionary
         of execution_data, which is data that may be useful to the transpiler in
@@ -64,7 +64,7 @@ class StepPerformer(ABC, object):
 
     @classmethod
     @abstractmethod
-    def transpile(cls, prev_state: State, post_state: State, **params: Dict[str, Any]) -> List[str]:
+    def transpile(cls, prev_state: State, post_state: State, **params: Any) -> List[str]:
         """
         Returns a list of the Python code lines that corresponds to this 
         step being executed.

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Union
 import pandas as pd
 from mitosheet.mito_widget import MitoWidget, sheet
 from mitosheet.transpiler.transpile import transpile
-from mitosheet.types import ColumnHeader, ColumnID
+from mitosheet.types import ColumnHeader, ColumnID, MultiLevelColumnHeader, PrimativeColumnHeader
 from mitosheet.utils import dfs_to_array_for_json, get_new_id
 
 
@@ -820,14 +820,13 @@ def make_multi_index_header_df(data: Dict[Union[str, int], List[Any]], column_he
         if isinstance(column_header, tuple):
             max_length = max(max_length, len(column_header))
     
-    final_column_headers = []
+    final_column_headers: List[ColumnHeader] = []
     for column_header in column_headers:
-        if isinstance(column_header, tuple):
+        if isinstance(column_header, tuple) or isinstance(column_header, list):
             final_column_headers.append(column_header)
         else:
-            final_column_header = ['' for _ in range(max_length - 1)]
-            final_column_header.insert(0, column_header)
-            final_column_headers.append(tuple(final_column_header))
+            final_column_header: MultiLevelColumnHeader = [column_header] + ['' for _ in range(max_length - 1)]
+            final_column_headers.append(final_column_header)
 
     df.columns = pd.MultiIndex.from_tuples(final_column_headers)
     if index is not None:

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Union
 import pandas as pd
 from mitosheet.mito_widget import MitoWidget, sheet
 from mitosheet.transpiler.transpile import transpile
-from mitosheet.types import ColumnHeader
+from mitosheet.types import ColumnHeader, ColumnID
 from mitosheet.utils import dfs_to_array_for_json, get_new_id
 
 
@@ -284,9 +284,9 @@ class MitoWidgetTestWrapper:
     def pivot_sheet(
             self, 
             sheet_index: int, 
-            pivot_rows: List[int],
-            pivot_columns: List[int],
-            values: Dict[str, List[str]],
+            pivot_rows: List[ColumnHeader],
+            pivot_columns: List[ColumnHeader],
+            values: Dict[ColumnHeader, List[str]],
             flatten_column_headers: bool=False,
             destination_sheet_index: int=None,
             step_id: str=None
@@ -515,7 +515,7 @@ class MitoWidgetTestWrapper:
         )
 
     @check_transpiled_code_after_call
-    def change_column_format(self, sheet_index: int, column_headers: List[ColumnHeader], new_format: Dict[str, str]) -> bool:
+    def change_column_format(self, sheet_index: int, column_headers: List[ColumnHeader], new_format: Dict[str, Any]) -> bool:
 
         column_ids = []
         for column_header in column_headers: 

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Union
 import pandas as pd
 from mitosheet.mito_widget import MitoWidget, sheet
 from mitosheet.transpiler.transpile import transpile
+from mitosheet.types import ColumnHeader
 from mitosheet.utils import dfs_to_array_for_json, get_new_id
 
 
@@ -208,11 +209,11 @@ class MitoWidgetTestWrapper:
             self, 
             how: str,
             sheet_index_one: int, 
-            merge_key_one: Any, 
-            selected_columns_one: List[Any],
+            merge_key_one: ColumnHeader, 
+            selected_columns_one: List[ColumnHeader],
             sheet_index_two: int, 
-            merge_key_two: Any,
-            selected_columns_two: List[Any]
+            merge_key_two: ColumnHeader,
+            selected_columns_two: List[ColumnHeader]
         ) -> bool:
 
         merge_key_column_id_one = self.mito_widget.steps_manager.curr_step.column_ids.get_column_id_by_header(
@@ -255,7 +256,7 @@ class MitoWidgetTestWrapper:
     def drop_duplicates(
             self, 
             sheet_index: int, 
-            column_headers: List[Any], 
+            column_headers: List[ColumnHeader], 
             keep: str,
         ) -> bool:
 
@@ -326,7 +327,7 @@ class MitoWidgetTestWrapper:
     def filter(
             self, 
             sheet_index: int, 
-            column_header: Any,
+            column_header: ColumnHeader,
             operator: str,
             type_: str,
             condition: str, 
@@ -363,7 +364,7 @@ class MitoWidgetTestWrapper:
     def filters(
             self, 
             sheet_index: int, 
-            column_header: Any,
+            column_header: ColumnHeader,
             operator: str,
             filters: List[Dict[str, Any]]
         ) -> bool:
@@ -393,7 +394,7 @@ class MitoWidgetTestWrapper:
     def sort(
             self, 
             sheet_index: int, 
-            column_header: Any,
+            column_header: ColumnHeader,
             sort_direction: str
         ) -> bool:
 
@@ -421,7 +422,7 @@ class MitoWidgetTestWrapper:
     def reorder_column(
             self, 
             sheet_index: int, 
-            column_header: Any, 
+            column_header: ColumnHeader, 
             new_column_index: int
         ) -> bool:
 
@@ -446,7 +447,7 @@ class MitoWidgetTestWrapper:
         )
 
     @check_transpiled_code_after_call
-    def rename_column(self, sheet_index: int, old_column_header: Any, new_column_header: Any, level: int=None) -> bool:
+    def rename_column(self, sheet_index: int, old_column_header: ColumnHeader, new_column_header: ColumnHeader, level: int=None) -> bool:
 
         column_id = self.mito_widget.steps_manager.curr_step.column_ids.get_column_id_by_header(
             sheet_index,
@@ -470,7 +471,7 @@ class MitoWidgetTestWrapper:
         )
 
     @check_transpiled_code_after_call
-    def delete_columns(self, sheet_index: int, column_headers: List[Any]) -> bool:
+    def delete_columns(self, sheet_index: int, column_headers: List[ColumnHeader]) -> bool:
         column_ids = [self.mito_widget.steps_manager.curr_step.column_ids.get_column_id_by_header(
             sheet_index,
             column_header 
@@ -491,7 +492,7 @@ class MitoWidgetTestWrapper:
         )
 
     @check_transpiled_code_after_call
-    def change_column_dtype(self, sheet_index: int, column_header: Any, new_dtype: str) -> bool:
+    def change_column_dtype(self, sheet_index: int, column_header: ColumnHeader, new_dtype: str) -> bool:
 
         column_id = self.mito_widget.steps_manager.curr_step.column_ids.get_column_id_by_header(
             sheet_index,
@@ -514,7 +515,7 @@ class MitoWidgetTestWrapper:
         )
 
     @check_transpiled_code_after_call
-    def change_column_format(self, sheet_index: int, column_headers: List[Any], new_format: Dict[str, str]) -> bool:
+    def change_column_format(self, sheet_index: int, column_headers: List[ColumnHeader], new_format: Dict[str, str]) -> bool:
 
         column_ids = []
         for column_header in column_headers: 
@@ -680,7 +681,7 @@ class MitoWidgetTestWrapper:
         )
 
     @check_transpiled_code_after_call
-    def set_cell_value(self, sheet_index: int, column_header: Any, row_index: int, new_value: Any) -> bool:
+    def set_cell_value(self, sheet_index: int, column_header: ColumnHeader, row_index: int, new_value: Any) -> bool:
         column_id = self.mito_widget.steps_manager.curr_step.column_ids.get_column_id_by_header(
             sheet_index,
             column_header
@@ -729,7 +730,7 @@ class MitoWidgetTestWrapper:
         )
 
 
-    def get_formula(self, sheet_index: int, column_header: Any) -> str:
+    def get_formula(self, sheet_index: int, column_header: ColumnHeader) -> str:
         """
         Gets the formula for a given column. Returns an empty
         string if nothing exists.
@@ -741,7 +742,7 @@ class MitoWidgetTestWrapper:
             return ''
         return self.mito_widget.steps_manager.curr_step.column_spreadsheet_code[sheet_index][column_id]
 
-    def get_python_formula(self, sheet_index: int, column_header: Any) -> str:
+    def get_python_formula(self, sheet_index: int, column_header: ColumnHeader) -> str:
         """
         Gets the formula for a given column. Returns an empty
         string if nothing exists.
@@ -753,7 +754,7 @@ class MitoWidgetTestWrapper:
             return ''
         return self.mito_widget.steps_manager.curr_step.column_python_code[sheet_index][column_id]
 
-    def get_value(self, sheet_index: int, column_header: Any, row: int) -> Any:
+    def get_value(self, sheet_index: int, column_header: ColumnHeader, row: int) -> Any:
         """
         Returns a value in a given dataframe at the given
         index in a column. NOTE: the row is 1 indexed!
@@ -762,7 +763,7 @@ class MitoWidgetTestWrapper:
         """
         return self.mito_widget.steps_manager.curr_step.dfs[sheet_index].at[row - 1, column_header]
 
-    def get_column(self, sheet_index: int, column_header: Any, as_list: bool) -> Union[pd.Series, List]:
+    def get_column(self, sheet_index: int, column_header: ColumnHeader, as_list: bool) -> Union[pd.Series, List]:
         """
         Returns a series object of the given column, or a list if
         as_list is True. 
@@ -799,7 +800,7 @@ def create_mito_wrapper_dfs(*args: pd.DataFrame) -> MitoWidgetTestWrapper:
     mito_widget = sheet(*args)
     return MitoWidgetTestWrapper(mito_widget)
 
-def make_multi_index_header_df(data: Dict[Union[str, int], List[Any]], column_headers: List[Any], index: List[Any]=None) -> pd.DataFrame:
+def make_multi_index_header_df(data: Dict[Union[str, int], List[Any]], column_headers: List[ColumnHeader], index: List[Any]=None) -> pd.DataFrame:
     """
     A helper function that allows you to easily create a multi-index
     header dataframe. 

--- a/mitosheet/mitosheet/topological_sort.py
+++ b/mitosheet/mitosheet/topological_sort.py
@@ -14,9 +14,10 @@ from copy import deepcopy
 from typing import Dict, Collection, List, Set
 
 from mitosheet.errors import MitoError, make_circular_reference_error
+from mitosheet.types import ColumnID
 
 
-def visit(column_evaluation_graph: Dict[str, Set[str]], node: str, visited: Dict[str, bool], finished_order: List[str], visited_loop: Set[str]) -> None:
+def visit(column_evaluation_graph: Dict[ColumnID, Set[ColumnID]], node: ColumnID, visited: Dict[ColumnID, bool], finished_order: List[ColumnID], visited_loop: Set[ColumnID]) -> None:
     """
     Recursive helper function for topological sort. Throws a
     circular_reference_error if there is a loop.
@@ -40,13 +41,13 @@ def visit(column_evaluation_graph: Dict[str, Set[str]], node: str, visited: Dict
     finished_order.append(node)
 
 
-def topological_sort_columns(column_evaluation_graph: Dict[str, Set[str]]) -> List[str]:
+def topological_sort_columns(column_evaluation_graph: Dict[ColumnID, Set[ColumnID]]) -> List[ColumnID]:
     """
     Topologically sorts by DFSing the graph, recording the finish order, and
     then returning nodes in reversed finish order.
     """
     visited = {node: False for node in column_evaluation_graph}
-    finish_order: List[str] = []
+    finish_order: List[ColumnID] = []
     # Visit each node in the graph
     for node in column_evaluation_graph:
         if not visited[node]:
@@ -65,7 +66,7 @@ def topological_sort_columns(column_evaluation_graph: Dict[str, Set[str]]) -> Li
     finish_order.reverse()
     return finish_order
 
-def subgraph_from_starting_column_id(column_evaluation_graph: Dict[str, Set[str]], starting_column_id: str) -> Dict[str, Set[str]]:
+def subgraph_from_starting_column_id(column_evaluation_graph: Dict[ColumnID, Set[ColumnID]], starting_column_id: ColumnID) -> Dict[ColumnID, Set[ColumnID]]:
     """
     Filters down the column_evaluation_graph to just the nodes that can be reached
     from the starting_point, including the starting_point itself.
@@ -85,10 +86,10 @@ def subgraph_from_starting_column_id(column_evaluation_graph: Dict[str, Set[str]
 
 
 def creates_circularity(
-        column_evaluation_graph: Dict[str, Set[str]],
-        column_id: str,
-        old_dependencies: Collection[str],
-        new_dependencies: Collection[str]
+        column_evaluation_graph: Dict[ColumnID, Set[ColumnID]],
+        column_id: ColumnID,
+        old_dependencies: Collection[ColumnID],
+        new_dependencies: Collection[ColumnID]
     ) -> bool:
     """
     Given a column_evaluation_graph, checks if removing the

--- a/mitosheet/mitosheet/transpiler/transpile_utils.py
+++ b/mitosheet/mitosheet/transpiler/transpile_utils.py
@@ -1,5 +1,7 @@
 from typing import Any, List, Set, Union
 
+from mitosheet.types import ColumnHeader
+
 
 def column_header_list_to_transpiled_code(column_headers: Union[List[Any], Set[Any]]) -> str:
     """
@@ -14,7 +16,7 @@ def column_header_list_to_transpiled_code(column_headers: Union[List[Any], Set[A
     return f'[{joined_transpiled_column_headers}]'
 
 
-def column_header_to_transpiled_code(column_header: Any) -> str:
+def column_header_to_transpiled_code(column_header: ColumnHeader) -> str:
     """
     Makes sure the column header is correctly transpiled to 
     code in a way that makes sure it's referenced properly.

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -7,11 +7,14 @@
 Contains some types
 """
 
-from typing import Any
-
+from typing import List, Union, Tuple
 
 ColumnID = str
-ColumnHeader = Any
 
+# A column header is either a primative type
+PrimativeColumnHeader = Union[int, float, bool, str]
+MultiLevelColumnHeader = Union[Tuple[PrimativeColumnHeader, ...], List[PrimativeColumnHeader]]
+# To a tuple of primative types (TODO: does this nest further?).
+ColumnHeader = Union[PrimativeColumnHeader, MultiLevelColumnHeader]
 
 

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Mito.
+
+"""
+Contains some types
+"""
+
+from typing import Any
+
+
+ColumnID = str
+ColumnHeader = Any
+
+
+

--- a/mitosheet/mitosheet/types.py
+++ b/mitosheet/mitosheet/types.py
@@ -4,7 +4,11 @@
 # Copyright (c) Mito.
 
 """
-Contains some types
+Contains some types that are useful in the Mitosheet package. 
+
+We use type aliases to make many parts of the codebase more
+explicit and clear, and make sure to test the types in our 
+continous integration
 """
 
 from typing import List, Union, Tuple

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -11,6 +11,7 @@ import json
 import re
 import uuid
 from typing import Any, Dict, List, Optional, Set
+from mitosheet.types import ColumnID
 
 import numpy as np
 import pandas as pd
@@ -80,11 +81,11 @@ def dfs_to_array_for_json(
         dfs: List[pd.DataFrame],
         df_names: List[str],
         df_sources: List[str],
-        column_spreadsheet_code_array: List[Dict[str, str]],
-        column_filters_array: List[Dict[str, Any]],
-        column_mito_types_array: List[Dict[str, str]],
+        column_spreadsheet_code_array: List[Dict[ColumnID, str]],
+        column_filters_array: List[Dict[ColumnID, Any]],
+        column_mito_types_array: List[Dict[ColumnID, str]],
         column_ids: ColumnIDMap,
-        column_format_types: List[Dict[str, Dict[str, str]]]
+        column_format_types: List[Dict[ColumnID, Dict[str, str]]]
     ) -> List:
 
     new_array = []
@@ -114,11 +115,11 @@ def df_to_json_dumpsable(
         original_df: pd.DataFrame,
         df_name: str,
         df_source: str,
-        column_spreadsheet_code: Dict[str, str],
-        column_filters: Dict[str, Any],
-        column_mito_types: Dict[str, str],
-        column_headers_to_column_ids: Dict[Any, str],
-        column_format_types: Dict[str, Dict[str, str]],
+        column_spreadsheet_code: Dict[ColumnID, str],
+        column_filters: Dict[ColumnID, Any],
+        column_mito_types: Dict[ColumnID, str],
+        column_headers_to_column_ids: Dict[ColumnID, str],
+        column_format_types: Dict[ColumnID, Dict[ColumnID, str]],
         max_length: Optional[int]=MAX_ROWS, # How many items you want to display
     ) -> Dict[str, Any]:
     """

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -11,7 +11,7 @@ import json
 import re
 import uuid
 from typing import Any, Dict, List, Optional, Set
-from mitosheet.types import ColumnID
+from mitosheet.types import ColumnHeader, ColumnID
 
 import numpy as np
 import pandas as pd
@@ -118,7 +118,7 @@ def df_to_json_dumpsable(
         column_spreadsheet_code: Dict[ColumnID, str],
         column_filters: Dict[ColumnID, Any],
         column_mito_types: Dict[ColumnID, str],
-        column_headers_to_column_ids: Dict[ColumnID, str],
+        column_headers_to_column_ids: Dict[ColumnHeader, ColumnID],
         column_format_types: Dict[ColumnID, Dict[ColumnID, str]],
         max_length: Optional[int]=MAX_ROWS, # How many items you want to display
     ) -> Dict[str, Any]:


### PR DESCRIPTION
# Description

This makes no functional changes; it just edits types to make things more clear. Seeing List[ColumnID] is much more clear than List[str]!

In making these changes, this PR also catches a few bugs where we were treating column headers as strings when they had no right to be! It will continue to catch bugs for us in the future as well :-)

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.