### PR TITLE
mitosheet: improve analysis id to be private when telemetry is off

### DIFF
--- a/mitosheet/src/widget.tsx
+++ b/mitosheet/src/widget.tsx
@@ -149,7 +149,8 @@ export class ExampleView extends DOMWidgetView {
                 not actually clear the cell if there is something there. This stops an anlaysis that
                 is read in from flashing
             */
-            overwriteIfCodeEmpty: this.creationSeconds !== undefined ? (this.creationSeconds < (new Date().getSeconds() - 60)) : true
+            overwriteIfCodeEmpty: this.creationSeconds !== undefined ? (this.creationSeconds < (new Date().getSeconds() - 60)) : true,
+            telemetryEnabled: userProfile.telemetryEnabled
         });
     }
 


### PR DESCRIPTION
# Description

Per clients request, since when telemetry is off we don't have anything, we use just a comment in the analysis code block.

# Testing

```
!python -m mitosheet turnofflogging
import mitosheet
mitosheet.sheet()
```

Then so some things, and make sure it replays. Then, turn on logging [!python -m mitosheet turnonlogging], and make sure it switches back + reads in correctly. Maybe switch back to logging off one more time, and make sure that direction works as well.

# Documentation

N/A