### PR TITLE
mitoinstaller: major cleanup, bug fixes with identify

### DIFF
--- a/mitoinstaller/mitoinstaller/__main__.py
+++ b/mitoinstaller/mitoinstaller/__main__.py
@@ -10,7 +10,7 @@ Long term, we aim to meet:
 from colorama import init
 from termcolor import colored  # type: ignore
 
-from mitoinstaller.install import do_install_or_upgrade
+from mitoinstaller.install import do_install
 
 
 def main() -> None:
@@ -18,7 +18,7 @@ def main() -> None:
     The main function of the Mito installer, this function is responsible
     for installing and upgrading the `mitosheet` package.
 
-    To install Mito (for the first time):
+    To install Mito:
     python -m mitoinstaller install
 
     To upgrade Mito:
@@ -35,15 +35,10 @@ def main() -> None:
     else:
         command = ''
 
-    # Check if it's a pro install
-    is_pro = '--pro' in sys.argv
-
-    if command == 'install':
-        do_install_or_upgrade('install', is_pro)
+    if command == 'install' or command == 'upgrade':
+        do_install()
     elif command == 'uninstall':
         print('To uninstall, run,', colored('`pip uninstall mitosheet`', 'green'))
-    elif command == 'upgrade':
-        do_install_or_upgrade('upgrade', is_pro)
     else:
         # NOTE: we don't add upgrade_to_jupyterlab_3 to the help.
         # We only send this command to the users who need to know this (namely, those that need to upgrade)

--- a/mitoinstaller/mitoinstaller/commands.py
+++ b/mitoinstaller/mitoinstaller/commands.py
@@ -3,16 +3,15 @@ Contains useful commands for interacting
 with the command line directly
 """
 
-import os
 import sys
+import traceback
 from subprocess import CompletedProcess
 from typing import List, Tuple, Union
 
-from termcolor import colored # type: ignore
+from termcolor import colored  # type: ignore
 
 # NOTE: Do not import subprocess here, we only want one
 # function to have it
-from mitoinstaller.user_install import is_running_test
 
 
 def get_output(completed_process: CompletedProcess) -> str:
@@ -208,8 +207,13 @@ def get_jupyterlab_metadata() -> Tuple[Union[str, None], Union[List[str], None]]
     
     return __version__, extension_names
 
-def exit_after_error(install_or_upgrade: str, error: str=None) -> None:
-    full_error = '\n\nSorry, looks like we hit a problem during {install_or_upgrade}. '.format(install_or_upgrade=install_or_upgrade) + \
+def exit_after_error() -> None:
+
+    # Print the full error so that the user can see it
+    print(traceback.format_exc())
+
+    # Then, print a final error message
+    full_error = '\n\nSorry, looks like we hit a problem.' + \
         '\nWe\'re happy to help you fix it ASAP. Just hop on our discord, and and post in the install-help channel. We\'ll get you sorted in a few minutes:\n\n\t https://discord.gg/AAeYm6YV7B\n'
 
     print(colored(full_error, 'red'))

--- a/mitoinstaller/mitoinstaller/install.py
+++ b/mitoinstaller/mitoinstaller/install.py
@@ -1,51 +1,24 @@
-"""
-We specify the installer as a list of steps that must run in order.
-
-Currently, we just attempt to install the mitosheet package. 
-"""
-
-from mitoinstaller.commands import exit_after_error
 from mitoinstaller.installer_steps import (FINAL_INSTALLER_STEPS,
                                            INITIAL_INSTALLER_STEPS,
                                            MITOSHEET_INSTALLER_STEPS,
                                            run_installer_steps)
-from mitoinstaller.installer_steps.initial_installer_steps import \
-    INITIAL_INSTALLER_STEPS_PRO
-from mitoinstaller.log_utils import log, log_error
 
 
-def do_install_or_upgrade(install_or_upgrade: str, is_pro: bool) -> None:
+def do_install() -> None:
     """
-    install_or_upgrade is the workhorse of actually installing mito. 
-    It just attempts to install the `mitosheet` package, and then launch
-    JLab with a starter file.
-
-    install_or_upgrade should be 'install' or 'upgrade'.
+    Runs the installer steps to install the `mitosheet` package.
 
     Notably, the process for installing Mito initially and upgrading Mito are
     identical. As such, we reuse this function to upgrade, just with different
     error and logging messages.
     """
-    print("Starting {install_or_upgrade}...".format(install_or_upgrade=install_or_upgrade))
+    print("Starting install...")
 
-    # Change the installation depending if the user is a pro user or not
-    if not is_pro:
-        run_installer_steps(INITIAL_INSTALLER_STEPS)
-    else:
-        run_installer_steps(INITIAL_INSTALLER_STEPS_PRO)
+    # Run the initiall installer steps
+    run_installer_steps(INITIAL_INSTALLER_STEPS)
 
-    # First, we try to install mitosheet
-    installed_mitosheet = run_installer_steps(MITOSHEET_INSTALLER_STEPS)
-    if installed_mitosheet:
-        # If we installed mitosheet, log that we did
-        log('install_finished_mitosheet')
-        
-        # Then run the final installer steps and exit
-        run_installer_steps(FINAL_INSTALLER_STEPS)
-        exit(0)
-    else:
-        # Otherwise, log the error (which prints to the user). Note that we don't give up here!
-        log_error('install_failed_mitosheet', print_to_user=False)
-        # TODO: we could make a clickable link to debugging instructions, or an email to send to Jake?
-        # I think we should prompt users to do this, defaulting to Yes!
-        exit_after_error(install_or_upgrade)
+    # Then, we try to install mitosheet package
+    run_installer_steps(MITOSHEET_INSTALLER_STEPS)
+
+    # Then, we try and launch JLab
+    run_installer_steps(FINAL_INSTALLER_STEPS)

--- a/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
@@ -3,12 +3,12 @@
 
 import os
 import sys
+import time
 
 import analytics
-from mitoinstaller.commands import check_running_jlab_3_processes
 from mitoinstaller.create_startup_file import create_startup_file
 from mitoinstaller.installer_steps.installer_step import InstallerStep
-from mitoinstaller.log_utils import log_error
+from mitoinstaller.log_utils import log
 from mitoinstaller.starter_notebook import (MITO_STARTER_NOTEBOOK_PATH,
                                             try_create_starter_notebook)
 from mitoinstaller.user_install import is_running_test
@@ -25,83 +25,30 @@ def replace_process_with_jupyter_lab():
     if is_running_test():
         return
 
-    # Flush analytics before we terminate the process
+    # Flush analytics before we terminate the process, as it's our last chance
     analytics.flush()
+    
     os.execl(sys.executable, 'python', '-m', 'jupyter', 'lab', MITO_STARTER_NOTEBOOK_PATH)
 
-
-def get_success_message():
-    """
-    Note that not many users get to the success message!
-
-    We show a different message depending on if this is an install or an upgrade,
-    and we further tell the user different things if they have a currently running
-    JLab instance (as they need to restart this)
-    """
-    running_jlab = check_running_jlab_3_processes()
-
-    separator_line = '----------------------------------------------------------------------------'
-
-    install_or_upgrade = 'install'
-    install_start = 'Mito has finished installing'
-    # NOTE: this is a bug that gives the wrong message, but it's fine, 
-    # since most people are installing and not upgrading.
-    upgrade_start = 'Mito has finished installing'
-
-    launch_jlab = 'Launch JupyterLab with:\t' + colored('python -m jupyter lab', 'green')
-    relaunch_jlab = colored('Please shut down the currently running JupyterLab and relaunch it to enable Mito', 'green')
-
-    render_mitosheet = colored('Then render a mitosheet following the instructions here: https://docs.trymito.io/how-to/creating-a-mitosheet', 'green')
-
-    if not running_jlab:
-        if install_or_upgrade == 'install':
-            return '\n{separator_line}\n{install_start}\n\n{launch_jlab}\n\n{render_mitosheet}\n{separator_line}'.format(
-                separator_line=separator_line,
-                install_start=install_start,
-                launch_jlab=launch_jlab,
-                render_mitosheet=render_mitosheet,
-            )
-        else:
-            return '\n{separator_line}\n{upgrade_start}\n\n{launch_jlab}\n\n{render_mitosheet}\n{separator_line}'.format(
-                separator_line=separator_line,
-                upgrade_start=upgrade_start,
-                launch_jlab=launch_jlab,
-                render_mitosheet=render_mitosheet,
-            )
-    else:
-        if install_or_upgrade == 'install':
-            return '\n{separator_line}\n{install_start}\n\n{relaunch_jlab}\n\n{render_mitosheet}\n{separator_line}'.format(
-                separator_line=separator_line,
-                install_start=install_start,
-                relaunch_jlab=relaunch_jlab,
-                render_mitosheet=render_mitosheet,
-            )
-        else:
-            return '\n{separator_line}\n{upgrade_start}\n\n{relaunch_jlab}\n\n{render_mitosheet}\n{separator_line}'.format(
-                separator_line=separator_line,
-                upgrade_start=upgrade_start,
-                relaunch_jlab=relaunch_jlab,
-                render_mitosheet=render_mitosheet,
-            )
 
 def print_success_message():
     """
     Prints a success message to the user, in the case that we cannot
-    launch JupyterLab. Furthermore, logs that the jupyter lab instance
+    launch JupyterLab. TODO: Furthermore, logs that the jupyter lab instance
     could not be launched.
     """
-    # If we get past this, then JLab must have not been able to replace the current process, so we 
-    # log that, and then print the success message anyways
-    log_error('failed_launch_jupyterlab', print_to_user=False)
-
-    print(get_success_message())
+    # Finially, if we get here, we print to the user that they should launch
+    # JLab and run it. Note that we only get here if the final install step of
+    # launching JLab does not work
+    print("\n\nThe mitosheet package has correctly been installed.")
+    print("To see instructions to render a mitosheet, see docs: ", colored('https://docs.trymito.io/how-to/creating-a-mitosheet', 'green'))
 
 
 FINAL_INSTALLER_STEPS = [
     InstallerStep(
         'Create import mito startup file',
         create_startup_file,
-        True
+        optional=True
     ),
     InstallerStep(
         'Creating a Mitosheet starter notebook',
@@ -116,6 +63,7 @@ FINAL_INSTALLER_STEPS = [
     # if this fails, then just print a success message to the user
     InstallerStep(
         'Finish Installation',
-        print_success_message
+        print_success_message,
+        optional=True
     )
 ]

--- a/mitoinstaller/mitoinstaller/installer_steps/initial_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/initial_installer_steps.py
@@ -1,3 +1,4 @@
+import sys
 from mitoinstaller import __version__
 from mitoinstaller.commands import upgrade_mito_installer
 from mitoinstaller.installer_steps.installer_step import InstallerStep
@@ -11,18 +12,14 @@ def initial_install_step_create_user():
 
     # If the user has no static install ID, create one
     if static_user_id is None:
-        try_create_user_json_file(is_pro=False)
-    
-    identify()
-    log('install_started', {
-        'mitoinstaller_version': __version__
-    })
+        try_create_user_json_file(is_pro=('--pro' in sys.argv))
 
-
-def initial_install_step_create_pro_user():
-    # Try and create the user.json file, or at least
-    # update mitosheet_telemetry if it is not already true
-    try_create_user_json_file(is_pro=True)
+    # Only try and log if we're not pro
+    if not ('--pro' in sys.argv):
+        identify()
+        log('install_started', {
+            'mitoinstaller_version': __version__
+        })
 
 
 INITIAL_INSTALLER_STEPS = [
@@ -31,18 +28,8 @@ INITIAL_INSTALLER_STEPS = [
         initial_install_step_create_user
     ),
     InstallerStep(
-        'Upgrading mitoinstaller',
-        upgrade_mito_installer
-    ),
-]
-
-INITIAL_INSTALLER_STEPS_PRO = [
-    InstallerStep(
-        'Create pro mito user',
-        initial_install_step_create_pro_user
-    ),
-    InstallerStep(
-        'Upgrading mitoinstaller',
-        upgrade_mito_installer
+        'Upgrade mitoinstaller',
+        upgrade_mito_installer,
+        optional=True
     ),
 ]

--- a/mitoinstaller/mitoinstaller/installer_steps/installer_step.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/installer_step.py
@@ -1,6 +1,8 @@
 
 from typing import Callable
 
+from mitoinstaller.log_utils import log, log_error
+
 
 class InstallerStep:
     """
@@ -9,6 +11,10 @@ class InstallerStep:
 
     If you label a step as optional, then although this step may fail,
     it will not stop the InstallerSteps after it from executing.
+
+    NOTE: install steps themselves should not log anything. All the logging
+    is handeled by the run_installer_steps function, which dramatically
+    clarifies when things go wrong.
     """
     def __init__(self, 
         installer_step_name: str, 
@@ -18,6 +24,13 @@ class InstallerStep:
         self.installer_step_name = installer_step_name
         self.execution_function = execution_function
         self.optional = optional
+
+    @property
+    def event_name(self):
+        return self.installer_step_name.replace(' ', '_').lower()
     
     def execute(self) -> None:
         self.execution_function()
+
+    def log_failure(self) -> None:
+        log_error(self.event_name + '_failed')

--- a/mitoinstaller/mitoinstaller/installer_steps/installer_step_utils.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/installer_step_utils.py
@@ -8,11 +8,25 @@ from mitoinstaller.installer_steps.installer_step import InstallerStep
 
 def run_installer_steps(installer_steps: List[InstallerStep]) -> None:
     """
-    A helper function that runs a list of InstallerSteps. This function
-    handles running the steps, and:
-    1. Logs if they succed
-    2. Logs if they fail
-    3. If a non-optional step fails, then terminates the program
+    A helper function for running a list of InstallerStep. This function
+    handles the running and logging of the steps. 
+
+    Our logging strategy meets the following form:
+    1. If the user is a pro user, we log nothing. Duh. 
+    2. Otherwise, if the user is not a pro user:
+        -   When the installer is started, we always generate `install_started` log
+        -   If the installer fails, we generate a log specific to the log step that
+            failed, as well as a `install_failed` log. 
+    
+    Thus, if there is an `install_stared` log, and no `install_failed` log, we can
+    conclude that install finished correctly. 
+
+    Notably, we cannot log if the install finishes correctly (and thus have to use
+    the above logic) because we attempt to replace the installer process with 
+    JupyterLab, which means we can no longer log. 
+
+    This cleanup and consistency in logging is primarily meant to make debugging
+    installer issues easier!
     """
 
     for installer_step in installer_steps:
@@ -30,7 +44,7 @@ def run_installer_steps(installer_steps: List[InstallerStep]) -> None:
             # with an error message for the user
             if not installer_step.optional:
                 # Do one major log if we fail, so that we can easily tell what happened
-                log_error('installer_failed')
+                log_error('install_failed', {'installer_step_name': installer_step.installer_step_name})
                 # I think we should prompt users to do this, defaulting to Yes!
                 exit_after_error()
 

--- a/mitoinstaller/mitoinstaller/installer_steps/installer_step_utils.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/installer_step_utils.py
@@ -1,3 +1,4 @@
+from mitoinstaller.commands import exit_after_error
 from mitoinstaller.log_utils import log_error
 import traceback
 from typing import List
@@ -5,30 +6,32 @@ from typing import List
 from mitoinstaller.installer_steps.installer_step import InstallerStep
 
 
-def run_installer_steps(installer_steps: List[InstallerStep]) -> bool:
+def run_installer_steps(installer_steps: List[InstallerStep]) -> None:
     """
-    A helper function that runs the installer steps, returning
-    True if they all terminate without error, and False if any
-    of them return with an error.
+    A helper function that runs a list of InstallerSteps. This function
+    handles running the steps, and:
+    1. Logs if they succed
+    2. Logs if they fail
+    3. If a non-optional step fails, then terminates the program
     """
 
     for installer_step in installer_steps:
         try:
             # Print the step name, so the user knows what's going on
             print(installer_step.installer_step_name)
+
+            # Execute the step
             installer_step.execute()
         except:
-            # Log the error. Print if it's not an optional step
-            log_error(installer_step.installer_step_name, print_to_user=(not installer_step.optional))
+            # Log that we failed on this step
+            installer_step.log_failure()
 
-            # If we error on a non optional step, then return False
-            # and continue if it was an optional step
-            if installer_step.optional:
-                continue
-            else:
-                return False
-    
-    return True
-
+            # If the install step is not optional, log that the install failed and exit
+            # with an error message for the user
+            if not installer_step.optional:
+                # Do one major log if we fail, so that we can easily tell what happened
+                log_error('installer_failed')
+                # I think we should prompt users to do this, defaulting to Yes!
+                exit_after_error()
 
     

--- a/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
@@ -19,15 +19,6 @@ def install_step_mitosheet_check_dependencies():
 
     jupyterlab_version, extension_names = get_jupyterlab_metadata()
 
-    # We log if the user is upgrading their mitosheet extension
-    if extension_names is not None and ('mitosheet' in extension_names or 'mitosheet2' in extension_names or 'mitosheet3' in extension_names):
-        log('upgrading_mitosheet_labextension',
-            {
-                'jupyterlab_version': jupyterlab_version,
-                'extension_names': extension_names
-            }
-        )
-
     # If no JupyterLab is installed, we can continue with install, as
     # there are no conflict dependencies
     if jupyterlab_version is None:
@@ -64,7 +55,7 @@ def install_step_mitosheet_install_mitosheet():
 
 MITOSHEET_INSTALLER_STEPS = [
     InstallerStep(
-        'Checking dependencies',
+        'Check dependencies',
         install_step_mitosheet_check_dependencies
     ),
     InstallerStep(
@@ -72,7 +63,7 @@ MITOSHEET_INSTALLER_STEPS = [
         remove_mitosheet_3_if_present
     ),
     InstallerStep(
-        'Installing mitosheet',
+        'Install mitosheet',
         install_step_mitosheet_install_mitosheet
     ),
 ]

--- a/mitoinstaller/mitoinstaller/log_utils.py
+++ b/mitoinstaller/mitoinstaller/log_utils.py
@@ -7,18 +7,18 @@ to the user.
 """
 import getpass
 import platform
+import sys
 import traceback
 from typing import Any, Dict
-import sys
 
 import analytics
-from termcolor import colored # type: ignore
 
 analytics.write_key = '6I7ptc5wcIGC4WZ0N1t0NXvvAbjRGUgX' 
 
 from mitoinstaller import __version__
-from mitoinstaller.user_install import (get_mitosheet_telemetry, get_static_user_id, is_running_test,
-                                        user_json_only_has_static_user_id)
+from mitoinstaller.user_install import (get_mitosheet_telemetry,
+                                        get_static_user_id, is_running_test,
+                                        user_json_is_installer_default)
 
 
 def is_on_kuberentes_mito() -> bool:
@@ -46,7 +46,7 @@ def identify() -> None:
     static_user_id = get_static_user_id()
     operating_system = platform.system()
 
-    if user_json_only_has_static_user_id() and not is_running_test():
+    if user_json_is_installer_default() and not is_running_test():
         analytics.identify(
             static_user_id,
             {
@@ -57,19 +57,13 @@ def identify() -> None:
             }
         )
 
-def log_error(event: str, params: Dict[str, Any]=None, print_to_user: bool=True) -> None:
+def log_error(event: str, params: Dict[str, Any]=None) -> None:
     """
-    Logs an error by optionally printing the traceback to the user, before
-    actually logging it.
+    Logs an error by adding the traceback to the error, for easier 
+    debugging.
     """
     if params is None:
         params = {}
-    
-    # First, we print the traceback, to make live debugging easier
-    if print_to_user:
-        print(colored(traceback.format_exc(), 'red'))
-        if (len(params) > 0):
-            print(colored(str(params), 'red'))
 
     recent_traceback = traceback.format_exc().strip().split('\n')
     # Then, we log it

--- a/mitoinstaller/mitoinstaller/user_install.py
+++ b/mitoinstaller/mitoinstaller/user_install.py
@@ -35,7 +35,9 @@ def is_running_test() -> bool:
 # otherwise does nothing with the user_json file. This makes sure
 # we keep the dependencies as simple as possible with this file. 
 # We also add the telemetry, which we turn off if the user has a 
-# pro subscription
+# pro subscription.
+# NOTE: if you delete a field from this, you need to update the 
+# user_json_is_installer_default to handle this properly
 USER_JSON_DEFAULT = {
     'static_user_id': get_random_id() if not is_running_test() else 'github_action',
     'mitosheet_telemetry': True,

--- a/mitoinstaller/mitoinstaller/user_install.py
+++ b/mitoinstaller/mitoinstaller/user_install.py
@@ -80,14 +80,18 @@ def get_mitosheet_telemetry() -> bool:
     except: 
         return True
 
-def user_json_only_has_static_user_id() -> bool:
+def user_json_is_installer_default() -> bool:
     """
-    Returns True if the user.json file only has the static_user_id in it
-    and otherwise returns False
+    Returns True if the user.json file is the installer default, 
+    and otherwise returns False. 
+
+    This allows us to not call identify if we have already done
+    so in the mitosheet package (which would overwrite things
+    we don't want to).
     """
     try:
         with open(USER_JSON_PATH) as f:
             user_json_object = json.load(f)
-            return len(user_json_object) == 1 and 'static_user_id' in user_json_object
+            return len(user_json_object) <= len(USER_JSON_DEFAULT)
     except:
         return False

--- a/mitoinstaller/tests/test_upgrades.py
+++ b/mitoinstaller/tests/test_upgrades.py
@@ -1,7 +1,10 @@
 import json
-import pytest
+
+from mitoinstaller.user_install import (USER_JSON_PATH, get_static_user_id,
+                                        user_json_is_installer_default)
+
 from tests.conftest import VirtualEnvironment
-from mitoinstaller.user_install import USER_JSON_PATH, get_static_user_id
+
 
 def test_upgrade_with_mitosheet3_moves_to_mitosheet(venv: VirtualEnvironment):
     # Setup what most of our old users used to have
@@ -38,7 +41,6 @@ def test_user_json_only_has_static_user_id():
         f.write(json.dumps({
             'static_user_id': 'github_action'
         }))
-    from mitoinstaller.user_install import user_json_is_installer_default
     
     assert user_json_is_installer_default()
 

--- a/mitoinstaller/tests/test_upgrades.py
+++ b/mitoinstaller/tests/test_upgrades.py
@@ -38,14 +38,19 @@ def test_user_json_only_has_static_user_id():
         f.write(json.dumps({
             'static_user_id': 'github_action'
         }))
-    from mitoinstaller.user_install import user_json_only_has_static_user_id
+    from mitoinstaller.user_install import user_json_is_installer_default
     
-    assert user_json_only_has_static_user_id()
+    assert user_json_is_installer_default()
 
     with open(USER_JSON_PATH, 'w+') as f:
         f.write(json.dumps({
             'static_user_id': 'github_action',
-            'other': 'nah'
+            'other': 'nah',
+            'other1': 'nah',
+            'other2': 'nah',
+            'other3': 'nah',
+            'other4': 'nah',
+            'other5': 'nah',
         }))
 
-    assert not user_json_only_has_static_user_id()
+    assert not user_json_is_installer_default()


### PR DESCRIPTION
# Description

This PR is high priority, as it does a few things:
1. It cleans up our logging in our installer - so we can actually tell what is happening. Things were very messy and inconsistent before, which mostly meant it's pretty much impossible to figure out when/why things are failing.
2. Fixes a bug where many install attempts were not logged (namely, those where users never ran an import mitosheet call), because the identify function was not calling the underlying analytics.identify due to a non-updated guard to stop profile overwriting.

Notably, to do so, I further simplify the architecture of the installer. It's pretty damn simple now, and should be really understandable. As before, I'm continually realizing that simplicity is of the _upmost_ importance here, because debugging it otherwise is pretty much impossible (given the varied places it exists).

# Testing

The command I use:
`rm -rf ~/.mito/user.json; deactivate; rm -rf venv; python3 -m venv venv; source venv/bin/activate; pip install -r requirements.txt; python -m mitoinstaller install`

Test the following:
1. Run the installer, get logs
2. Run the installer with `--pro`, get logs
3. Do Control + C during some random steps, get logs
4. Add `raise Exception()` to random steps in random places, run installer, and make sure it still generates logs that work properly.

NOTE: a major part of this is making sure that the logs make sense. Specifically, our logging strategy is documented in the `run_installer_steps` comment - *make sure that we meet this specification and that you can tell what happened based on the logs, given the test you ran.* 

Being able to debug from the logs is the most important part of this PR!

# Documentation

No.