### PR TITLE
mitosheet: don't clear analysis if it doesn't exist

### DIFF
--- a/mitosheet/mitosheet/errors.py
+++ b/mitosheet/mitosheet/errors.py
@@ -377,6 +377,25 @@ def make_is_directory_error(file_name: str) -> MitoError:
     )
 
 
+def make_no_analysis_error(analysis_id: str, error_modal: bool=True) -> MitoError:
+    """
+    Helper function for creating a no_analysis_error.
+
+    Occurs when a user tries to replay an analysis that they don't have access to in 
+    their .mito folder
+    """
+    to_fix = f'When you call mitosheet.sheet() and there is a code cell below that contains an analysis ID, \
+    Mito tries to replay that analysis. However, you do not have access to the analysis {analysis_id} so Mito is unable to replay it. \
+    Add a new code cell below the mitosheet.sheet() call to start a new analysis.' 
+    
+    return MitoError(
+        'no_analysis_error', 
+        "You don't have access to the analysis",
+        to_fix,
+        error_modal=error_modal
+    )
+
+
 ARG_FULL_NAME = {
     'int': 'number',
     'float': 'number',

--- a/mitosheet/mitosheet/updates/replay_analysis.py
+++ b/mitosheet/mitosheet/updates/replay_analysis.py
@@ -8,6 +8,7 @@ Replays an existing analysis onto the sheet
 """
 
 from typing import Any, Dict
+from mitosheet.errors import make_no_analysis_error
 
 from mitosheet.mito_analytics import log
 from mitosheet.saved_analyses import read_and_upgrade_analysis
@@ -37,6 +38,13 @@ def execute_replay_analysis_update(
     state container (except the initalize step) before applying the saved analysis.
     """
 
+    # If we're getting an event telling us to update, we read in the steps from the file
+    analysis = read_and_upgrade_analysis(analysis_name)
+    # If there is no analysis with this name, give up
+    if analysis is None:
+        log('replayed_nonexistant_analysis_failed')
+        raise make_no_analysis_error(analysis_name)
+
     # We only keep the intialize step only, if we want to clear,
     # and also update the analysis name to the replayed analysis
     # NOTE: we update the analysis name so that when the code
@@ -46,13 +54,6 @@ def execute_replay_analysis_update(
     if clear_existing_analysis:
         steps_manager.steps = steps_manager.steps[:1]
         steps_manager.analysis_name = analysis_name
-
-    # If we're getting an event telling us to update, we read in the steps from the file
-    analysis = read_and_upgrade_analysis(analysis_name)
-    # If there is no analysis with this name, give up
-    if analysis is None:
-        log('replayed_nonexistant_analysis_failed')
-        return
 
     # When replaying an analysis with import events, you can also send over
     # new params to the import events to replace them. We replace them in the steps here

--- a/mitosheet/mitosheet/updates/replay_analysis.py
+++ b/mitosheet/mitosheet/updates/replay_analysis.py
@@ -40,7 +40,10 @@ def execute_replay_analysis_update(
 
     # If we're getting an event telling us to update, we read in the steps from the file
     analysis = read_and_upgrade_analysis(analysis_name)
-    # If there is no analysis with this name, give up
+
+    # If there is no analysis with this name, generate an error. This must occur before  
+    # steps_manager.steps = steps_manager.steps[:1] so that we don't clear all of the user's generated code. 
+    # This is particularly important for users who received the notebook from a colleague.
     if analysis is None:
         log('replayed_nonexistant_analysis_failed')
         raise make_no_analysis_error(analysis_name)

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -332,34 +332,6 @@ function activateWidgetExtension(
         }
     });
 
-
-    app.commands.addCommand('repeat-analysis', {
-        label: 'Replicates the current analysis on a given new file, in a new cell.',
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        execute: (args: any) => {
-
-            const fileName = args.fileName as string;
-
-            // We get the current notebook (currentWidget)
-            const notebook = tracker.currentWidget?.content;
-            const context = tracker.currentWidget?.context;
-            if (!notebook || !context) return;
-
-            // We run the current cell and insert a cell below
-            // TODO: see if handling this promise is good enough!
-            void NotebookActions.runAndInsert(notebook, context.sessionContext);
-
-            // And then we write to this inserted cell (which is now the active cell)
-            const activeCell = notebook.activeCell;
-            if (activeCell) {
-                const value = activeCell.model.modelDB.get('value') as IObservableString;
-                const df_name = fileName.replace(' ', '_').split('.')[0]; // We replace common file names with a dataframe name
-                const code = `# Repeated analysis on ${fileName}\n\n${df_name} = pd.read_csv('${fileName}')\n\nmito_analysis(${df_name})\n\nmitosheet.sheet(${df_name})`
-                value.text = code;
-            }
-        }
-    });
-
     app.commands.addCommand('get-args', {
         label: 'Reads the arguments passed to the mitosheet.sheet call',
         execute: (): string[] => {


### PR DESCRIPTION
# Description

Previously, if a user replayed an analysis that they didn't have access to in their .mito folder, it would completely clear all of their generated code. This isn't generally an issue for users, but I spoke with a user that is sharing notebooks back and forth via OneDrive and was concerned about deleting their colleague's work. 

Now, if the analysis doesn't exist, we just give an error that explains what is happening (along with the log you've already created) and we don't clear the analysis. 

# Testing

1. Create an analysis
2. Change the analysis ID
3. Rerun the analysis and notice that an error appears instead of clearing out the generated code. 

- [x] I have tested this on real data that is reasonable and large
- [x] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.