### PR TITLE
Logging changes

### DIFF
--- a/.github/workflows/deploy-mitosheet-private.yml
+++ b/.github/workflows/deploy-mitosheet-private.yml
@@ -1,0 +1,52 @@
+name: Deploy mitosheet-private
+on: workflow_dispatch
+
+
+jobs:
+  deploy-mitosheet-private:
+    name: Deploy mitosheet-private
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.extract_branch.outputs.branch }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup Auth for PyPi
+        run: |
+          echo -e "[distutils]" >> ~/.pypirc
+          echo -e "index-servers =" >> ~/.pypirc
+          echo -e "    pypi" >> ~/.pypirc
+          echo -e "    testpypi" >> ~/.pypirc
+          echo -e "[pypi]" >> ~/.pypirc
+          echo -e "repository = https://pypi.python.org/pypi" >> ~/.pypirc
+          echo -e "username = __token__" >> ~/.pypirc
+          echo -e "password = ${{ secrets.PYPI_API_TOKEN }}" >> ~/.pypirc
+          echo -e "" >> ~/.pypirc
+          echo -e "[testpypi]" >> ~/.pypirc
+          echo -e "repository = https://test.pypi.org/legacy/" >> ~/.pypirc
+          echo -e "username = __token__" >> ~/.pypirc
+          echo -e "password = ${{ secrets.TEST_PYPI_API_TOKEN }}" >> ~/.pypirc
+      - name: Setup mitosheet
+        run: |
+          cd mitosheet
+          rm -rf venv
+          python3 -m venv venv
+          source venv/bin/activate
+          python switch.py mitosheet-private
+          python ../deployment/bump_version.py mitosheet-private ${{ steps.extract_branch.outputs.branch }}
+          python -m pip install -e ".[test, deploy]"          
+      - name: Deploy mitosheet
+        run: |
+          cd mitosheet
+          source venv/bin/activate
+          python ../deployment/deploy.py ${{ steps.extract_branch.outputs.branch }}

--- a/deployment/deploy.py
+++ b/deployment/deploy.py
@@ -37,7 +37,8 @@ def main():
     Deploy to PyPi with `python3 deploy.py [dev | main]`.
 
     Note that it will deploy whatever package is currently the defined package
-    in the package.json, which could either be mitosheet or mitosheet3. 
+    in the package.json, which could either be any mitosheet package, or the 
+    mitoinstaller. 
 
     Note that this should be run in the folder of the package that is being
     deployed (e.g. the folder where the setup.py is).

--- a/mitosheet/mitosheet/mito_analytics.py
+++ b/mitosheet/mitosheet/mito_analytics.py
@@ -411,6 +411,22 @@ def log_event_processed(event: Dict[str, Any], steps_manager: StepsManagerType, 
             ),
             steps_manager=steps_manager
         )
+
+        # We also generate a double log in the case of errors, whenever anything fails. This allows
+        # us to easily track the number of users who are getting errors
+        if failed:
+            log(
+                'error', 
+                dict(
+                    log_event=log_event,
+                    **event_properties,
+                    **steps_manager_properties,
+                    **error_properties
+                ),
+                steps_manager=steps_manager
+            )
+
+
     except:
         # We don't want logging to ever brick the application, so if the logging fails
         # we just log simple information about the event. This should never occur, but it

--- a/mitosheet/mitosheet/mito_analytics.py
+++ b/mitosheet/mitosheet/mito_analytics.py
@@ -168,6 +168,7 @@ def log(log_event: str, params: Dict[Any, Any]=None, steps_manager: StepsManager
     if params is None:
         params = {}
 
+    global location
     if location is None:
         location = get_location()
     

--- a/mitosheet/mitosheet/mito_analytics.py
+++ b/mitosheet/mitosheet/mito_analytics.py
@@ -39,7 +39,7 @@ import analytics
 # Write key taken from segement.com
 analytics.write_key = '6I7ptc5wcIGC4WZ0N1t0NXvvAbjRGUgX' 
 
-from mitosheet._version import __version__
+from mitosheet._version import __version__, package_name
 from mitosheet.errors import MitoError, get_recent_traceback_as_list
 from mitosheet.user import (UJ_FEEDBACKS, UJ_INTENDED_BEHAVIOR,
                             UJ_STATIC_USER_ID, UJ_USER_EMAIL, UJ_USER_SALT,
@@ -52,6 +52,11 @@ def telemetry_turned_on() -> bool:
     Helper function that tells if you if logging is turned on or
     turned off on the entire Mito instance
     """
+    # If the current package is mitosheet-private, then we don't log anything,
+    # ever, under any circumstances - this is a custom distribution for a client
+    if package_name == 'mitosheet-private':
+        return False
+
     telemetry = get_user_field(UJ_MITOSHEET_TELEMETRY) 
     return telemetry if telemetry is not None else False
 
@@ -177,6 +182,7 @@ def log(log_event: str, params: Dict[Any, Any]=None, steps_manager: StepsManager
         'version_python': sys.version_info,
         'version_jupyterlab': jupyterlab_version,
         'version_mito': __version__,
+        'package_name': package_name,
         'location': location
     }
 
@@ -289,6 +295,7 @@ def identify() -> None:
             'version_python': sys.version_info,
             'version_sys': sys.version,
             'version_mito': __version__,
+            'package_name': package_name, 
             'version_jupyterlab': jupyterlab_version,
             'operating_system': operating_system,
             'email': user_email,

--- a/mitosheet/mitosheet/mito_analytics.py
+++ b/mitosheet/mitosheet/mito_analytics.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List
 from mitosheet.parser import parse_formula
 from mitosheet.types import StepsManagerType
 from mitosheet.user.schemas import UJ_MITOSHEET_TELEMETRY
+from mitosheet.user.location import get_location
 
 try:
     from jupyterlab import __version__ as jupyterlab_version
@@ -150,6 +151,9 @@ def get_installed_mitosheets_pip_show():
         return []
 
 
+# We only calculate the location once so that we don't cause performance issues
+location = None
+
 def log(log_event: str, params: Dict[Any, Any]=None, steps_manager: StepsManagerType=None) -> None:
     """
     Helper function that logs an event with the given parameters. However,
@@ -163,13 +167,20 @@ def log(log_event: str, params: Dict[Any, Any]=None, steps_manager: StepsManager
 
     if params is None:
         params = {}
+
+    if location is None:
+        location = get_location()
     
     # Add the python properties to every log event we can
     python_properties = {
         'version_python': sys.version_info,
         'version_jupyterlab': jupyterlab_version,
-        'version_mito': __version__ 
+        'version_mito': __version__,
+        'location': location
     }
+
+    # Add some data about where this is being run from, so we make sure we
+    # support users systems
     
     params = dict(
         **params,

--- a/mitosheet/mitosheet/mito_analytics.py
+++ b/mitosheet/mitosheet/mito_analytics.py
@@ -21,6 +21,7 @@ Our general approach to logging can be understood as:
 import platform
 import subprocess
 import sys
+import time
 from typing import Any, Dict, List
 
 from mitosheet.parser import parse_formula
@@ -309,7 +310,7 @@ def log_recent_error(log_event: str=None) -> None:
     )
 
 
-def log_event_processed(event: Dict[str, Any], steps_manager: StepsManagerType, failed: bool=False, mito_error: MitoError=None) -> None:
+def log_event_processed(event: Dict[str, Any], steps_manager: StepsManagerType, failed: bool=False, mito_error: MitoError=None, start_time: float=None) -> None:
     """
     Helper function for logging when an event is processed
     by the widget state container. 
@@ -391,6 +392,11 @@ def log_event_processed(event: Dict[str, Any], steps_manager: StepsManagerType, 
             }
         else:
             error_properties = {}
+
+        # We also log some timing information - which we round to a single decimal place just
+        # so that we can bucket these items easily
+        if start_time is not None:
+            event_properties['processing_time'] = round(time.perf_counter() - start_time, 1)
 
         # We choose to log the event type, as it is the best high-level item for our logs
         # and we append a _failed if the event failed in doing this.

--- a/mitosheet/mitosheet/mito_widget.py
+++ b/mitosheet/mitosheet/mito_widget.py
@@ -7,24 +7,26 @@
 Main file containing the mito widget.
 """
 import json
+import time
 from typing import Any, Dict, List, Union
-import pandas as pd
-import random
-from ipywidgets import DOMWidget
-import traitlets as t
 
-from mitosheet.mito_analytics import log, log_event_processed, log_recent_error, telemetry_turned_on
-from mitosheet.step_performers import STEP_TYPE_TO_USAGE_TRIGGERED_FEEDBACK_ID
-from mitosheet.user.schemas import UJ_MITOSHEET_LAST_FIFTY_USAGES, UJ_RECEIVED_TOURS, UJ_USER_EMAIL
-from mitosheet.user.db import get_user_field
-from mitosheet.user.utils import is_excel_import_enabled, is_pro
-from mitosheet.api import API
+import pandas as pd
+import traitlets as t
+from ipywidgets import DOMWidget
+
 from mitosheet._frontend import module_name, module_version
+from mitosheet.api import API
+from mitosheet.data_in_mito import DataTypeInMito
 from mitosheet.errors import MitoError, get_recent_traceback
+from mitosheet.mito_analytics import (log, log_event_processed,
+                                      log_recent_error, telemetry_turned_on)
 from mitosheet.saved_analyses import write_analysis
 from mitosheet.steps_manager import StepsManager
 from mitosheet.user import is_local_deployment, should_upgrade_mitosheet
-from mitosheet.data_in_mito import DataTypeInMito
+from mitosheet.user.db import get_user_field
+from mitosheet.user.schemas import (UJ_MITOSHEET_LAST_FIFTY_USAGES,
+                                    UJ_RECEIVED_TOURS, UJ_USER_EMAIL)
+from mitosheet.user.utils import is_excel_import_enabled, is_pro
 
 
 class MitoWidget(DOMWidget):
@@ -177,6 +179,8 @@ class MitoWidget(DOMWidget):
 
         4. A log_event is just an event that should get logged on the backend.
         """
+
+        start_time = time.perf_counter()
         event = content
 
         try:
@@ -191,7 +195,7 @@ class MitoWidget(DOMWidget):
             # NOTE: we don't need to case on log_event above because it always gets
             # passed to this function, and thus is logged. However, we do not log
             # api calls, as they are just noise.
-            log_event_processed(event, self.steps_manager)
+            log_event_processed(event, self.steps_manager, start_time=start_time)
 
             return True
         except MitoError as e:
@@ -199,7 +203,7 @@ class MitoWidget(DOMWidget):
             print(e)
             
             # Log processing this event failed
-            log_event_processed(event, self.steps_manager, failed=True, mito_error=e)
+            log_event_processed(event, self.steps_manager, failed=True, mito_error=e, start_time=start_time)
 
             # If the error says to ignore the error modal, then we
             # send some data with the response so that the frontend
@@ -226,7 +230,7 @@ class MitoWidget(DOMWidget):
         except:
             print(get_recent_traceback())
             # We log that processing failed, but have no edit error
-            log_event_processed(event, self.steps_manager, failed=True)
+            log_event_processed(event, self.steps_manager, failed=True, start_time=start_time)
             # Report it to the user, and then return
             self.send({
                 'event': 'edit_error',

--- a/mitosheet/mitosheet/steps_manager.py
+++ b/mitosheet/mitosheet/steps_manager.py
@@ -8,6 +8,7 @@ import uuid
 from copy import copy, deepcopy
 import pandas as pd
 from typing import Any, Callable, Dict, Collection, List, Set, Tuple, Union
+from mitosheet.mito_analytics import log
 
 from mitosheet.step_performers.import_steps.simple_import import SimpleImportStepPerformer
 from mitosheet.step_performers.import_steps.excel_import import ExcelImportStepPerformer
@@ -16,7 +17,7 @@ from mitosheet.step import Step
 from mitosheet.step_performers import EVENT_TYPE_TO_STEP_PERFORMER
 from mitosheet.updates import UPDATES
 from mitosheet.preprocessing import PREPROCESS_STEP_PERFORMERS
-from mitosheet.utils import dfs_to_array_for_json, get_new_id
+from mitosheet.utils import dfs_to_array_for_json, get_new_id, is_default_df_names
 from mitosheet.transpiler.transpile import transpile
 from mitosheet.data_in_mito import DataTypeInMito, get_data_type_in_mito
 
@@ -342,6 +343,15 @@ class StepsManager():
         # If we add a new step, then we clear the last_undone_list_store, as
         # you cannot redo something after you make a new edit
         self.undone_step_list_store = []
+
+        # NOTE: we also check here if we're receiving an edit event, and we have not
+        # yet read in the non-default dataframe names. We have to log this here, rather
+        # than in the .sheet call (or elsewhere) because the dataframe names are read
+        # in after the sheet is rendered. Thus, we just check after the first edit event
+        # (e.g. when there are two steps) - if we still have default dataframe names, this
+        # is an error
+        if len(self.steps) == 2 and is_default_df_names(self.curr_step.df_names): # NOTE: two means we have done at least one edit.
+            log('args_update_failed')
 
     def handle_update_event(self, update_event: Dict[str, Any]) -> None:
         """

--- a/mitosheet/mitosheet/tests/startup/test_startup.py
+++ b/mitosheet/mitosheet/tests/startup/test_startup.py
@@ -1,5 +1,3 @@
-
-from installer.mitoinstaller.create_startup_file import IMPORT_MITOSHEET_FILE_CONTENTS as installer_file_contents
 from mitosheet.startup.startup_utils import IMPORT_MITOSHEET_FILE_CONTENTS as mitosheet_file_contents
 import os
 import subprocess
@@ -19,4 +17,7 @@ def test_create_startup_file():
 
 
 def test_file_contents_in_sync():
+    import sys
+    sys.path.insert(0, '../mitoinstaller')
+    from mitoinstaller.create_startup_file import IMPORT_MITOSHEET_FILE_CONTENTS as installer_file_contents
     assert installer_file_contents == mitosheet_file_contents

--- a/mitosheet/mitosheet/user/location.py
+++ b/mitosheet/mitosheet/user/location.py
@@ -1,0 +1,79 @@
+import os
+from mitosheet.utils import run_command
+
+
+def is_in_google_colab() -> bool:
+    # From: https://discourse.jupyter.org/t/find-out-if-my-code-runs-inside-a-notebook-or-jupyter-lab/6935/19
+    try:
+        from IPython.core.getipython import get_ipython
+        return 'google.colab' in str(get_ipython())
+    except:
+        return False
+
+def is_in_vs_code() -> bool:
+    # From: https://github.com/microsoft/vscode-jupyter/issues/3364
+    return 'VSCODE_PID' in os.environ
+
+def is_jupyter_lab_running() -> bool:
+    """
+    Format of command output: 
+
+    Currently running servers:
+    http://localhost:8888/?token=wenflwenflqnwdlkqmwldkm :: Path/to/launch
+    """
+    try:
+        return '::' in run_command(['jupyter', 'lab', 'list'])[0]
+    except:
+        return False
+
+def is_jupyter_notebook_running() -> bool:
+    """
+    Format of command output: 
+
+    Currently running servers:
+    http://localhost:8888/?token=wenflwenflqnwdlkqmwldkm :: Path/to/launch
+    """
+    try:
+        return '::' in run_command(['jupyter', 'notebook', 'list'])[0]
+    except:
+        return False
+
+def is_notebook() -> bool:
+    """
+    Returns true if this code is run in some sort of notebook
+    Taken from: https://stackoverflow.com/questions/15411967/how-can-i-check-if-code-is-executed-in-the-ipython-notebook
+    """
+    try:
+        from IPython.core.getipython import get_ipython
+    except:
+        return False
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell == 'ZMQInteractiveShell':
+            return True   # Jupyter notebook or qtconsole
+        elif shell == 'TerminalInteractiveShell':
+            return False  # Terminal running IPython
+        else:
+            return False  # Other type (?)
+    except NameError:
+        return False      # Probably standard Python interpreter
+
+def get_location() -> str:
+    notebook = is_notebook()
+    lab_running = is_jupyter_lab_running()
+    notebook_running = is_jupyter_notebook_running()
+
+    if is_in_google_colab():
+        return 'location_google_colab'
+    elif is_in_vs_code():
+        return 'location_vs_code'
+    elif notebook and (lab_running and not notebook_running):
+        return 'location_jupyter_lab'
+    elif notebook and (not lab_running and notebook_running):
+        return 'location_jupyter_notebook'
+    elif notebook:
+        # NOTE: in this case, both jlab and jnotebook are running, and
+        # we cannot tell where we are. So we just say unknown
+        return 'location_unknown_notebook'
+    else:
+        return 'location_unknown'

--- a/mitosheet/mitosheet/user/location.py
+++ b/mitosheet/mitosheet/user/location.py
@@ -1,4 +1,9 @@
+"""
+Utilities for figuring out where Mito is being run.
+"""
+
 import os
+
 from mitosheet.utils import run_command
 
 

--- a/mitosheet/mitosheet/user/utils.py
+++ b/mitosheet/mitosheet/user/utils.py
@@ -10,9 +10,7 @@ current user.
 import getpass
 import os
 from datetime import datetime
-from subprocess import CompletedProcess
 import sys
-from typing import List, Tuple
 
 import pandas as pd
 from mitosheet._version import __version__

--- a/mitosheet/mitosheet/user/utils.py
+++ b/mitosheet/mitosheet/user/utils.py
@@ -10,14 +10,15 @@ current user.
 import getpass
 import os
 from datetime import datetime
+from subprocess import CompletedProcess
 import sys
+from typing import List, Tuple
 
 import pandas as pd
 from mitosheet._version import __version__
 from mitosheet.user.db import get_user_field
 from mitosheet.user.schemas import (UJ_MITOSHEET_LAST_UPGRADED_DATE,
                                     UJ_MITOSHEET_PRO)
-
 
 def is_running_test() -> bool:
     """

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -9,7 +9,7 @@ Contains helpful utility functions
 import json
 import re
 import uuid
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 from mitosheet.types import ColumnHeader, ColumnID
 
 import numpy as np
@@ -238,5 +238,32 @@ def get_random_id() -> str:
 
 def get_new_id() -> str:
     return str(uuid.uuid4())
+
+
+def run_command(command_array: List[str]) -> Tuple[str, str]:
+    """
+    An internal command that should be used to run all commands
+    that run on the command line, so that output from failing
+    commands can be captured.
+
+    Can toggle if this raises an error with fail_on_nonzero_exit_code
+    """
+    import subprocess
+    completed_process = subprocess.run(
+        command_array, 
+        # NOTE: we do not use the capture_output variable, as this doesn't work before
+        # python 3.7, and we want users to be able to install before that
+        stdout=subprocess.PIPE, 
+        stderr=subprocess.STDOUT,
+        # NOTE: we use universal_newlines to get the result back as text, 
+        # but we don't use text=True, because we want to work before 3.7 when
+        # text was introduced. See here: https://stackoverflow.com/questions/41171791/how-to-suppress-or-capture-the-output-of-subprocess-run
+        universal_newlines=True
+    )
+    # We default the stdout and stderr to empty strings if they are not strings, 
+    # to make code that handles them have an easier time (they might be None)
+    stdout = completed_process.stdout if isinstance(completed_process.stdout, str) else ''
+    stderr = completed_process.stderr if isinstance(completed_process.stderr, str) else ''
+    return stdout, stderr
 
 

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -245,14 +245,12 @@ def run_command(command_array: List[str]) -> Tuple[str, str]:
     An internal command that should be used to run all commands
     that run on the command line, so that output from failing
     commands can be captured.
-
-    Can toggle if this raises an error with fail_on_nonzero_exit_code
     """
     import subprocess
     completed_process = subprocess.run(
         command_array, 
         # NOTE: we do not use the capture_output variable, as this doesn't work before
-        # python 3.7, and we want users to be able to install before that
+        # python 3.7
         stdout=subprocess.PIPE, 
         stderr=subprocess.STDOUT,
         # NOTE: we use universal_newlines to get the result back as text, 

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -74,6 +74,13 @@ def get_valid_dataframe_names(existing_df_names: List[str], original_df_names: L
     
     return final_names
 
+def is_default_df_names(df_names: List[str]) -> bool:
+    """
+    Returns true if the df names list is the default df names
+    created when the widget state container is initialized
+    """
+    return len(df_names) > 0 and df_names == [f'df{i + 1}' for i in range(len(df_names))]
+
 def dfs_to_array_for_json(
         modified_sheet_indexes: Set[int],
         previous_array: List,

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -148,7 +148,7 @@ if name == 'mitosheet2':
             """,
         long_description_content_type='text/markdown'
     )
-elif name == 'mitosheet' or name == 'mitosheet3':
+elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
     # Representative files that should exist after a successful build
     jstargets = [
         str(lab_path / "package.json"),

--- a/mitosheet/switch.py
+++ b/mitosheet/switch.py
@@ -145,116 +145,7 @@ MITOSHEET_PACKAGE_JSON = """{
     "outputDir": "mitosheet/labextension",
     "extension": "lib/plugin"
   },
-  "name": "mitosheet",
-  "license": "AGPL-3.0-only",
-  "author": {
-    "name": "Mito Sheet",
-    "email": "naterush1997@gmail.com"
-  },
-  "bugs": {
-    "url": "https://github.com/mito/mito/issues"
-  },
-  "repository": {
-    "url": "https://github.com/mito/mito",
-    "type": "git"
-  },
-  "version": "0.3.131",
-  "dependencies": {
-    "@jupyter-widgets/base": "^4",
-    "@jupyterlab/notebook": "^3.0.6",
-    "@types/fscreen": "^1.0.1",
-    "@types/jest": "^27.0.2",
-    "@types/react-dom": "^17.0.2",
-    "fscreen": "^1.1.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "ts-jest": "^27.0.3"
-  },
-  "scripts": {
-    "test:jest": "jest",
-    "deploy:staging": "python3 deployment/deploy.py staging",
-    "build:prod": "jlpm run build:lib && jlpm run build:labextension",
-    "clean:labextension": "rimraf mitosheet/labextension",
-    "deploy:app": "python3 deployment/deploy.py app",
-    "build:labextension:dev": "jupyter labextension build --development True .",
-    "prepare": "jlpm run clean && jlpm run build:prod",
-    "watch:lib": "tsc -w",
-    "build:labextension": "jupyter labextension build .",
-    "deploy:all": "python3 deployment/deploy.py all",
-    "build": "jlpm run build:lib && jlpm run build:labextension:dev",
-    "build:lib": "tsc",
-    "deploy:pypi": "python3 setup.py sdist bdist_wheel upload",
-    "clean:nbextension": "rimraf mitosheet/nbextension/static/index.js",
-    "build:all": "npm run build:labextension && npm run build:nbextension",
-    "lint:check": "eslint src/ --ext .ts,.tsx",
-    "watch:nbextension": "webpack --watch",
-    "lint": "eslint src/ --ext .ts,.tsx --fix",
-    "watch": "run-p watch:src watch:labextension",
-    "watch:labextension": "jupyter labextension watch .",
-    "install:extension": "jupyter labextension develop --overwrite .",
-    "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
-    "prepack": "npm run build:lib",
-    "watch:src": "tsc -w",
-    "clean": "jlpm run clean:lib",
-    "clean:all": "jlpm run clean:lib && jlpm run clean:labextension"
-  },
-  "keywords": [
-    "jupyter",
-    "jupyterlab",
-    "jupyterlab-extension",
-    "widgets"
-  ],
-  "devDependencies": {
-    "@jupyterlab/builder": "^3.0.0",
-    "@testing-library/jest-dom": "^5.14.1",
-    "@testing-library/react": "^12.0.0",
-    "@types/expect.js": "^0.3.29",
-    "@types/mocha": "^9.0.0",
-    "@types/node": "^16.10.2",
-    "@types/react": "^17.0.26",
-    "@typescript-eslint/eslint-plugin": "^4.8.1",
-    "@typescript-eslint/parser": "^4.8.1",
-    "acorn": "^8.5.0",
-    "application": "npm:@lumino/application@^1.13.1",
-    "eslint": "^7.14.0",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-office-addins": "^1.0.3",
-    "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-react": "^7.21.3",
-    "expect.js": "^0.3.1",
-    "fs-extra": "^10.0.0",
-    "jest": "^27.0.6",
-    "jest-css-modules-transform": "^4.3.0",
-    "mkdirp": "^1.0.4",
-    "mocha": "^9.1.2",
-    "npm-run-all": "^4.1.5",
-    "prettier": "^2.1.1",
-    "rimraf": "^3.0.2",
-    "typescript": "^4.4.3",
-    "widgets": "npm:@lumino/widgets@^1.16.1"
-  },
-  "main": "lib/index.js",
-  "homepage": "https://github.com/mito/mito",
-  "types": "./lib/index.d.ts",
-  "description": "The Mito Spreadsheet",
-  "resolutions": {
-    "@types/react": "^17.0.2"
-  }
-}"""
-
-MITOSHEET_THREE_PACKAGE_JSON = """{
-  "files": [
-    "lib/**/*.js",
-    "fonts/**/*",
-    "dist/*.js",
-    "css/**/*.css",
-    "style/index.js"
-  ],
-  "jupyterlab": {
-    "outputDir": "mitosheet/labextension",
-    "extension": "lib/plugin"
-  },
-  "name": "mitosheet3",
+  "name": "REPLACE_WITH_PACKAGE_NAME_WITH_REPLACE",
   "license": "AGPL-3.0-only",
   "author": {
     "name": "Mito Sheet",
@@ -343,7 +234,7 @@ MITOSHEET_THREE_PACKAGE_JSON = """{
     "widgets": "npm:@lumino/widgets@^1.16.1"
   },
   "main": "lib/index.js",
-  "homepage": "https://github.com/mito-ds/monorepo",
+  "homepage": "https://trymito.io",
   "types": "./lib/index.d.ts",
   "description": "The Mito Spreadsheet",
   "resolutions": {
@@ -392,9 +283,11 @@ def switch(new_package):
     if new_package == 'mitosheet2':
       open('package.json', 'w').write(MITOSHEET_TWO_PACKAGE_JSON)
     elif new_package == 'mitosheet':    
-      open('package.json', 'w').write(MITOSHEET_PACKAGE_JSON)
+      open('package.json', 'w').write(MITOSHEET_PACKAGE_JSON.replace('REPLACE_WITH_PACKAGE_NAME_WITH_REPLACE', 'mitosheet'))
     elif new_package == 'mitosheet3':    
-      open('package.json', 'w').write(MITOSHEET_THREE_PACKAGE_JSON)
+      open('package.json', 'w').write(MITOSHEET_PACKAGE_JSON.replace('REPLACE_WITH_PACKAGE_NAME_WITH_REPLACE', 'mitosheet3'))
+    elif new_package == 'mitosheet-private':
+      open('package.json', 'w').write(MITOSHEET_PACKAGE_JSON.replace('REPLACE_WITH_PACKAGE_NAME_WITH_REPLACE', 'mitosheet-private'))
 
     
 if __name__ == '__main__':
@@ -405,7 +298,14 @@ if __name__ == '__main__':
     if new_package == curr_package:
         print(f'You may not need to switch, as {new_package} is already the current package. Refreshing anyways.')
 
+    valid_package_names = [
+      'mitosheet2',
+      'mitosheet',
+      'mitosheet3',
+      'mitosheet-private'
+    ]
+
     # Sanity check!
-    assert new_package == 'mitosheet2' or new_package == 'mitosheet' or new_package == 'mitosheet3'
+    assert new_package in valid_package_names
 
     switch(new_package)


### PR DESCRIPTION
# Description

NOTE: merge after mitosheet private!


1. Adds logging for how long ops take to run, in 10ths of a second
2. Add an explicit log for errors
3. Add log if DF names are not read in correctly
4. Add location log

# Testing

## How long an op takes to run

Just check log to see processing time

## An explicit log for errors

Generate an invalid formula, and see if an explicit error log is generated

## Testing the df names are not read correctly

Comment out line 142 of Mito.tsx, so the names aren't read in correctly. Then, try and make an edit, and make sure the log gets generated.

## Testing for the location

1. Check in Python terminal (make sure in venv where jupyterlab is run from). Run
```
python3
from mitosheet.user.location import get_location
get_location()
```
Try running this when no labs/notebooks are running, and when they are

6. Test in Jlab

Start a Jlab, and run
```
from mitosheet.user.location import get_location
get_location()
```

7. Test in JNotebook

Kill the Jlab. Run `jupyter notebook`. Run
```
from mitosheet.user.location import get_location
get_location()
```

8. Run both a JLab and Notebook 

In one of them, run
```
from mitosheet.user.location import get_location
get_location()
```
It should print out unknown notebook - we don't have a good way to tell! 

9. VS Code notebook

Open a notebook in VS Code, and run that
```
from mitosheet.user.location import get_location
get_location()
```

10. VS Code python file
Create a Python file `test.py` in VS Code, and from the command line run `python3 test.py`:
```
from mitosheet.user.location import get_location
print(get_location())
```
It should be location unknown.

11. Test in Google cola

Copy in the entire contents of the `mitosheet/user/location.py` file, as well as the `run_command` function from `mitosheet/utils`. Then, run `get_location()` - and make sure it's google collab.

12. Check it's in the logs

Finally, check that this is in the logs

# Documentation

None.