### PR TITLE
mitosheet: have error modal display an traceback

### DIFF
--- a/mitosheet/mitosheet/errors.py
+++ b/mitosheet/mitosheet/errors.py
@@ -36,6 +36,7 @@ class MitoError(Exception):
         self.header = header
         self.to_fix = to_fix
         self.error_modal = error_modal
+        self.traceback = get_recent_traceback() # record the most recent error when the error is created
 
 def make_no_sheet_error(sheet_indexes: Set[int]) -> MitoError:
     """

--- a/mitosheet/mitosheet/mito_widget.py
+++ b/mitosheet/mitosheet/mito_widget.py
@@ -204,14 +204,16 @@ class MitoWidget(DOMWidget):
                 'id': event['id'],
                 'type': e.type_,
                 'header': e.header,
-                'to_fix': e.to_fix
+                'to_fix': e.to_fix,
+                'traceback': e.traceback,
             }
             if not e.error_modal:
                 response['data'] = {
                     'event': 'edit_error',
                     'type': e.type_,
                     'header': e.header,
-                    'to_fix': e.to_fix
+                    'to_fix': e.to_fix,
+                    'traceback': e.traceback,
                 }
 
             # Report it to the user, and then return
@@ -226,7 +228,8 @@ class MitoWidget(DOMWidget):
                 'id': event['id'],
                 'type': 'execution_error',
                 'header': 'Execution Error',
-                'to_fix': 'Sorry, there was an error during executing this code.'
+                'to_fix': 'Sorry, there was an error during executing this code.',
+                'traceback': get_recent_traceback()
             })
 
         return False

--- a/mitosheet/src/components/DefaultModal.tsx
+++ b/mitosheet/src/components/DefaultModal.tsx
@@ -34,7 +34,8 @@ const DefaultModal = (
         viewComponent?: React.ReactFragment;
         buttons: React.ReactFragment;
         setUIState?: React.Dispatch<React.SetStateAction<UIState>>;
-        overlay?: boolean
+        overlay?: boolean;
+        wide?: boolean;
     }): JSX.Element => {
 
     const headerColor = props.modalType === ModalEnum.Error ? '#ED4747' : '#343434' 
@@ -54,7 +55,7 @@ const DefaultModal = (
         */
         <div className={classNames({'modal-container': !displayOverlay}, {'overlay': displayOverlay})}>
             <div className={classNames({'modal-container': displayOverlay})}>
-                <div className='modal'>
+                <div className={classNames('modal', {'modal-wide': props.wide})}>
                     {props.setUIState !== undefined && 
                         <Row justify='end'>
                             <Col offsetRight={.25}>

--- a/mitosheet/src/components/modals/ErrorModal.tsx
+++ b/mitosheet/src/components/modals/ErrorModal.tsx
@@ -27,23 +27,22 @@ const ErrorModal = (
         <DefaultModal
             header={props.error.header}
             modalType={ModalEnum.Error}
+            wide
             viewComponent={
                 <Fragment>
                     {props.error.to_fix &&
                         <div className='text-align-left text-body-1' onClick={() => setViewTraceback((viewTraceback) => !viewTraceback)}>
-                            {props.error.to_fix} 
+                            {props.error.to_fix} {' '}
                             {props.error.traceback && 
-                                <div className='text-body-1-link'>
-                                    Toggle view traceback.
-                                </div>
+                                <span className='text-body-1-link'>
+                                    Click to view full traceback.
+                                </span>
                             }
                         </div>
                     }
                     {props.error.traceback && viewTraceback &&
-                        <div className='flex flex-column text-align-left text-overflow-hidden text-overflow-scroll mt-5px' style={{height: '200px', border: '1px solid var(--mito-purple)'}}>
-                            {props.error.traceback.split('\n').map(p => {
-                                return <p>{p}</p>
-                            })} 
+                        <div className='flex flex-column text-align-left text-overflow-hidden text-overflow-scroll mt-5px' style={{height: '200px', border: '1px solid var(--mito-purple)', borderRadius: '2px', padding: '5px'}}>
+                            <pre>{props.error.traceback}</pre>
                         </div>
                     }
                 </Fragment>

--- a/mitosheet/src/components/modals/ErrorModal.tsx
+++ b/mitosheet/src/components/modals/ErrorModal.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Mito
 
-import React, {Fragment} from 'react';
+import React, {Fragment, useState} from 'react';
 import DefaultModal from '../DefaultModal'; 
 import { ModalEnum } from './modals';
 import TextButton from '../elements/TextButton';
@@ -17,6 +17,7 @@ const ErrorModal = (
         setUIState: React.Dispatch<React.SetStateAction<UIState>>;
         mitoAPI: MitoAPI
     }): JSX.Element => {
+    const [viewTraceback, setViewTraceback] = useState(false);
 
     if (props.error === undefined) {
         return (<></>)
@@ -28,9 +29,23 @@ const ErrorModal = (
             modalType={ModalEnum.Error}
             viewComponent={
                 <Fragment>
-                    <div>
-                        {props.error.to_fix} 
-                    </div>
+                    {props.error.to_fix &&
+                        <div className='text-align-left text-body-1' onClick={() => setViewTraceback((viewTraceback) => !viewTraceback)}>
+                            {props.error.to_fix} 
+                            {props.error.traceback && 
+                                <div className='text-body-1-link'>
+                                    Toggle view traceback.
+                                </div>
+                            }
+                        </div>
+                    }
+                    {props.error.traceback && viewTraceback &&
+                        <div className='flex flex-column text-align-left text-overflow-hidden text-overflow-scroll mt-5px' style={{height: '200px', border: '1px solid var(--mito-purple)'}}>
+                            {props.error.traceback.split('\n').map(p => {
+                                return <p>{p}</p>
+                            })} 
+                        </div>
+                    }
                 </Fragment>
             }
             buttons={

--- a/mitosheet/src/types.tsx
+++ b/mitosheet/src/types.tsx
@@ -190,6 +190,7 @@ export interface MitoError {
     type: string;
     header: string;
     to_fix: string;
+    traceback?: string;
 }
 
 /**

--- a/mitosheet/src/utils/classNames.tsx
+++ b/mitosheet/src/utils/classNames.tsx
@@ -8,7 +8,7 @@
         classNames('abc', {'123': true}) = 'abc 123'
         classNames('abc', {'123': false}) = 'abc'
 */
-export const classNames = (...args: (string | undefined | Record<string, boolean>)[]): string => {
+export const classNames = (...args: (string | undefined | Record<string, boolean | undefined>)[]): string => {
     let finalString = '';
 
     for (let i = 0; i < args.length; i++) {


### PR DESCRIPTION
# Description

@aarondr77 this is something you've been talking about for a while, so feast your eyes. Feel free to make it prettier / look better. 

Note that this is a workaround as we continue to improve our in place error handling; this does not want to stay forever!

# Testing

Try as many errors as you can think of:
1. Invalid formulas
2. Invalid merge
3. Writing any formula in a sheet with the column header `0` <- this is in `small-datasets/small-excel`
4. And any more you can think of!

Note the goal here is to make sure none of our error infra broke; so some of the above don't trigger the error modal at all.

# Documentation

Note if any new documentation needs to addressed or reviewed.