### PR TITLE
error boundary: add basic error boundary to Mito to stop violent sheet crashes

### DIFF
--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -55,6 +55,7 @@ import DropDuplicatesTaskpane from './taskpanes/DropDuplicates/DropDuplicates';
 import { createActions } from '../utils/actions';
 import SearchTaskpane from './taskpanes/Search/SearchTaskpane';
 import loadPlotly from '../utils/plotly';
+import ErrorBoundary from './elements/ErrorBoundary';
 
 export type MitoProps = {
     model_id: string;
@@ -547,65 +548,67 @@ export const Mito = (props: MitoProps): JSX.Element => {
 
     return (
         <div className="mito-container" data-jp-suppress-context-menu ref={mitoContainerRef}>
-            <Toolbar 
-                mitoAPI={props.mitoAPI}
-                currStepIdx={analysisData.currStepIdx}
-                lastStepIndex={lastStepSummary.step_idx}
-                highlightPivotTableButton={highlightPivotTableButton}
-                highlightAddColButton={highlightAddColButton}
-                actions={actions}
-                mitoContainerRef={mitoContainerRef}
-                gridState={gridState}
-                setGridState={setGridState}
-                uiState={uiState}
-                setUIState={setUIState}
-                sheetData={sheetDataArray[uiState.selectedSheetIndex]}
-            />
-            <div className="mito-main-sheet-div"> 
-                <div className={formulaBarAndSheetClassNames}>
-                    <EndoGrid
-                        sheetDataArray={sheetDataArray}
-                        mitoAPI={props.mitoAPI}
-                        uiState={uiState}
-                        setUIState={setUIState}
-                        sheetIndex={uiState.selectedSheetIndex}
-                        gridState={gridState}
-                        setGridState={setGridState}
-                        editorState={editorState}
-                        setEditorState={setEditorState}
-                    />
-                </div>
-                {uiState.currOpenTaskpane.type !== TaskpaneType.NONE && 
-                    <div className={taskpaneClassNames}>
-                        {getCurrOpenTaskpane()}
-                    </div>
-                }
-            </div>
-            {/* Display the tour if there is one */}
-            {getCurrTour()}
-            <Footer
-                sheetDataArray={sheetDataArray}
-                gridState={gridState}
-                setGridState={setGridState}
-                mitoAPI={props.mitoAPI}
-                closeOpenEditingPopups={closeOpenEditingPopups}
-                uiState={uiState}
-                setUIState={setUIState}
-                mitoContainerRef={mitoContainerRef}
-            />
-            {getCurrentModalComponent()}
-            {uiState.loading > 0 && <LoadingIndicator/>}      
-            {/* 
-                If the step index of the last step isn't the current step,
-                then we are out of date, and we tell the user this.
-            */}
-            {analysisData.currStepIdx !== lastStepSummary.step_idx && 
-                <CatchUpPopup
-                    fastForward={() => {
-                        void props.mitoAPI.checkoutStepByIndex(lastStepSummary.step_idx);
-                    }}
+            <ErrorBoundary mitoAPI={props.mitoAPI}>
+                <Toolbar 
+                    mitoAPI={props.mitoAPI}
+                    currStepIdx={analysisData.currStepIdx}
+                    lastStepIndex={lastStepSummary.step_idx}
+                    highlightPivotTableButton={highlightPivotTableButton}
+                    highlightAddColButton={highlightAddColButton}
+                    actions={actions}
+                    mitoContainerRef={mitoContainerRef}
+                    gridState={gridState}
+                    setGridState={setGridState}
+                    uiState={uiState}
+                    setUIState={setUIState}
+                    sheetData={sheetDataArray[uiState.selectedSheetIndex]}
                 />
-            }
+                <div className="mito-main-sheet-div"> 
+                    <div className={formulaBarAndSheetClassNames}>
+                        <EndoGrid
+                            sheetDataArray={sheetDataArray}
+                            mitoAPI={props.mitoAPI}
+                            uiState={uiState}
+                            setUIState={setUIState}
+                            sheetIndex={uiState.selectedSheetIndex}
+                            gridState={gridState}
+                            setGridState={setGridState}
+                            editorState={editorState}
+                            setEditorState={setEditorState}
+                        />
+                    </div>
+                    {uiState.currOpenTaskpane.type !== TaskpaneType.NONE && 
+                        <div className={taskpaneClassNames}>
+                            {getCurrOpenTaskpane()}
+                        </div>
+                    }
+                </div>
+                {/* Display the tour if there is one */}
+                {getCurrTour()}
+                <Footer
+                    sheetDataArray={sheetDataArray}
+                    gridState={gridState}
+                    setGridState={setGridState}
+                    mitoAPI={props.mitoAPI}
+                    closeOpenEditingPopups={closeOpenEditingPopups}
+                    uiState={uiState}
+                    setUIState={setUIState}
+                    mitoContainerRef={mitoContainerRef}
+                />
+                {getCurrentModalComponent()}
+                {uiState.loading > 0 && <LoadingIndicator/>}      
+                {/* 
+                    If the step index of the last step isn't the current step,
+                    then we are out of date, and we tell the user this.
+                */}
+                {analysisData.currStepIdx !== lastStepSummary.step_idx && 
+                    <CatchUpPopup
+                        fastForward={() => {
+                            void props.mitoAPI.checkoutStepByIndex(lastStepSummary.step_idx);
+                        }}
+                    />
+                }
+            </ErrorBoundary>
         </div>
     );
 }

--- a/mitosheet/src/components/elements/ErrorBoundary.tsx
+++ b/mitosheet/src/components/elements/ErrorBoundary.tsx
@@ -25,8 +25,7 @@ class ErrorBoundary extends Component<Props, State> {
         void this.props.mitoAPI.sendLogMessage('frontend_render_failed', {
             'error_name': error.name,
             'error_message': error.message,
-            'error_stack': error.stack,
-            'error_info_component_stack': errorInfo.componentStack.split('\n')
+            'error_stack': error.stack?.split('\n'),
         })
     }
 

--- a/mitosheet/src/components/elements/ErrorBoundary.tsx
+++ b/mitosheet/src/components/elements/ErrorBoundary.tsx
@@ -26,7 +26,7 @@ class ErrorBoundary extends Component<Props, State> {
             'error_name': error.name,
             'error_message': error.message,
             'error_stack': error.stack,
-            'error_info_component_stack': errorInfo.componentStack
+            'error_info_component_stack': errorInfo.componentStack.split('\n')
         })
     }
 

--- a/mitosheet/src/components/elements/ErrorBoundary.tsx
+++ b/mitosheet/src/components/elements/ErrorBoundary.tsx
@@ -23,8 +23,10 @@ class ErrorBoundary extends Component<Props, State> {
 
     public componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
         void this.props.mitoAPI.sendLogMessage('frontend_render_failed', {
-            'error': error,
-            'errorInfo': errorInfo.componentStack
+            'error_name': error.name,
+            'error_message': error.message,
+            'error_stack': error.stack,
+            'error_info_component_stack': errorInfo.componentStack
         })
     }
 

--- a/mitosheet/src/components/elements/ErrorBoundary.tsx
+++ b/mitosheet/src/components/elements/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import React, { Component, ErrorInfo, ReactNode } from "react";
+import MitoAPI from "../../api";
+
+interface Props {
+  children: ReactNode;
+  mitoAPI: MitoAPI;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false
+  };
+
+  public static getDerivedStateFromError(_: Error): State {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+      this.props.mitoAPI.sendLogMessage('frontend_crash_error', {
+          'error': error,
+          'errorInfo': errorInfo.componentStack
+      })
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return (
+        <h2 className='text-color-red p-10px'>
+            Sorry... Mito had an error. Rerun the Jupyter Cell above, and hopefully this won't happen again.
+        </h2>
+      )
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/mitosheet/src/components/elements/ErrorBoundary.tsx
+++ b/mitosheet/src/components/elements/ErrorBoundary.tsx
@@ -21,7 +21,7 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-      this.props.mitoAPI.sendLogMessage('frontend_crash_error', {
+      this.props.mitoAPI.sendLogMessage('frontend_render_failed', {
           'error': error,
           'errorInfo': errorInfo.componentStack
       })

--- a/mitosheet/src/components/elements/ErrorBoundary.tsx
+++ b/mitosheet/src/components/elements/ErrorBoundary.tsx
@@ -1,43 +1,44 @@
 import React, { Component, ErrorInfo, ReactNode } from "react";
 import MitoAPI from "../../api";
+import { DISCORD_INVITE_LINK } from "../../data/documentationLinks";
 
 interface Props {
-  children: ReactNode;
-  mitoAPI: MitoAPI;
+    children: ReactNode;
+    mitoAPI: MitoAPI;
 }
 
 interface State {
-  hasError: boolean;
+    hasError: boolean;
 }
 
 class ErrorBoundary extends Component<Props, State> {
-  public state: State = {
-    hasError: false
-  };
+    public state: State = {
+        hasError: false
+    };
 
-  public static getDerivedStateFromError(_: Error): State {
+    public static getDerivedStateFromError(): State {
     // Update state so the next render will show the fallback UI.
-    return { hasError: true };
-  }
-
-  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-      this.props.mitoAPI.sendLogMessage('frontend_render_failed', {
-          'error': error,
-          'errorInfo': errorInfo.componentStack
-      })
-  }
-
-  public render() {
-    if (this.state.hasError) {
-      return (
-        <h2 className='text-color-red p-10px'>
-            Sorry... Mito had an error. Rerun the Jupyter Cell above, and hopefully this won't happen again.
-        </h2>
-      )
+        return { hasError: true };
     }
 
-    return this.props.children;
-  }
+    public componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+        void this.props.mitoAPI.sendLogMessage('frontend_render_failed', {
+            'error': error,
+            'errorInfo': errorInfo.componentStack
+        })
+    }
+
+    public render(): ReactNode {
+        if (this.state.hasError) {
+            return (
+                <p className='text-body-1 text-color-red p-10px'>
+                    Looks like Mito had an error! Sorry about that. Rerun the Jupyter Cell above, and <a className='text-body-1-link' href={DISCORD_INVITE_LINK} target='_blank' rel="noreferrer">join our Discord for support</a> if this error occurs again.
+                </p>
+            )
+        }
+
+        return this.props.children;
+    }
 }
 
 export default ErrorBoundary;

--- a/mitosheet/src/components/elements/ErrorBoundary.tsx
+++ b/mitosheet/src/components/elements/ErrorBoundary.tsx
@@ -17,7 +17,7 @@ class ErrorBoundary extends Component<Props, State> {
     };
 
     public static getDerivedStateFromError(): State {
-    // Update state so the next render will show the fallback UI.
+        // Update state so the next render will show the fallback UI.
         return { hasError: true };
     }
 

--- a/mitosheet/src/components/modals/ErrorModal.tsx
+++ b/mitosheet/src/components/modals/ErrorModal.tsx
@@ -6,6 +6,7 @@ import { ModalEnum } from './modals';
 import TextButton from '../elements/TextButton';
 import MitoAPI from '../../api';
 import { MitoError, UIState } from '../../types';
+import { DISCORD_INVITE_LINK } from '../../data/documentationLinks';
 
 /*
     A modal that displays error messages and gives
@@ -50,7 +51,7 @@ const ErrorModal = (
                     <TextButton
                         variant='dark'
                         width='medium'
-                        href='https://discord.gg/XdJSZyejJU'
+                        href={DISCORD_INVITE_LINK}
                         target='_blank'
                         onClick={() => {
                             props.setUIState((prevUIState) => {

--- a/mitosheet/src/components/toolbar/Toolbar.tsx
+++ b/mitosheet/src/components/toolbar/Toolbar.tsx
@@ -51,6 +51,8 @@ const Toolbar = (
         void props.mitoAPI.checkoutStepByIndex(props.lastStepIndex);
     }
 
+    throw new Error('I crashed!');
+
     return (
         <div className='toolbar-container'>
             <div className='toolbar-left-half'>

--- a/mitosheet/src/components/toolbar/Toolbar.tsx
+++ b/mitosheet/src/components/toolbar/Toolbar.tsx
@@ -51,8 +51,6 @@ const Toolbar = (
         void props.mitoAPI.checkoutStepByIndex(props.lastStepIndex);
     }
 
-    throw new Error('I crashed!');
-
     return (
         <div className='toolbar-container'>
             <div className='toolbar-left-half'>

--- a/mitosheet/src/data/documentationLinks.tsx
+++ b/mitosheet/src/data/documentationLinks.tsx
@@ -5,3 +5,4 @@
 
 export const DOCUMENTATION_LINK_TUTORIAL = "https://docs.trymito.io/getting-started/tutorial";
 export const DOCUMENTATION_LINK_IMPORT = "https://docs.trymito.io/how-to/importing-data-to-mito";
+export const DISCORD_INVITE_LINK = "https://discord.gg/XdJSZyejJU";

--- a/mitosheet/src/utils/actions.tsx
+++ b/mitosheet/src/utils/actions.tsx
@@ -6,6 +6,7 @@ import { doesAnySheetExist, doesColumnExist, doesSheetContainData, getCellDataFr
 import { ModalEnum } from "../components/modals/modals";
 import { ControlPanelTab } from "../components/taskpanes/ControlPanel/ControlPanelTaskpane";
 import { TaskpaneType } from "../components/taskpanes/taskpanes";
+import { DISCORD_INVITE_LINK } from "../data/documentationLinks";
 import { FunctionDocumentationObject, functionDocumentationObjects } from "../data/function_documentation";
 import { Action, ActionEnum, DFSource, EditorState, GridState, SheetData, UIState } from "../types"
 import { getDeduplicatedArray } from "./arrays";
@@ -393,7 +394,7 @@ export const createActions = (
                 setEditorState(undefined);
 
                 // Open discord
-                window.open('https://discord.gg/XdJSZyejJU', '_blank')
+                window.open(DISCORD_INVITE_LINK, '_blank')
             },
             isDisabled: () => {return undefined},
             searchTerms: ['help', 'contact', 'support'],


### PR DESCRIPTION
# Description

See title.

# Testing

Add this line somewhere in the toolbar, before the return statement: 
```
throw new Error('I crashed!');
```
Check that the log appears in Mixpanel!

# Documentation

No.