### PR TITLE
mitosheet: add starts with and endswith string filters

### DIFF
--- a/mitosheet/mitosheet/step_performers/filter.py
+++ b/mitosheet/mitosheet/step_performers/filter.py
@@ -31,6 +31,8 @@ FC_STRING_CONTAINS = "contains"
 FC_STRING_DOES_NOT_CONTAIN = "string_does_not_contain"
 FC_STRING_EXACTLY = "string_exactly"
 FC_STRING_NOT_EXACTLY = "string_not_exactly"
+FC_STRING_STARTS_WITH = "string_starts_with"
+FC_STRING_ENDS_WITH = "string_ends_with"
 
 FC_NUMBER_EXACTLY = "number_exactly"
 FC_NUMBER_NOT_EXACTLY = "number_not_exactly"
@@ -66,6 +68,8 @@ FILTER_FORMAT_STRING_DICT = {
     FC_STRING_DOES_NOT_CONTAIN: "~{df_name}[{transpiled_column_header}].str.contains('{value}', na=False)",
     FC_STRING_EXACTLY: "{df_name}[{transpiled_column_header}] == '{value}'",
     FC_STRING_NOT_EXACTLY: "{df_name}[{transpiled_column_header}] != '{value}'",
+    FC_STRING_STARTS_WITH: "{df_name}[{transpiled_column_header}].str.startswith('{value}', na=False)",
+    FC_STRING_ENDS_WITH: "{df_name}[{transpiled_column_header}].str.endswith('{value}', na=False)",
     # DATES
     FC_DATETIME_EXACTLY: "{df_name}[{transpiled_column_header}] == pd.to_datetime('{value}')",
     FC_DATETIME_NOT_EXACTLY: "{df_name}[{transpiled_column_header}] != pd.to_datetime('{value}')",
@@ -133,6 +137,14 @@ FILTER_FORMAT_STRING_MULTIPLE_VALUES_DICT = {
     FC_STRING_NOT_EXACTLY: {
         "Or": "{df_name}[{transpiled_column_header}].apply(lambda val: any(val != s for s in {values}))",
         "And": "{df_name}[{transpiled_column_header}].apply(lambda val: all(val != s for s in {values}))",
+    },
+    FC_STRING_STARTS_WITH: {
+        "Or": "{df_name}[{transpiled_column_header}].apply(lambda val: any(str(val).startswith(s) for s in {values}))",
+        "And": "{df_name}[{transpiled_column_header}].apply(lambda val: all(str(val).startswith(s) for s in {values}))",
+    },
+    FC_STRING_ENDS_WITH: {
+        "Or": "{df_name}[{transpiled_column_header}].apply(lambda val: any(str(val).endswith(s) for s in {values}))",
+        "And": "{df_name}[{transpiled_column_header}].apply(lambda val: all(str(val).endswith(s) for s in {values}))",
     },
     FC_DATETIME_EXACTLY: {
         "Or": "{df_name}[{transpiled_column_header}].isin({values})",
@@ -366,8 +378,12 @@ def get_applied_filter(
     # Then string
     if condition == FC_STRING_CONTAINS:
         return df[column_header].str.contains(value, na=False)
-    if condition == FC_STRING_DOES_NOT_CONTAIN:
+    elif condition == FC_STRING_DOES_NOT_CONTAIN:
         return ~df[column_header].str.contains(value, na=False)
+    elif condition == FC_STRING_STARTS_WITH:
+        return df[column_header].str.startswith(value, na=False)
+    elif condition == FC_STRING_ENDS_WITH:
+        return df[column_header].str.endswith(value, na=False)
     elif condition == FC_STRING_EXACTLY:
         return df[column_header] == value
     elif condition == FC_STRING_NOT_EXACTLY:

--- a/mitosheet/mitosheet/tests/steps_performers/test_filter.py
+++ b/mitosheet/mitosheet/tests/steps_performers/test_filter.py
@@ -33,6 +33,8 @@ from mitosheet.step_performers.filter import (
     FC_STRING_DOES_NOT_CONTAIN,
     FC_STRING_EXACTLY,
     FC_STRING_NOT_EXACTLY,
+    FC_STRING_STARTS_WITH,
+    FC_STRING_ENDS_WITH,
 )
 from mitosheet.tests.test_utils import create_mito_wrapper, create_mito_wrapper_dfs
 
@@ -180,6 +182,18 @@ FILTER_TESTS = [
         FC_STRING_DOES_NOT_CONTAIN,
         "1",
         pd.DataFrame(data={"A": ["3", "4", "5", "6"]}, index=list(range(2, 6))),
+    ),
+    (
+        pd.DataFrame(data={"A": ["1", "12", "31"]}),
+        FC_STRING_STARTS_WITH,
+        "1",
+        pd.DataFrame(data={"A": ["1", "12"]}),
+    ),
+    (
+        pd.DataFrame(data={"A": ["12", "122222", "31"]}),
+        FC_STRING_ENDS_WITH,
+        "2",
+        pd.DataFrame(data={"A": ["12", "122222"]}),
     ),
     (
         pd.DataFrame(data={"A": ["1", "12", "3", "4", "5", "6"]}),
@@ -873,6 +887,38 @@ FILTER_TESTS_MULTIPLE_VALUES_PER_CONDITION = [
         1,
         2,
         "df1 = df1[df1['A'].apply(lambda val: any(val <= n for n in [1, 2]))]",
+    ),
+    (
+        pd.DataFrame({"A": ["123", "1334", "4567"]}),
+        FC_STRING_STARTS_WITH,
+        "And",
+        "1",
+        "12",
+        "df1 = df1[df1['A'].apply(lambda val: all(str(val).startswith(s) for s in ['1', '12']))]",
+    ),
+    (
+        pd.DataFrame({"A": ["123", "1334", "4567"]}),
+        FC_STRING_STARTS_WITH,
+        "Or",
+        "1",
+        "4",
+        "df1 = df1[df1['A'].apply(lambda val: any(str(val).startswith(s) for s in ['1', '4']))]",
+    ),
+    (
+        pd.DataFrame({"A": ["123", "1334", "4567"]}),
+        FC_STRING_ENDS_WITH,
+        "And",
+        "1",
+        "12",
+        "df1 = df1[df1['A'].apply(lambda val: all(str(val).endswith(s) for s in ['1', '12']))]",
+    ),
+    (
+        pd.DataFrame({"A": ["123", "1334", "4567"]}),
+        FC_STRING_ENDS_WITH,
+        "Or",
+        "1",
+        "4",
+        "df1 = df1[df1['A'].apply(lambda val: any(str(val).endswith(s) for s in ['1', '4']))]",
     ),
     (
         pd.DataFrame(

--- a/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/filter/filterConditions.tsx
+++ b/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/filter/filterConditions.tsx
@@ -26,6 +26,8 @@ export const STRING_SELECT_OPTIONS: Record<StringFilterCondition, string> = {
     ['string_does_not_contain']: 'does not contain',
     ['string_exactly']: 'is exactly',
     ['string_not_exactly']: 'is not exactly',
+    ['string_starts_with']: 'starts with',
+    ['string_ends_with']: 'ends with',
     ['empty']: 'is empty',
     ['not_empty']: 'is not empty'
 } 

--- a/mitosheet/src/types.tsx
+++ b/mitosheet/src/types.tsx
@@ -79,6 +79,8 @@ export type StringFilterCondition = 'contains'
 | 'string_does_not_contain'
 | 'string_exactly'
 | 'string_not_exactly'
+| 'string_starts_with'
+| 'string_ends_with'
 | 'empty'
 | 'not_empty'
 


### PR DESCRIPTION
# Description

Closes #138 

# Testing

See tests. Test in Mito. Note that on Mixed type data, our current string filtering does not perform well when combining different types into multiple filter conditions (namely, `na=None` is not how we combine things in the multi-filter conditions - where we type cast). 

A note on the tests for the "combining filter conditions" for future reference:
1. We no longer test transpired code directly (I think when these were written, we used to do so).
2. The string condition aggregation isn't tested at all, let alone with mixed data types.

Instead of fixing these issues, I opened an issue here: https://github.com/mito-ds/monorepo/issues/139

# Documentation

Nope.