### PR TITLE
mitosheet: log notebook version

### DIFF
--- a/mitosheet/mitosheet/mito_analytics.py
+++ b/mitosheet/mitosheet/mito_analytics.py
@@ -39,6 +39,10 @@ try:
     from jupyterlab import __version__ as jupyterlab_version
 except:
     jupyterlab_version = 'No JupyterLab'
+try:
+    from notebook import __version__ as notebook_version
+except:
+    notebook_version = 'No notebook'
 
 import analytics
 
@@ -187,6 +191,7 @@ def log(log_event: str, params: Dict[Any, Any]=None, steps_manager: StepsManager
     python_properties = {
         'version_python': sys.version_info,
         'version_jupyterlab': jupyterlab_version,
+        'version_notebook': notebook_version,
         'version_mito': __version__,
         'package_name': package_name,
         'location': location,
@@ -309,6 +314,7 @@ def identify() -> None:
             'version_mito': __version__,
             'package_name': package_name, 
             'version_jupyterlab': jupyterlab_version,
+            'version_notebook': notebook_version,
             'operating_system': operating_system,
             'email': user_email,
             'local': local,


### PR DESCRIPTION
# Description

Per this investigation, adds a log so we know what version of notebooks to build for: https://www.notion.so/trymito/Jupyter-Versions-640b9f8459c04daa9b4ffb7420d920d8

# Testing

Test it logs notebook version.

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.