### PR TITLE
Strip path from tracebacks

### DIFF
--- a/.github/workflows/test-mitoinstaller.yml
+++ b/.github/workflows/test-mitoinstaller.yml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         python-version: [3.6, 3.8]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        exclude:
+          - python-version: 3.6
+            os: 'windows-latest'
     runs-on: ${{ matrix.os }}
     steps:
     - name: Cancel Previous Runs

--- a/mitoinstaller/mitoinstaller/log_utils.py
+++ b/mitoinstaller/mitoinstaller/log_utils.py
@@ -7,6 +7,7 @@ to the user.
 """
 import getpass
 import platform
+import re
 import sys
 import traceback
 from typing import Any, Dict
@@ -57,6 +58,15 @@ def identify() -> None:
             }
         )
 
+def get_recent_traceback() -> str:
+    """
+    Helper function that returns the most recent traceback, with the file paths
+    stripped to remove all but the mitosheet file names for ease in debugging.
+    
+    Inspired by https://stackoverflow.com/questions/25272368/hide-file-from-traceback
+    """
+    return re.sub(r'File ".*[\\/]([^\\/]+.py)"', r'File "\1"', traceback.format_exc())
+
 def log_error(event: str, params: Dict[str, Any]=None) -> None:
     """
     Logs an error by adding the traceback to the error, for easier 
@@ -65,7 +75,7 @@ def log_error(event: str, params: Dict[str, Any]=None) -> None:
     if params is None:
         params = {}
 
-    recent_traceback = traceback.format_exc().strip().split('\n')
+    recent_traceback = get_recent_traceback().strip().split('\n')
     # Then, we log it
     log(
         event,

--- a/mitosheet/mitosheet/errors.py
+++ b/mitosheet/mitosheet/errors.py
@@ -13,6 +13,7 @@ MitoError box to avoid creating too many new classes!
 See more about why we use errors here: 
 https://stackoverflow.com/questions/16138232/is-it-a-good-practice-to-use-try-except-else-in-python
 """
+import re
 import traceback
 from typing import Any, Collection, Set, List
 
@@ -431,7 +432,13 @@ def make_operator_type_error(operator: str, arg_one_type: str, arg_two_type: str
     )
 
 def get_recent_traceback() -> str:
-    return traceback.format_exc()
+    """
+    Helper function that returns the most recent traceback, with the file paths
+    stripped to remove all but the mitosheet file names for ease in debugging.
+    
+    Inspired by https://stackoverflow.com/questions/25272368/hide-file-from-traceback
+    """
+    return re.sub(r'File ".*[\\/]([^\\/]+.py)"', r'File "\1"', traceback.format_exc())
 
 def get_recent_traceback_as_list() -> List[str]:
     """
@@ -444,4 +451,4 @@ def get_recent_traceback_as_list() -> List[str]:
     and thus we avoid things getting chopped this way.
     """
     # NOTE: We ignore empty lines, as they add no information
-    return [line for line in traceback.format_exc().split('\n') if line != '']
+    return [line for line in get_recent_traceback().split('\n') if line != '']


### PR DESCRIPTION
# Description

Makes it so we get no path unnecessary path information in our tracebacks.

# Testing

Generate error logs with installer and with the mitosheet package, and make sure they only have the last file name. After we merge them (NOTE: after we do the deploy), let's test this on windows as well!

# Documentation

No.