### PR TITLE
mitosheet: add 6 new graph types, remove ctas and limitations

### DIFF
--- a/docs/how-to/graphing.md
+++ b/docs/how-to/graphing.md
@@ -7,14 +7,23 @@ description: This documentation explains how to create exploratory graphs in Mit
 {% embed url="https://youtu.be/LG-NoFdEZAI" %}
 
 
-
 Mito's graphing functionality is designed to help you explore your dataset. By supporting Plotly graphs, Mito users can create interactive graphs, drill down on data points inside those graphs, and zoom in/out to see the right amount of detail.&#x20;
 
-Mito graphs come in many shapes and sizes (literally!). Mito supports bar charts, box plots, histograms, and scatter plots. Mito/Plotly graphs also support adding multiple series to each axis. For example, creating a stacked graph is a helpful tool for identifying relationships between series along a common attribute.&#x20;
+Mito graphs come in many shapes and sizes. Mito currently supports the graph types:
+1. Scatter 
+2. Line
+3. Bar
+4. Histogram
+5. Box
+6. Violin
+7. Strip
+8. ECDF (Empirical Cumulative Distribution Function)
+9. Density heatmap
+10. Density Contour
+
+You can add mulitple columns to an axis to better understand your data. For example, creating a stacked graph is a helpful tool for identifying relationships between series along a common attribute.&#x20;
 
 To create a graph, click the **Graph** button in the Mito toolbar. In the the graph sidebar that appears, use the configuration settings to create the graph. Use the **select dropdowns** to set the chart type and add series to each axis.
-
-The grey subtext that may appear in the graph sidebar will explain why certain functionality may/may not yet be supported, and provide you a way to request new graphing features. &#x20;
 
 ![](<../.gitbook/assets/final mito graphing.png>)
 

--- a/mitosheet/mitosheet/step_performers/graph/graph_utils.py
+++ b/mitosheet/mitosheet/step_performers/graph/graph_utils.py
@@ -12,16 +12,28 @@ import plotly.graph_objects as go
 
 # Graph types should be kept consistent with the GraphType in GraphSidebar.tsx
 SCATTER = "scatter"
+LINE = "line"
 BAR = "bar"
 HISTOGRAM = "histogram"
 BOX = "box"
+STRIP = "strip"
+VIOLIN = "violin"
+ECDF = "ecdf"
+DENSITY_HEATMAP = "density heatmap"
+DENSITY_CONTOUR = "density contour"
 
 # Label for each type of graph used in the graph title
 GRAPH_TITLE_LABELS = {
     SCATTER: "scatter plot",
+    LINE: "line",
     BAR: "bar chart",
     BOX: "box plot",
     HISTOGRAM: "histogram",
+    STRIP: "strip",
+    VIOLIN: "violin",
+    ECDF: "ecdf",
+    DENSITY_HEATMAP: "density heatmap",
+    DENSITY_CONTOUR: "density contour",
 }
 
 

--- a/mitosheet/mitosheet/step_performers/graph/plotly_express_graphs.py
+++ b/mitosheet/mitosheet/step_performers/graph/plotly_express_graphs.py
@@ -4,24 +4,19 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 
-from typing import List, Union, Dict, Tuple
+from typing import Dict, List, Tuple, Union
+
 import pandas as pd
-from mitosheet.transpiler.transpile_utils import (
-    column_header_list_to_transpiled_code,
-    column_header_to_transpiled_code,
-)
-from mitosheet.types import ColumnHeader
 import plotly.express as px
 import plotly.graph_objects as go
-from mitosheet.step_performers.graph.graph_utils import (
-    BAR,
-    BOX,
-    HISTOGRAM,
-    SCATTER,
-    create_parameter,
-    get_barmode,
-    get_graph_title,
-)
+from mitosheet.step_performers.graph.graph_utils import (BAR, BOX, DENSITY_CONTOUR, DENSITY_HEATMAP, ECDF, HISTOGRAM,
+                                                         LINE, SCATTER, STRIP, VIOLIN,
+                                                         create_parameter,
+                                                         get_barmode,
+                                                         get_graph_title)
+from mitosheet.transpiler.transpile_utils import (
+    column_header_list_to_transpiled_code, column_header_to_transpiled_code)
+from mitosheet.types import ColumnHeader
 
 # TAB is used in place of \t in generated code because
 # Jupyter turns \t into a grey arrow, but converts four spaces into a tab.
@@ -96,22 +91,34 @@ def graph_creation(
     if len(x_axis_column_headers) == 1:
         # Note: In the new interface, x will always have a length of 0 or 1
         all_params["x"] = x_axis_column_headers[0]
-    if len(x_axis_column_headers) > 1:
+    elif len(x_axis_column_headers) > 1:
         all_params["x"] = x_axis_column_headers
 
     if len(y_axis_column_headers) == 1:
         all_params["y"] = y_axis_column_headers[0]
-    if len(y_axis_column_headers) > 1:
+    elif len(y_axis_column_headers) > 1:
         all_params["y"] = y_axis_column_headers
 
     if graph_type == BOX:
         return px.box(df, **all_params)
-    if graph_type == HISTOGRAM:
+    elif graph_type == HISTOGRAM:
         return px.histogram(df, **all_params)
-    if graph_type == BAR:
+    elif graph_type == BAR:
         return px.bar(df, **all_params)
-    if graph_type == SCATTER:
+    elif graph_type == SCATTER:
         return px.scatter(df, **all_params)
+    elif graph_type == LINE:
+        return px.line(df, **all_params)
+    elif graph_type == VIOLIN:
+        return px.violin(df, **all_params)
+    elif graph_type == STRIP:
+        return px.strip(df, **all_params)
+    elif graph_type == ECDF:
+        return px.ecdf(df, **all_params)
+    elif graph_type == DENSITY_HEATMAP:
+        return px.density_heatmap(df, **all_params)
+    elif graph_type == DENSITY_CONTOUR:
+        return px.density_contour(df, **all_params)
 
 
 def graph_creation_code(
@@ -151,12 +158,24 @@ def graph_creation_code(
 
     if graph_type == BOX:
         return f"fig = px.box({df_name}, {params})"
-    if graph_type == HISTOGRAM:
+    elif graph_type == HISTOGRAM:
         return f"fig = px.histogram({df_name}, {params})"
-    if graph_type == BAR:
+    elif graph_type == BAR:
         return f"fig = px.bar({df_name}, {params})"
-    if graph_type == SCATTER:
+    elif graph_type == SCATTER:
         return f"fig = px.scatter({df_name}, {params})"
+    elif graph_type == LINE:
+        return f"fig = px.line({df_name}, {params})"
+    elif graph_type == VIOLIN:
+        return f"fig = px.violin({df_name}, {params})"
+    elif graph_type == STRIP:
+        return f"fig = px.strip({df_name}, {params})"
+    elif graph_type == ECDF:
+        return f"fig = px.ecdf({df_name}, {params})"
+    elif graph_type == DENSITY_HEATMAP:
+        return f"fig = px.density_heatmap({df_name}, {params})"
+    elif graph_type == DENSITY_CONTOUR:
+        return f"fig = px.density_contour({df_name}, {params})"
     return ""
 
 

--- a/mitosheet/mitosheet/step_performers/graph/plotly_express_graphs.py
+++ b/mitosheet/mitosheet/step_performers/graph/plotly_express_graphs.py
@@ -99,26 +99,26 @@ def graph_creation(
     elif len(y_axis_column_headers) > 1:
         all_params["y"] = y_axis_column_headers
 
-    if graph_type == BOX:
-        return px.box(df, **all_params)
-    elif graph_type == HISTOGRAM:
-        return px.histogram(df, **all_params)
-    elif graph_type == BAR:
+    if graph_type == BAR:
         return px.bar(df, **all_params)
-    elif graph_type == SCATTER:
-        return px.scatter(df, **all_params)
     elif graph_type == LINE:
         return px.line(df, **all_params)
+    elif graph_type == SCATTER:
+        return px.scatter(df, **all_params)
+    elif graph_type == HISTOGRAM:
+        return px.histogram(df, **all_params)
+    elif graph_type == DENSITY_HEATMAP:
+        return px.density_heatmap(df, **all_params)
+    elif graph_type == DENSITY_CONTOUR:
+        return px.density_contour(df, **all_params)
+    elif graph_type == BOX:
+        return px.box(df, **all_params)
     elif graph_type == VIOLIN:
         return px.violin(df, **all_params)
     elif graph_type == STRIP:
         return px.strip(df, **all_params)
     elif graph_type == ECDF:
         return px.ecdf(df, **all_params)
-    elif graph_type == DENSITY_HEATMAP:
-        return px.density_heatmap(df, **all_params)
-    elif graph_type == DENSITY_CONTOUR:
-        return px.density_contour(df, **all_params)
 
 
 def graph_creation_code(
@@ -156,26 +156,26 @@ def graph_creation_code(
         create_parameter(param[0], param[1], param[2]) for param in all_params
     )
 
-    if graph_type == BOX:
-        return f"fig = px.box({df_name}, {params})"
-    elif graph_type == HISTOGRAM:
-        return f"fig = px.histogram({df_name}, {params})"
-    elif graph_type == BAR:
+    if graph_type == BAR:
         return f"fig = px.bar({df_name}, {params})"
-    elif graph_type == SCATTER:
-        return f"fig = px.scatter({df_name}, {params})"
     elif graph_type == LINE:
         return f"fig = px.line({df_name}, {params})"
+    elif graph_type == SCATTER:
+        return f"fig = px.scatter({df_name}, {params})"
+    elif graph_type == HISTOGRAM:
+        return f"fig = px.histogram({df_name}, {params})"
+    elif graph_type == DENSITY_HEATMAP:
+        return f"fig = px.density_heatmap({df_name}, {params})"
+    elif graph_type == DENSITY_CONTOUR:
+        return f"fig = px.density_contour({df_name}, {params})"
+    elif graph_type == BOX:
+        return f"fig = px.box({df_name}, {params})"
     elif graph_type == VIOLIN:
         return f"fig = px.violin({df_name}, {params})"
     elif graph_type == STRIP:
         return f"fig = px.strip({df_name}, {params})"
     elif graph_type == ECDF:
         return f"fig = px.ecdf({df_name}, {params})"
-    elif graph_type == DENSITY_HEATMAP:
-        return f"fig = px.density_heatmap({df_name}, {params})"
-    elif graph_type == DENSITY_CONTOUR:
-        return f"fig = px.density_contour({df_name}, {params})"
     return ""
 
 

--- a/mitosheet/src/components/taskpanes/Graph/AxisSection.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/AxisSection.tsx
@@ -38,7 +38,7 @@ const AxisSection = (props: {
 }): JSX.Element => {
 
     // Filter the column headers that the user can select to only the columns that are the correct type for the graph
-    let selectableColumnIDs: ColumnID[] = Object.keys(props.columnIDsMap);
+    const selectableColumnIDs: ColumnID[] = Object.keys(props.columnIDsMap);
 
     // Create Large Selects and delete buttons for each of the columns that have already been selected
     const selectedColumnHeaderSelects = props.selectedColumnIDs.map((columnID, i) => {

--- a/mitosheet/src/components/taskpanes/Graph/AxisSection.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/AxisSection.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Mito
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import MitoAPI from '../../../api';
 import XIcon from '../../icons/XIcon';
 import { GraphType } from './GraphSidebar';
@@ -13,7 +13,6 @@ import '../../../../css/taskpanes/Graph/AxisSection.css'
 import { ColumnID, ColumnIDsMap } from '../../../types';
 import DropdownItem from '../../elements/DropdownItem';
 import { getDisplayColumnHeader } from '../../../utils/columnHeaders';
-import { isNumberDtype } from '../../../utils/dtypes';
 
 
 export enum GraphAxisType {
@@ -38,55 +37,8 @@ const AxisSection = (props: {
     mitoAPI: MitoAPI;
 }): JSX.Element => {
 
-    /* 
-        Save the cta for each of the possible subtexts. We save a subtext for each one 
-        so that changing one cta does not change all of them. 
-    */
-    const [disableDueToSingleAxisGraphCTA, setDisableDueToSingleAxisGraphCTA] = useState<string | undefined>(undefined)
-    const [disabledDueToKeySeriesRequirementCTA, setDisabledDueToKeySeriesCTARequirementCTA] = useState<string | undefined>(undefined)
-    const [disabledDueToMaxSeriesReachedCTA, setDisabledDueToMaxSeriesReachedCTA] = useState<string | undefined>(undefined)
-
-    useEffect(() => {
-        if (disableDueToSingleAxisGraphCTA !== undefined) {
-            logCtaClick('Single Axis Graph')
-        }
-    }, [disableDueToSingleAxisGraphCTA])
-
-    useEffect(() => {
-        if (disabledDueToKeySeriesRequirementCTA !== undefined) {
-            logCtaClick('Key Series Required')
-        }
-    }, [disabledDueToKeySeriesRequirementCTA])
-
-    useEffect(() => {
-        if (disabledDueToMaxSeriesReachedCTA !== undefined) {
-            logCtaClick('Max Series Reached')
-        }
-    }, [disabledDueToMaxSeriesReachedCTA])
-
-    const logCtaClick = (ctaClicked: string) => {
-        const x_axis_column_ids = props.graphAxis === GraphAxisType.X_AXIS ? props.selectedColumnIDs : props.otherAxisSelectedColumnIDs
-        const y_axis_column_ids = props.graphAxis === GraphAxisType.Y_AXIS ? props.selectedColumnIDs : props.otherAxisSelectedColumnIDs
-
-        void props.mitoAPI.log('graph_cta_clicked', {
-            'graph_type': props.graphType,
-            'axis': props.graphAxis,
-            'x_axis_column_ids': x_axis_column_ids,
-            'y_axis_column_ids': y_axis_column_ids,
-            'cta_clicked': ctaClicked
-        });
-    }
-
     // Filter the column headers that the user can select to only the columns that are the correct type for the graph
-    let selectableColumnIDs: ColumnID[] = []
-    if (props.graphType === GraphType.BOX || props.graphType === GraphType.HISTOGRAM) {
-        selectableColumnIDs = Object.keys(props.columnIDsMap).filter(columnID => {
-            return isNumberDtype(props.columnDtypesMap[columnID])
-        })
-    } else {
-        // If the graph is not a Box plot of Histogram, then any column can be selected.
-        selectableColumnIDs = Object.keys(props.columnIDsMap);
-    }
+    let selectableColumnIDs: ColumnID[] = Object.keys(props.columnIDsMap);
 
     // Create Large Selects and delete buttons for each of the columns that have already been selected
     const selectedColumnHeaderSelects = props.selectedColumnIDs.map((columnID, i) => {
@@ -129,22 +81,8 @@ const AxisSection = (props: {
     const numSelectedColumns = props.selectedColumnIDs.length
     const numOtherAxisSelectedColumns = props.otherAxisSelectedColumnIDs.length
 
-    /* 
-        1. If the graph type selected only supports one axis, and the other axis already has a series, 
-        then don't let the user add a series to this axis
-    */
-    const disableDueToSingleAxisGraphBool =
-        (props.graphType === GraphType.BOX || props.graphType === GraphType.HISTOGRAM) &&
-        numOtherAxisSelectedColumns > 0
-
-    /* 
-        2. If the axis only has 1 series, but the other axis has more than 1 series, then you can't add more series
-        to this axis because we don't let users stack on both columns. 
-    */
-    const disabledDueToKeySeriesRequirementBool = numSelectedColumns === 1 && numOtherAxisSelectedColumns > 1
-
     /* 3. If there are already four series being graphed, then don't let the user add another series */
-    const disabledDueToMaxSeriesReachedBool = numSelectedColumns + numOtherAxisSelectedColumns >= 4
+    const disabledDueToMaxSeriesReachedBool = numSelectedColumns + numOtherAxisSelectedColumns >= 10
 
     return (
         <div className='axis-section-container'>
@@ -158,7 +96,7 @@ const AxisSection = (props: {
                     <DropdownButton
                         text='+ Add'
                         width='small'
-                        disabled={disableDueToSingleAxisGraphBool || disabledDueToKeySeriesRequirementBool || disabledDueToMaxSeriesReachedBool}
+                        disabled={disabledDueToMaxSeriesReachedBool}
                         searchable
                     >
                         {selectableColumnIDs.map(columnID => {
@@ -180,44 +118,9 @@ const AxisSection = (props: {
                     </DropdownButton>
                 </Col>
             </Row>
-            {/* At most one of the three subtext messages are displayed */}
-            {disableDueToSingleAxisGraphBool &&
+            {disabledDueToMaxSeriesReachedBool &&
                 <div className='text-subtext-1 text-align-left'>
-                    {props.graphType}s only support one axis.&nbsp;
-                    {disableDueToSingleAxisGraphCTA === undefined ?
-                        <a className='axis-section-cta' onClick={() => {
-                            setDisableDueToSingleAxisGraphCTA("Thanks! Coming Soon. ")
-                        }}>
-                            Want to use both axises?
-                        </a> :
-                        <>{disableDueToSingleAxisGraphCTA}</>
-                    }
-                </div>
-            }
-            {!disableDueToSingleAxisGraphBool && disabledDueToKeySeriesRequirementBool &&
-                <div className='text-subtext-1 text-align-left'>
-                    You can only have multiple series on one axis at a time.&nbsp;
-                    {disabledDueToKeySeriesRequirementCTA === undefined ?
-                        <a className='axis-section-cta' onClick={() => {
-                            setDisabledDueToKeySeriesCTARequirementCTA("Thanks! Coming Soon. ")
-                        }}>
-                            Want to stack both axises?
-                        </a> :
-                        <>{disabledDueToKeySeriesRequirementCTA}</>
-                    }
-                </div>
-            }
-            {!disableDueToSingleAxisGraphBool && !disabledDueToKeySeriesRequirementBool && disabledDueToMaxSeriesReachedBool &&
-                <div className='text-subtext-1 text-align-left'>
-                    You can only graph four series at once.&nbsp;
-                    {disabledDueToMaxSeriesReachedCTA === undefined ?
-                        <a className='axis-section-cta' onClick={() => {
-                            setDisabledDueToMaxSeriesReachedCTA("Thanks! Coming Soon. ")
-                        }}>
-                            Want more?
-                        </a> :
-                        <>{disabledDueToMaxSeriesReachedCTA}</>
-                    }
+                    You can only graph ten series at once.
                 </div>
             }
             {selectedColumnHeaderSelects}

--- a/mitosheet/src/components/taskpanes/Graph/GraphSidebar.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/GraphSidebar.tsx
@@ -247,8 +247,8 @@ const GraphSidebar = (props: {
     }
 
     const setGraphType = (graphType: GraphType) => {
-        let xAxisColumnIDsCopy = [...graphParams.graphCreation.x_axis_column_ids]
-        let yAxisColumnIDsCopy = [...graphParams.graphCreation.y_axis_column_ids]
+        const xAxisColumnIDsCopy = [...graphParams.graphCreation.x_axis_column_ids]
+        const yAxisColumnIDsCopy = [...graphParams.graphCreation.y_axis_column_ids]
 
         // Update the graph type
         setGraphParams(prevGraphParams => {

--- a/mitosheet/src/components/taskpanes/Graph/GraphSidebar.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/GraphSidebar.tsx
@@ -17,17 +17,23 @@ import DropdownItem from '../../elements/DropdownItem';
 import '../../../../css/taskpanes/Graph/GraphSidebar.css'
 import '../../../../css/taskpanes/Graph/LoadingSpinner.css'
 import DefaultEmptyTaskpane from '../DefaultTaskpane/DefaultEmptyTaskpane';
-import { isNumberDtype } from '../../../utils/dtypes';
 import Toggle from '../../elements/Toggle';
 import usePrevious from '../../../hooks/usePrevious';
 import { useDebouncedEffect } from '../../../hooks/useDebouncedEffect';
 
 export enum GraphType {
     SCATTER = 'scatter',
+    LINE = 'line',
     BAR = 'bar',
     HISTOGRAM = 'histogram',
     BOX = 'box',
+    VIOLIN = 'violin',
+    STRIP = 'strip',
+    ECDF = 'ecdf',
+    DENSITY_HEATMAP = 'density heatmap',
+    DENSITY_CONTOUR = 'density contour',
 }
+
 
 // Millisecond delay between loading graphs, so that
 // we don't load to many graphs when the user is clicking around
@@ -240,44 +246,9 @@ const GraphSidebar = (props: {
         setGraphUpdatedNumber((old) => old + 1);
     }
 
-    const removeNonNumberColumnIDs = (columnIDs: ColumnID[]) => {
-        const filteredColumnIDs = columnIDs.filter(columnID => {
-            return props.columnDtypesMap !== undefined && isNumberDtype(props.columnDtypesMap[columnID])
-        })
-        return filteredColumnIDs
-    }
-
     const setGraphType = (graphType: GraphType) => {
         let xAxisColumnIDsCopy = [...graphParams.graphCreation.x_axis_column_ids]
         let yAxisColumnIDsCopy = [...graphParams.graphCreation.y_axis_column_ids]
-
-        /* 
-            If the user switches to a Box plot or Histogram, then we make sure that
-            1. all of the selected columns are numbers. 
-            2. there are not columns in both the x and y axis. 
-        */
-        if (graphType === GraphType.BOX || graphType === GraphType.HISTOGRAM) {
-            xAxisColumnIDsCopy = removeNonNumberColumnIDs(xAxisColumnIDsCopy)
-            yAxisColumnIDsCopy = removeNonNumberColumnIDs(yAxisColumnIDsCopy)
-
-            // Make sure that only one axis has selected column headers. 
-            if (xAxisColumnIDsCopy.length > 0 && yAxisColumnIDsCopy.length > 0) {
-                yAxisColumnIDsCopy = []
-            }
-        }
-
-        // Log that we reset the selected columns
-        if (xAxisColumnIDsCopy.length !== graphParams.graphCreation.x_axis_column_ids.length || 
-            yAxisColumnIDsCopy.length !== graphParams.graphCreation.y_axis_column_ids.length) {
-            void props.mitoAPI.log('reset_graph_columns_on_graph_type_change');
-        }
-
-        // Log that the user switched graph types
-        void props.mitoAPI.log('switched_graph_type', {
-            'graph_type': graphType,
-            'x_axis_column_ids': xAxisColumnIDsCopy,
-            'y_axis_column_ids': yAxisColumnIDsCopy,
-        });
 
         // Update the graph type
         setGraphParams(prevGraphParams => {
@@ -450,18 +421,31 @@ const GraphSidebar = (props: {
                                     dropdownWidth='medium'
                                 >
                                     <DropdownItem
-                                        title={GraphType.BAR}
-                                    />
-                                    <DropdownItem
                                         title={GraphType.BOX}
-                                        subtext='Only supports number columns'
                                     />
                                     <DropdownItem
                                         title={GraphType.HISTOGRAM}
-                                        subtext='Only supports number columns'
                                     />
                                     <DropdownItem
                                         title={GraphType.SCATTER}
+                                    />
+                                    <DropdownItem
+                                        title={GraphType.LINE}
+                                    />
+                                    <DropdownItem
+                                        title={GraphType.VIOLIN}
+                                    />
+                                    <DropdownItem
+                                        title={GraphType.STRIP}
+                                    />
+                                    <DropdownItem
+                                        title={GraphType.ECDF}
+                                    />
+                                    <DropdownItem
+                                        title={GraphType.DENSITY_HEATMAP}
+                                    />
+                                    <DropdownItem
+                                        title={GraphType.DENSITY_CONTOUR}
                                     />
                                 </Select>
                             </Col>

--- a/mitosheet/src/components/taskpanes/Graph/GraphSidebar.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/GraphSidebar.tsx
@@ -161,11 +161,6 @@ const GraphSidebar = (props: {
         }
     }, [props.lastStepIndex])
 
-    // We log when the graph has been opened
-    useEffect(() => {
-        void props.mitoAPI.log('opened_graph');
-    }, []);
-
     // Async load in the data from the mitoAPI
     useDebouncedEffect(() => {
         // If we haven't updated the graph yet, then don't send a new graph message so that 
@@ -365,7 +360,6 @@ const GraphSidebar = (props: {
                                             currOpenTaskpane: { type: TaskpaneType.NONE }
                                         }
                                     })
-                                    void props.mitoAPI.log('closed_graph')
                                 }}
                             />
                         </Col>

--- a/mitosheet/src/components/taskpanes/Graph/GraphSidebar.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/GraphSidebar.tsx
@@ -22,16 +22,16 @@ import usePrevious from '../../../hooks/usePrevious';
 import { useDebouncedEffect } from '../../../hooks/useDebouncedEffect';
 
 export enum GraphType {
-    SCATTER = 'scatter',
-    LINE = 'line',
     BAR = 'bar',
+    LINE = 'line',
+    SCATTER = 'scatter',
     HISTOGRAM = 'histogram',
+    DENSITY_HEATMAP = 'density heatmap',
+    DENSITY_CONTOUR = 'density contour',
     BOX = 'box',
     VIOLIN = 'violin',
     STRIP = 'strip',
     ECDF = 'ecdf',
-    DENSITY_HEATMAP = 'density heatmap',
-    DENSITY_CONTOUR = 'density contour',
 }
 
 
@@ -415,16 +415,25 @@ const GraphSidebar = (props: {
                                     dropdownWidth='medium'
                                 >
                                     <DropdownItem
-                                        title={GraphType.BOX}
+                                        title={GraphType.BAR}
                                     />
                                     <DropdownItem
-                                        title={GraphType.HISTOGRAM}
+                                        title={GraphType.LINE}
                                     />
                                     <DropdownItem
                                         title={GraphType.SCATTER}
                                     />
                                     <DropdownItem
-                                        title={GraphType.LINE}
+                                        title={GraphType.HISTOGRAM}
+                                    />
+                                    <DropdownItem
+                                        title={GraphType.DENSITY_HEATMAP}
+                                    />
+                                    <DropdownItem
+                                        title={GraphType.DENSITY_CONTOUR}
+                                    />
+                                    <DropdownItem
+                                        title={GraphType.BOX}
                                     />
                                     <DropdownItem
                                         title={GraphType.VIOLIN}
@@ -434,12 +443,6 @@ const GraphSidebar = (props: {
                                     />
                                     <DropdownItem
                                         title={GraphType.ECDF}
-                                    />
-                                    <DropdownItem
-                                        title={GraphType.DENSITY_HEATMAP}
-                                    />
-                                    <DropdownItem
-                                        title={GraphType.DENSITY_CONTOUR}
                                     />
                                 </Select>
                             </Col>


### PR DESCRIPTION
# Description

See title. I went through plotly express and added every graph that supports and x and y axis: https://plotly.com/python/plotly-express/.

In the future, we can extend to support many more of these graph types (we just need to change up the interface to communicate to the user which params they need to pass).

The main question I have: what order should we put these in? We should put them in a good default order, and then standardize across the codebase (e.g. in the definitions and if statements). @aarondr77 if you wanna go for this, do it!

# Testing

Test new graph types, and generated code works!

# Documentation

Yes, a list of graph types are added.