### PR TITLE
Graph bug fixes from usability test

### DIFF
--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -213,7 +213,6 @@ export const Mito = (props: MitoProps): JSX.Element => {
             return {
                 ...prevUIState,
                 selectedSheetIndex: newSheetIndex,
-                selectedTabType: 'data'
             };
         })
 

--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -30,7 +30,7 @@ import LoadingIndicator from './LoadingIndicator';
 import ErrorModal from './modals/ErrorModal';
 import MitoAPI from '../api';
 import PivotTaskpane from './taskpanes/PivotTable/PivotTaskpane';
-import { EDITING_TASKPANES, TaskpaneType, FULLSCREEN_TASKPANES } from './taskpanes/taskpanes';
+import { EDITING_TASKPANES, TaskpaneType } from './taskpanes/taskpanes';
 import MergeTaskpane from './taskpanes/Merge/MergeTaskpane';
 import ControlPanelTaskpane, { ControlPanelTab } from './taskpanes/ControlPanel/ControlPanelTaskpane';
 import SignUpModal from './modals/SignupModal';
@@ -200,6 +200,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
         // Make sure that the selectedSheetIndex is always >= 0 so we can index into the 
         // widthDataArray without erroring
         setUIState(prevUIState => {
+
             const prevSelectedSheetIndex = prevUIState.selectedSheetIndex;
             let newSheetIndex = prevSelectedSheetIndex;
 
@@ -211,7 +212,8 @@ export const Mito = (props: MitoProps): JSX.Element => {
             
             return {
                 ...prevUIState,
-                selectedSheetIndex: newSheetIndex
+                selectedSheetIndex: newSheetIndex,
+                selectedTabType: 'data'
             };
         })
 
@@ -284,6 +286,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
                             destinationSheetIndex: uiState.selectedSheetIndex,
                             existingPivotParams: existingPivotParams
                         },
+                        selectedTabType: 'data'
                     }
                 })
             }
@@ -569,8 +572,8 @@ export const Mito = (props: MitoProps): JSX.Element => {
     }
 
     const taskpaneOpen = uiState.currOpenTaskpane.type !== TaskpaneType.NONE;
-    const fullscreenTaskpaneOpen = FULLSCREEN_TASKPANES.includes(uiState.currOpenTaskpane.type);
-    const narrowTaskpaneOpen = taskpaneOpen && !fullscreenTaskpaneOpen;
+    const graphTaskpaneOpen = uiState.currOpenTaskpane.type === TaskpaneType.GRAPH && uiState.selectedTabType === 'graph';
+    const narrowTaskpaneOpen = taskpaneOpen && !graphTaskpaneOpen;
 
     /* 
         We detect whether the taskpane is open in wide mode, narrow mode, or not open at all. We then
@@ -578,15 +581,18 @@ export const Mito = (props: MitoProps): JSX.Element => {
         The class sets the width of the sheet. 
     */
     const formulaBarAndSheetClassNames = classNames('mito-formula-bar-and-mitosheet-div', {
-        'mito-formula-bar-and-mitosheet-div-fullscreen-taskpane-open': fullscreenTaskpaneOpen,
+        'mito-formula-bar-and-mitosheet-div-fullscreen-taskpane-open': graphTaskpaneOpen,
         'mito-formula-bar-and-mitosheet-div-narrow-taskpane-open': narrowTaskpaneOpen
     })
 
     const taskpaneClassNames = classNames({
         'mito-default-taskpane': !taskpaneOpen,
-        'mito-default-fullscreen-taskpane-open': fullscreenTaskpaneOpen,
+        'mito-default-fullscreen-taskpane-open': graphTaskpaneOpen,
         'mito-default-narrow-taskpane-open': narrowTaskpaneOpen,
     })
+
+
+    console.log("MITO", uiState.selectedTabType, taskpaneOpen, graphTaskpaneOpen, narrowTaskpaneOpen)
 
     return (
         <div className="mito-container" data-jp-suppress-context-menu ref={mitoContainerRef}>

--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -591,9 +591,6 @@ export const Mito = (props: MitoProps): JSX.Element => {
         'mito-default-narrow-taskpane-open': narrowTaskpaneOpen,
     })
 
-
-    console.log("MITO", uiState.selectedTabType, taskpaneOpen, graphTaskpaneOpen, narrowTaskpaneOpen)
-
     return (
         <div className="mito-container" data-jp-suppress-context-menu ref={mitoContainerRef}>
             <ErrorBoundary mitoAPI={props.mitoAPI}>

--- a/mitosheet/src/components/footer/Footer.tsx
+++ b/mitosheet/src/components/footer/Footer.tsx
@@ -32,6 +32,8 @@ function Footer(props: FooterProps): JSX.Element {
     const selectedGraphID = props.uiState.selectedGraphID
     const selectedTabType = props.uiState.selectedTabType
 
+    console.log("FOOTER", selectedTabType)
+
     // Get the sheet index to display the rows and columns of. 
     // If the sheet tab is a graph, then display the info from the data being graphed 
     const sheetIndex = selectedTabType === 'graph' && selectedGraphID !== undefined && props.graphDataDict[selectedGraphID] !== undefined ? 

--- a/mitosheet/src/components/footer/Footer.tsx
+++ b/mitosheet/src/components/footer/Footer.tsx
@@ -32,8 +32,6 @@ function Footer(props: FooterProps): JSX.Element {
     const selectedGraphID = props.uiState.selectedGraphID
     const selectedTabType = props.uiState.selectedTabType
 
-    console.log("FOOTER", selectedTabType)
-
     // Get the sheet index to display the rows and columns of. 
     // If the sheet tab is a graph, then display the info from the data being graphed 
     const sheetIndex = selectedTabType === 'graph' && selectedGraphID !== undefined && props.graphDataDict[selectedGraphID] !== undefined ? 

--- a/mitosheet/src/components/taskpanes/taskpanes.tsx
+++ b/mitosheet/src/components/taskpanes/taskpanes.tsx
@@ -69,9 +69,4 @@ export const EDITING_TASKPANES: TaskpaneType[] = [
     TaskpaneType.DROP_DUPLICATES,
     TaskpaneType.DOWNLOAD,
 ]
-
-export const FULLSCREEN_TASKPANES: TaskpaneType[] = [
-    TaskpaneType.GRAPH
-]
-
     


### PR DESCRIPTION
# Description

- [x] [[Init.py](http://init.py/)](http://Init.py) is missing in deployed version, bc of a merge conflict resolution I did badly, I think.
- [x] If you: import data, create a graph, make a pivot table, and then rerun the top cell, it ends up with the graph selected but the wrong sheet tab selected. We should fix this, obvi.
- [ ] The double message that gets sent out, which causes users to need to click undo twice to get rid of a newly created graph.

I don't have a good way of doing this one. We want:
1. To update the graph if the underlying data has been edited
2. To not update the graph when the user opens it otherwise.

I don't think both of these things are possible, without a backend implementation of "refresh_dependent_graphs" - which IMO would be really horribly annoying and not worth it. Thoughts?

- [ ] Jake felt like the loading indicator for the graph showed up a little bit late. Maybe we can make the loading indicator be a normal effect, and then the actual backend call in a debounced effect. ← I actually don’t think we should fix this, because it will lead to weird race conditions that are not good to debug at *all*.


# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.