### PR TITLE
[INVESTIGATION] mitosheet: optimize out unneeded code after deletes

### DIFF
--- a/mitosheet/mitosheet/step.py
+++ b/mitosheet/mitosheet/step.py
@@ -121,6 +121,43 @@ class Step:
         """
         return self.post_state if self.post_state is not None else \
             (self.prev_state if self.prev_state is not None else State([]))
+        
+    @property
+    def new_sheet_indexes_this_step(self) -> Set[int]:
+        """
+        Returns the set of sheet indexes for sheets that were created 
+        during this step. This is useful for depedency detection
+        """
+        if self.prev_state is None:
+            return {i for i in range(len(self.post_state.dfs))}
+        
+        if self.post_state is None:
+            return {}
+
+        return {
+            i for i in range(
+                len(self.prev_state.dfs),
+                len(self.post_state.dfs)
+            )
+        }
+    
+    @property
+    def input_sheet_indexes(self) -> Set[int]:
+        """
+        TODO
+        """
+        return self.step_performer.get_input_dataframe_indexes(
+            **self.params
+        )
+
+    @property
+    def output_sheet_indexes(self) -> Set[int]:
+        """
+        TODO
+        """
+        return self.step_performer.get_output_dataframe_indexes(
+            **self.params
+        )
 
     def set_prev_state_and_execute(self, new_prev_state: State) -> None:
         """

--- a/mitosheet/mitosheet/step_performers/bulk_old_rename/bulk_old_rename.py
+++ b/mitosheet/mitosheet/step_performers/bulk_old_rename/bulk_old_rename.py
@@ -124,7 +124,14 @@ class BulkOldRenameStepPerformer(StepPerformer):
         return f'Renamed headers for compatibility with previous Mito versions'
 
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_output_dataframe_indexes( # type: ignore
+        cls, 
+        **params
+    ) -> Set[int]:
+        return {-1}
+    
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         **params
     ) -> Set[int]:

--- a/mitosheet/mitosheet/step_performers/column_steps/add_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/add_column.py
@@ -112,7 +112,17 @@ class AddColumnStepPerformer(StepPerformer):
         return f'Added column {column_header}' 
 
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index: int,
+        column_header: str,
+        column_header_index: int,
+        **params
+    ) -> Set[int]:
+        return {sheet_index}
+
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
         column_header: str,

--- a/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
@@ -360,7 +360,18 @@ class ChangeColumnDtypeStepPerformer(StepPerformer):
         return f'Changed {column_id} from {old_dtype} to {new_dtype}'
 
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index: int,
+        column_id: ColumnID,
+        old_dtype: str,
+        new_dtype: str,
+        **params
+    ) -> Set[int]:
+        return {sheet_index}
+    
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
         column_id: ColumnID,

--- a/mitosheet/mitosheet/step_performers/column_steps/change_column_format.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/change_column_format.py
@@ -81,7 +81,16 @@ class ChangeColumnFormatStepPerformer(StepPerformer):
         return f'Formatted column{"s" if len(column_ids) > 1 else ""} {formated_column_ids} as {format_type["type"]}'
 
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index: int,
+        column_ids: List[ColumnID],
+        **params
+    ) -> Set[int]:
+        return {sheet_index}
+    
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
         column_ids: List[ColumnID],

--- a/mitosheet/mitosheet/step_performers/column_steps/delete_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/delete_column.py
@@ -90,7 +90,16 @@ class DeleteColumnStepPerformer(StepPerformer):
         return f'Deleted column{"s" if len(column_ids) > 1 else ""} {formated_column_ids}'
 
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index: int,
+        column_ids: List[ColumnID],
+        **params
+    ) -> Set[int]:
+        return {sheet_index}
+    
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
         column_ids: List[ColumnID],

--- a/mitosheet/mitosheet/step_performers/column_steps/rename_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/rename_column.py
@@ -134,7 +134,18 @@ class RenameColumnStepPerformer(StepPerformer):
             return f'Renamed header at level {level} to {new_column_header}'
     
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index: int,
+        column_id: ColumnID,
+        new_column_header: str,
+        level=None,
+        **params
+    ) -> Set[int]:
+        return {sheet_index}
+    
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
         column_id: ColumnID,

--- a/mitosheet/mitosheet/step_performers/column_steps/reorder_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/reorder_column.py
@@ -120,7 +120,17 @@ class ReorderColumnStepPerformer(StepPerformer):
         return f'Reordered {column_id}'
     
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index: int,
+        column_id: ColumnID,
+        new_column_index: int,
+        **params
+    ) -> Set[int]:
+        return {sheet_index}
+    
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
         column_id: ColumnID,

--- a/mitosheet/mitosheet/step_performers/column_steps/set_column_formula.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/set_column_formula.py
@@ -187,7 +187,18 @@ class SetColumnFormulaStepPerformer(StepPerformer):
         return f'Set {column_id} to {new_formula}'
 
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index: int,
+        column_id: ColumnID,
+        old_formula: str,
+        new_formula: str,
+        **params
+    ) -> Set[int]:
+        return {sheet_index}
+    
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
         column_id: ColumnID,

--- a/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_delete.py
+++ b/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_delete.py
@@ -87,7 +87,16 @@ class DataframeDeleteStepPerformer(StepPerformer):
         return f'Deleted dataframe {old_dataframe_name}'
     
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index: int,
+        old_dataframe_name: str,
+        **params
+    ) -> Set[int]:
+        return {sheet_index}
+    
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
         old_dataframe_name: str,

--- a/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_duplicate.py
+++ b/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_duplicate.py
@@ -80,9 +80,17 @@ class DataframeDuplicateStepPerformer(StepPerformer):
             new_df_name = df_names[len(df_names) - 1]
             return f'Duplicated {old_df_name} to {new_df_name}'
         return f'Duplicated a df'
+
+    @classmethod
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index: int,
+        **params
+    ) -> Set[int]:
+        return {}
     
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
         **params

--- a/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_rename.py
+++ b/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_rename.py
@@ -87,7 +87,17 @@ class DataframeRenameStepPerformer(StepPerformer):
         return f'Renamed {old_dataframe_name} to {new_dataframe_name}'
 
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index: int,
+        old_dataframe_name: str,
+        new_dataframe_name: str,
+        **params
+    ) -> Set[int]:
+        return {sheet_index}
+
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
         old_dataframe_name: str,

--- a/mitosheet/mitosheet/step_performers/drop_duplicates.py
+++ b/mitosheet/mitosheet/step_performers/drop_duplicates.py
@@ -125,7 +125,17 @@ class DropDuplicatesStepPerformer(StepPerformer):
         return f'Drop duplicates'
 
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index: int,
+        column_ids: List[ColumnID],
+        keep: str,
+        **params
+    ) -> Set[int]:
+        return {sheet_index}
+    
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
         column_ids: List[ColumnID],

--- a/mitosheet/mitosheet/step_performers/filter.py
+++ b/mitosheet/mitosheet/step_performers/filter.py
@@ -351,7 +351,18 @@ class FilterStepPerformer(StepPerformer):
         return f'Filtered {column_id}'
 
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index: int,
+        column_id: ColumnID,
+        operator: str,
+        filters,
+        **params
+    ) -> Set[int]:
+        return {sheet_index}
+
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
         column_id: ColumnID,

--- a/mitosheet/mitosheet/step_performers/import_steps/excel_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/excel_import.py
@@ -125,7 +125,18 @@ class ExcelImportStepPerformer(StepPerformer):
         return f'Imported {file_name}'
 
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        file_name: str,
+        sheet_names: List[str],
+        has_headers: bool,
+        use_deprecated_id_algorithm: bool=False,
+        **params
+    ) -> Set[int]:
+        return {}
+
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         file_name: str,
         sheet_names: List[str],

--- a/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
@@ -126,7 +126,16 @@ class SimpleImportStepPerformer(StepPerformer):
         return f'Imported {", ".join(file_names)}'
     
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        file_names: List[str],
+        use_deprecated_id_algorithm: bool=False,
+        **params
+    ) -> Set[int]:
+        return {}
+    
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         file_names: List[str],
         use_deprecated_id_algorithm: bool=False,

--- a/mitosheet/mitosheet/step_performers/merge.py
+++ b/mitosheet/mitosheet/step_performers/merge.py
@@ -183,7 +183,20 @@ class MergeStepPerformer(StepPerformer):
         return f'Merged dataframes {sheet_index_one} and {sheet_index_two}'
     
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        how: str,
+        sheet_index_one: int,
+        merge_key_column_id_one: ColumnID,
+        selected_column_ids_one: List[ColumnID],
+        sheet_index_two: int,
+        merge_key_column_id_two: ColumnID,
+        selected_column_ids_two: List[ColumnID],
+    ) -> Set[int]:
+        return {sheet_index_one, sheet_index_two}
+    
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         how: str,
         sheet_index_one: int,

--- a/mitosheet/mitosheet/step_performers/pivot.py
+++ b/mitosheet/mitosheet/step_performers/pivot.py
@@ -217,9 +217,22 @@ class PivotStepPerformer(StepPerformer):
             old_df_name = df_names[sheet_index]
             return f'Pivoted {old_df_name} into {new_df_name}'
         return f'Pivoted dataframe {sheet_index}'
-
+        
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index,
+        pivot_rows_column_ids,
+        pivot_columns_column_ids,
+        values_column_ids_map,
+        destination_sheet_index=None,
+        use_deprecated_id_algorithm: bool=False,
+        **params
+    ) -> Set[int]:
+        return {sheet_index}
+    
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index,
         pivot_rows_column_ids,

--- a/mitosheet/mitosheet/step_performers/set_cell_value.py
+++ b/mitosheet/mitosheet/step_performers/set_cell_value.py
@@ -165,7 +165,19 @@ class SetCellValueStepPerformer(StepPerformer):
         return f'Set column {column_id} at index {row_index} to {new_value}'
 
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index: int,
+        column_id: ColumnID,
+        row_index: int,
+        old_value: str,
+        new_value: Union[str, None],
+        **params
+    ) -> Set[int]:
+        return {sheet_index}
+    
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
         column_id: ColumnID,

--- a/mitosheet/mitosheet/step_performers/sort.py
+++ b/mitosheet/mitosheet/step_performers/sort.py
@@ -112,7 +112,17 @@ class SortStepPerformer(StepPerformer):
         return f'Sorted {column_id} in {sort_direction} order'
 
     @classmethod
-    def get_modified_dataframe_indexes( # type: ignore
+    def get_input_dataframe_indexes( # type: ignore
+        cls, 
+        sheet_index: int,
+        column_id: ColumnID,
+        sort_direction: str,
+        **params
+    ) -> Set[int]:
+        return {sheet_index}
+
+    @classmethod
+    def get_output_dataframe_indexes( # type: ignore
         cls, 
         sheet_index: int,
         column_id: ColumnID,

--- a/mitosheet/mitosheet/step_performers/step_performer.py
+++ b/mitosheet/mitosheet/step_performers/step_performer.py
@@ -82,7 +82,21 @@ class StepPerformer(ABC, object):
 
     @classmethod
     @abstractmethod
-    def get_modified_dataframe_indexes(cls, **params: Any) -> Set[int]:
+    def get_input_dataframe_indexes(cls, **params: Any) -> Set[int]:
+        """
+        Returns a set of all the sheet indexes that were taken as input
+        during this step, and used
+
+        If it returns an empty set, then this step took no indexes.
+
+        If it returns a set with -1, then took all indexes. This is dumb
+        and we should make it match the get_output_dataframe_indexes...
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def get_output_dataframe_indexes(cls, **params: Any) -> Set[int]:
         """
         Returns a set of all the sheet indexes that were modified
         by this step.

--- a/mitosheet/mitosheet/tests/steps_performers/column_steps/test_add_column.py
+++ b/mitosheet/mitosheet/tests/steps_performers/column_steps/test_add_column.py
@@ -71,10 +71,7 @@ def test_add_column_and_then_delete():
         if isinstance(value, list):
             assert len(value) == 0
 
-    assert mito.transpiled_code == [
-        'df1.insert(1, \'B\', 0)',
-        'del df1'
-    ]
+    assert mito.transpiled_code == []
 
 def test_add_column_in_middle():
     df = pd.DataFrame({'A': [123], 'B': [123]})

--- a/mitosheet/mitosheet/tests/steps_performers/dataframe_steps/test_dataframe_delete.py
+++ b/mitosheet/mitosheet/tests/steps_performers/dataframe_steps/test_dataframe_delete.py
@@ -24,9 +24,7 @@ def test_can_delete_single_dataframe():
         if isinstance(value, list):
             assert len(value) == 0
 
-    assert mito.transpiled_code == [
-        'del df1'
-    ]
+    assert mito.transpiled_code == []
 
 
 def test_can_delete_then_add_to_other_sheet():
@@ -39,7 +37,6 @@ def test_can_delete_then_add_to_other_sheet():
     assert len(mito.dfs) == 1
 
     assert mito.transpiled_code == [
-        'del df1',
         'df2.insert(1, \'B\', 0)'
     ]
 
@@ -64,6 +61,22 @@ def test_can_delete_middle_of_multiple_dfs():
             assert len(value.column_header_to_column_id) == 2
             assert len(value.column_id_to_column_header) == 2
 
-    assert mito.transpiled_code == [
-        'del df2'
-    ]
+    assert mito.transpiled_code == []
+
+def test_pivot_then_delete():
+    df1 = pd.DataFrame({'A': [123]})
+    mito = create_mito_wrapper_dfs(df1)
+    mito.pivot_sheet(0, ['A'], [], {'A': ['sum']}, flatten_column_headers=True)
+    mito.delete_dataframe(0)
+
+    print(mito.dfs[0])
+    assert mito.dfs[0].equals(pd.DataFrame({'A': [123], 'A sum': [123]}))
+
+def test_merge_then_delete():
+    df1 = pd.DataFrame({'A': [123]})
+    df2 = pd.DataFrame({'A': [123], 'B': [1234]})
+    mito = create_mito_wrapper_dfs(df1, df2)
+    mito.merge_sheets('left', 0, 'A', ['A'], 1, 'A', ['A', 'B'])
+    mito.delete_dataframe(0)
+
+    assert mito.dfs[0].equals(pd.DataFrame({'A': [123], 'B': [1234]}))

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -4,6 +4,7 @@
 # Copyright (c) Mito.
 # Distributed under the terms of the Modified BSD License.
 
+import os
 import pytest
 import pandas as pd
 
@@ -242,3 +243,18 @@ def test_transpile_merge_then_sort():
         'df3 = df1.merge(temp_df, left_on=[\'Name\'], right_on=[\'Name\'], how=\'left\', suffixes=[\'_df1\', \'_df2\'])',
         'df3 = df3.sort_values(by=\'Number\', ascending=True, na_position=\'first\')',
     ]
+
+def test_transpile_removes_delete():
+    df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})
+    df.to_csv('test.csv', index=False)
+
+    # Create with no dataframes
+    mito = create_mito_wrapper_dfs()
+    # And then import just a test file
+    mito.simple_import(['test.csv'])
+    mito.delete_dataframe(0)
+
+    assert mito.transpiled_code == []
+
+    # Remove the test file
+    os.remove('test.csv')

--- a/mitosheet/mitosheet/transpiler/transpile.py
+++ b/mitosheet/mitosheet/transpiler/transpile.py
@@ -9,11 +9,18 @@ Exports the transpile function, which takes the backend widget
 container and generates transpiled Python code.
 """
 
+from typing import TYPE_CHECKING, Any
 from mitosheet.preprocessing import PREPROCESS_STEP_PERFORMERS
+from mitosheet.transpiler.transpile_utils import get_steps_to_transpile
+
+if TYPE_CHECKING:
+    from mitosheet.steps_manager import StepsManager
+else:
+    StepsManager = Any
 
 IN_PREVIOUS_STEP_COMMENT = '# You\'re viewing a previous step. Click fast forward in the Mitosheet above to see the full analysis.'
 
-def transpile(steps_manager, add_comments=True):
+def transpile(steps_manager: StepsManager, add_comments=True):
     """
     Transpiles the code from the current steps in the steps_manager, 
     displaying up to the checked out step.
@@ -33,13 +40,11 @@ def transpile(steps_manager, add_comments=True):
         if len(preprocess_code) > 0:
             code.extend(preprocess_code)
 
-    from mitosheet.steps_manager import get_step_indexes_to_skip
-    step_indexes_to_skip = get_step_indexes_to_skip(steps_manager.steps)
-
     # We only transpile up to the currently checked out step
-    for step_index, step in enumerate(steps_manager.steps[:steps_manager.curr_step_idx + 1]):
+    steps_to_transpile = get_steps_to_transpile(steps_manager)
+    for step in steps_to_transpile:
         # Skip the initalize step, or any step we should skip
-        if step.step_type == 'initialize' or step_index in step_indexes_to_skip:
+        if step.step_type == 'initialize':
             continue
 
         # The total code for this step

--- a/mitosheet/mitosheet/transpiler/transpile_utils.py
+++ b/mitosheet/mitosheet/transpiler/transpile_utils.py
@@ -1,4 +1,10 @@
-from typing import Any, List, Set, Union
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any, Dict, List, Set, Union
+
+if TYPE_CHECKING:
+    from mitosheet.steps_manager import StepsManager
+else:
+    StepsManager = Any
 
 from mitosheet.types import ColumnHeader
 
@@ -42,3 +48,129 @@ def list_to_string_without_internal_quotes(list: List[Any]) -> str:
     """
     string = (', ').join(list)
     return "[" + string +  "]"
+
+
+def get_steps_to_transpile(steps_manager: StepsManager):
+    """
+    0:
+        Input: 0
+        Output: 1
+    1:
+        Input: 1
+        Output: Delete 1
+    0:
+        Input: 0
+        Output: 1
+
+    # Step 1: Move from sheet index -> sheet id
+
+    First, we move from using sheet indexes for keeping track of dataframes to 
+    sheet ids. This makes this entire algorithm much easier. We first construct 
+    a mapping from step index -> sheet index -> sheet id. 
+    
+    To assign an ID to a dataframe, we simply ID it with the string 
+    `{sheet_index}_{num_deletes}` before the dataframe was imported, making
+    sure to keep track of things properly in the case of a delete.
+
+    # Step 2: Figure out what additional steps we can skip
+
+    Loop over the unskipped steps from start to finish. For each step:
+        - If a dataframe is created:
+            Update creation_step_index from sheet id -> step index
+        - If a dataframe is deleted:
+            Loop from the creation_step_index of that sheet to the current
+            index, looking for steps that take this dataframe as input, and
+            output a different dataframe. 
+
+            If there is a step that takes this dataframe as input and outputs
+            a different dataframe as output, then continue. Otherwise, mark
+            all the steps that take this dataframe as input as skippable as 
+            well, in the transpilation step. 
+    """
+    from mitosheet.step_performers.dataframe_steps.dataframe_delete import \
+        DataframeDeleteStepPerformer
+
+    # Step 1: create IDs
+
+    sheet_id_map: Dict[int, Dict[int, str]] = {}
+    num_deletes = 0
+    for step_index, step in enumerate(steps_manager.curr_unskipped_steps):
+        if step_index == 0:
+            # TODO: handle dataframes that are passed to mitosheet?
+            sheet_id_map[step_index] = dict()
+        else:
+            sheet_id_map[step_index] = deepcopy(sheet_id_map[step_index - 1])
+        
+        new_sheet_indexes_this_step = step.new_sheet_indexes_this_step
+
+        for sheet_index in new_sheet_indexes_this_step:
+            sheet_id_map[step_index][sheet_index] = f'{sheet_index}_{num_deletes}'
+        
+        if step.step_type == DataframeDeleteStepPerformer.step_type():
+            deleted_sheet_index = step.params['sheet_index']
+            for sheet_index in range(deleted_sheet_index, len(step.dfs)):
+                sheet_id_map[step_index][sheet_index] = sheet_id_map[step_index][sheet_index + 1]
+            del sheet_id_map[step_index][len(step.dfs)] # TODO: might be an off by one
+
+            num_deletes += 1
+
+    # Step 2: Figure out which additional steps to skip
+    additional_step_indexes_to_skip_in_transpiling = set()
+    creation_step_index: Dict[str, int] = {} 
+
+    curr_unskipped_steps = steps_manager.curr_unskipped_steps
+
+    for step_index, step in enumerate(curr_unskipped_steps):
+        new_sheet_indexes_this_step = step.new_sheet_indexes_this_step
+        if len(new_sheet_indexes_this_step) != 0:
+            for sheet_index in new_sheet_indexes_this_step:
+                sheet_id = sheet_id_map[step_index][sheet_index]
+                creation_step_index[sheet_id] = step_index
+        if step.step_type == DataframeDeleteStepPerformer.step_type():
+            print(f'Step {step_index} is a delete. Trying to see if we can optimize')
+            # First, find the sheet id deleted
+            deleted_sheet_index = step.params['sheet_index']
+            sheet_id = sheet_id_map[step_index - 1][deleted_sheet_index]
+
+            optimizable = True
+            steps_to_remove = set()
+            for partial_past_step_index, past_step in enumerate(curr_unskipped_steps[creation_step_index[sheet_id]:step_index]):
+                past_step_index = partial_past_step_index + creation_step_index[sheet_id]
+
+                if past_step_index == 0:
+                    continue
+
+                newly_created_ids = set(sheet_id_map[past_step_index][index] for index in past_step.new_sheet_indexes_this_step)
+                # First, we check if this dataframe was newly created here
+                if newly_created_ids == {sheet_id}:
+                    steps_to_remove.add(past_step_index)
+                    continue
+
+                input_sheet_indexes = past_step.input_sheet_indexes
+                if input_sheet_indexes == {-1}:
+                    input_sheet_ids = newly_created_ids
+                else:
+                    input_sheet_ids = set(sheet_id_map[past_step_index - 1][index] for index in input_sheet_indexes)
+                output_sheet_indexes = past_step.output_sheet_indexes
+                if output_sheet_indexes == {-1}:
+                    output_sheet_ids = newly_created_ids
+                else:
+                    output_sheet_ids = set(sheet_id_map[past_step_index - 1][index] for index in output_sheet_indexes)
+                
+                if {sheet_id} == input_sheet_ids and input_sheet_ids != output_sheet_ids:
+                    optimizable = False
+
+                if {sheet_id} == input_sheet_ids and {sheet_id} == output_sheet_ids:
+                    steps_to_remove.add(past_step_index)
+
+            if optimizable:
+                additional_step_indexes_to_skip_in_transpiling.update(steps_to_remove)
+                additional_step_indexes_to_skip_in_transpiling.add(step_index)
+        
+    return [step for step_index, step in enumerate(steps_manager.curr_unskipped_steps) if step_index not in additional_step_indexes_to_skip_in_transpiling]
+
+
+
+
+        
+

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -76,7 +76,7 @@ def get_valid_dataframe_names(existing_df_names: List[str], original_df_names: L
     return final_names
 
 def dfs_to_array_for_json(
-        modified_sheet_indexes: Set[int],
+        output_sheet_indexes: Set[int],
         previous_array: List,
         dfs: List[pd.DataFrame],
         df_names: List[str],
@@ -90,7 +90,7 @@ def dfs_to_array_for_json(
 
     new_array = []
     for sheet_index, df in enumerate(dfs):
-        if sheet_index in modified_sheet_indexes:
+        if sheet_index in output_sheet_indexes:
             new_array.append(
                 df_to_json_dumpsable(
                     df, 


### PR DESCRIPTION
# Description

This PR implements optimizing out unneeded code after a delete. See the core algorithm for the optimization in the compiler utilities. Generally, pretty happy with how it _works_, but not the actual implementation (it's very messy). As such, **let's not merge this.**

What I liked from this implementation:
1. The general approach of having a set of input and output indexes, that a step performer knows about. 
2. The modification of the step class to be aware of this data (so input and output indexes are wrapped by the step, as well as the newly created indexes makes a _lot_ of sense). 

What I didn't like from this implementation:
1. The lack of symmetry between the return types of input sheet indexes
2. The existence of a sheet id as being really useful for the algorithms we implemented. It kinda makes me want to... move everything from sheet_index to sheet id. I wonder how this refactor would go!
3. How our steps manager stores and reports steps. I think the fact that all consumers of the steps in the step manager have to filter them to valid ones is... terrible UX. I want to move to hiding the invalid steps unless you want them; the list of steps should be auto filtered!

# Testing

Do some imports, merges, and pivots, and then delete data frames. If the data frame you delete was not used in any later step, it's creation and edits should disappear as well!

# Documentation

No. We're also not merging.