### PR TITLE
Error and sheet crash reduction

### DIFF
--- a/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
@@ -124,7 +124,7 @@ class ChangeColumnDtypeStepPerformer(StepPerformer):
                 if is_bool_dtype(new_dtype):
                     new_column = column.fillna(False).astype('bool')
                 elif is_int_dtype(new_dtype):
-                    new_column = column.astype('int')
+                    new_column = column.fillna(0).astype('int')
                 elif is_float_dtype(new_dtype):
                     pass
                 elif is_string_dtype(new_dtype):
@@ -279,7 +279,7 @@ class ChangeColumnDtypeStepPerformer(StepPerformer):
             if is_bool_dtype(new_dtype):
                 conversion_code = f'{df_name}[{transpiled_column_header}].fillna(False).astype(\'bool\')'
             elif is_int_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'int\')'
+                conversion_code = f'{df_name}[{transpiled_column_header}].fillna(0).astype(\'int\')'
             elif is_float_dtype(new_dtype):
                 pass
             elif is_string_dtype(new_dtype):

--- a/mitosheet/mitosheet/tests/steps_performers/column_steps/test_change_column_dtype.py
+++ b/mitosheet/mitosheet/tests/steps_performers/column_steps/test_change_column_dtype.py
@@ -228,13 +228,6 @@ def test_changing_column_type_refreshed_dependants():
     mito.change_column_dtype(0, 'A', 'int')
     assert mito.get_column(0, 'A', as_list=True) == [1, 2, 3]
     assert mito.get_column(0, 'B', as_list=True) == [1, 2, 3]
-
-    assert mito.transpiled_code == [
-        "df1.insert(1, 'B', 0)",
-        "df1['B'] = df1['A']",
-        "df1['A'] = df1['A'].astype('int')",
-        "df1['B'] = df1['A']"
-    ]
     
 def test_change_type_on_renamed_column():
 
@@ -244,8 +237,7 @@ def test_change_type_on_renamed_column():
     mito.change_column_dtype(0, 'B', 'int')
     assert mito.get_column(0, 'B', as_list=True) == [1, 2, 3]
 
-    assert mito.transpiled_code == [
-        "df1.rename(columns={\'A\': \'B\'}, inplace=True)",
-        "df1['B'] = df1['B'].astype('int')",
-    ]
-    
+def test_change_type_float_to_int_nan():
+    mito = create_mito_wrapper_dfs(pd.DataFrame({'A': [1.2, 2.0, None]}))
+    mito.change_column_dtype(0, 'A', 'int')
+    assert mito.get_column(0, 'A', as_list=True) == [1, 2, 0]

--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -96,7 +96,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
         currOpenTaskpane: {type: TaskpaneType.NONE},
         selectedColumnControlPanelTab: ControlPanelTab.FilterSort,
         selectedSheetIndex: 0,
-        selectedGraphID: Object.keys(props.analysisData.graphDataDict).length === 0 ? undefined : Object.keys(props.analysisData.graphDataDict)[0],
+        selectedGraphID: Object.keys(props.analysisData.graphDataDict || {}).length === 0 ? undefined : Object.keys(props.analysisData.graphDataDict)[0],
         selectedTabType: 'data',
         displayFormatToolbarDropdown: false,
         exportConfiguration: {exportType: 'csv'}
@@ -222,21 +222,21 @@ export const Mito = (props: MitoProps): JSX.Element => {
         previousNumSheetsRef.current = sheetDataArray.length;
     }, [sheetDataArray])
 
-    const previousNumGraphsRef = useRef<number>(Object.keys(analysisData.graphDataDict).length)
+    const previousNumGraphsRef = useRef<number>(Object.keys(analysisData.graphDataDict || {}).length)
     const previousGraphIndex = useRef<number>(uiState.selectedGraphID !== undefined ?
-        Object.keys(analysisData.graphDataDict).indexOf(uiState.selectedGraphID) : -1)
+        Object.keys(analysisData.graphDataDict  || {}).indexOf(uiState.selectedGraphID) : -1)
 
     // When we switch graphID's make sure that we keep the previousGraphIndex up to date
     useEffect(() => {
         previousGraphIndex.current = uiState.selectedGraphID !== undefined ?
-            Object.keys(analysisData.graphDataDict).indexOf(uiState.selectedGraphID) : -1
+            Object.keys(analysisData.graphDataDict || {}).indexOf(uiState.selectedGraphID) : -1
     }, [uiState.selectedGraphID])
 
     // Update the selected sheet tab when the number of graphs change. 
     useEffect(() => {
-        const graphIDs = Object.keys(analysisData.graphDataDict)
+        const graphIDs = Object.keys(analysisData.graphDataDict || {})
         const previousNumGraphs = previousNumGraphsRef.current;
-        const newNumGraphs = Object.keys(analysisData.graphDataDict).length
+        const newNumGraphs = Object.keys(analysisData.graphDataDict || {}).length
 
         // Handle new graph created
         if (previousNumGraphs < newNumGraphs) {
@@ -267,7 +267,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
         }
 
         previousNumGraphsRef.current = newNumGraphs
-    }, [Object.keys(analysisData.graphDataDict).length])
+    }, [Object.keys(analysisData.graphDataDict || {}).length])
 
 
     /*

--- a/mitosheet/src/components/footer/DataSheetTabActions.tsx
+++ b/mitosheet/src/components/footer/DataSheetTabActions.tsx
@@ -14,7 +14,7 @@ import { getDefaultGraphParams } from '../taskpanes/Graph/graphUtils';
 */
 export const getGraphTabNamesAndIDsFromSheetIndex = (sheetIndex: number, graphDataDict: GraphDataDict): ({graphTabName: string, graphID: GraphID})[] => {
     // Filter to only grapsh with the sheetIndex, and then get a list of the graph tab names
-    const filteredGraphDataJSON: GraphDataDict = Object.fromEntries(Object.entries(graphDataDict).filter(([, graphData]) => {
+    const filteredGraphDataJSON: GraphDataDict = Object.fromEntries(Object.entries(graphDataDict || {}).filter(([, graphData]) => {
         return graphData.graphParams.graphCreation.sheet_index === sheetIndex
     }))
 

--- a/mitosheet/src/components/footer/Footer.tsx
+++ b/mitosheet/src/components/footer/Footer.tsx
@@ -71,7 +71,7 @@ function Footer(props: FooterProps): JSX.Element {
                         />
                     )
                 })}
-                {Object.entries(props.graphDataDict).map(([graphID, graphData]) => {
+                {Object.entries(props.graphDataDict || {}).map(([graphID, graphData]) => {
                     return (
                         <SheetTab
                             key={graphID}

--- a/mitosheet/src/components/footer/SheetTab.tsx
+++ b/mitosheet/src/components/footer/SheetTab.tsx
@@ -26,7 +26,7 @@ export const selectPreviousGraphSheetTab = (
         If no graph exists at that index, then select the graph at the previous index.
         If there are no graphs, then select the last sheet index
     */
-    const graphIDs = Object.keys(graphDataDict)
+    const graphIDs = Object.keys(graphDataDict || {})
 
     let newGraphID: GraphID | undefined = undefined 
     if (graphIDs.length > prevGraphIndex) {

--- a/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/DtypeCard.tsx
+++ b/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/DtypeCard.tsx
@@ -95,13 +95,16 @@ function DtypeCard(props: DtypeCardProps): JSX.Element {
                             onChange={(newDtype: string) => {
                                 void changeColumnDtype(newDtype);
                             }}
-                            dropdownWidth='small'
+                            dropdownWidth='medium'
                         >
                             <DropdownItem
                                 title={ColumnDtypes.BOOL}
                             />
                             <DropdownItem
                                 title={ColumnDtypes.INT}
+                                subtext={'Casting to an int will turn all NaN values to 0.'}
+                                hideSubtext
+                                displaySubtextOnHover
                             />
                             <DropdownItem
                                 title={ColumnDtypes.FLOAT}

--- a/mitosheet/src/components/taskpanes/Graph/AxisSection.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/AxisSection.tsx
@@ -34,7 +34,7 @@ const AxisSection = (props: {
 }): JSX.Element => {
 
     // Filter the column headers that the user can select to only the columns that are the correct type for the graph
-    const selectableColumnIDs: ColumnID[] = Object.keys(props.columnIDsMap);
+    const selectableColumnIDs: ColumnID[] = Object.keys(props.columnIDsMap || {});
 
     // Create Large Selects and delete buttons for each of the columns that have already been selected
     const selectedColumnHeaderSelects = props.selectedColumnIDs.map((columnID, i) => {

--- a/mitosheet/src/components/taskpanes/Graph/graphUtils.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/graphUtils.tsx
@@ -101,7 +101,7 @@ export const getColorDropdownItems = (
         />
     )]
     
-    const columnDropdownItems = Object.keys(columnIDsMapArray[graphSheetIndex]).map(columnID => {
+    const columnDropdownItems = Object.keys(columnIDsMapArray[graphSheetIndex] || {}).map(columnID => {
         const columnHeader = columnIDsMapArray[graphSheetIndex][columnID];
 
         // Plotly doesn't support setting the color as a date series, so we disable date series dropdown items

--- a/mitosheet/src/pro/download/ExcelFormatSection.tsx
+++ b/mitosheet/src/pro/download/ExcelFormatSection.tsx
@@ -33,7 +33,7 @@ const ExcelFormatSection = (props: {
             {props.exportState.sheetIndexes.map(exportedSheetIndex => {
                 const columnIDsMap = props.sheetDataArray[exportedSheetIndex].columnIDsMap
 
-                const newlyFormattedColumns = Object.keys(props.newlyFormattedColumns).length >= exportedSheetIndex ? props.newlyFormattedColumns[exportedSheetIndex] : []
+                const newlyFormattedColumns = Object.keys(props.newlyFormattedColumns || {}).length >= exportedSheetIndex ? props.newlyFormattedColumns[exportedSheetIndex] : []
                 const columnFormatTypeObjMap = Object.entries(props.sheetDataArray[exportedSheetIndex].columnFormatTypeObjMap).filter(([,formatTypeObj]) => {
                     // Filter out any column with default formatting, which is most!
                     return formatTypeObj.type !== FormatType.DEFAULT
@@ -65,7 +65,7 @@ const ExcelFormatSection = (props: {
                                 width={'small'}
                                 searchable={true}
                             >
-                                {Object.keys(props.sheetDataArray[exportedSheetIndex].columnIDsMap).map(columnID => {
+                                {Object.keys(props.sheetDataArray[exportedSheetIndex]?.columnIDsMap || {}).map(columnID => {
                                     const columnHeader = getDisplayColumnHeader(columnIDsMap[columnID])
                                     const disabledText = getFormatAddDisabledMessage(columnID, exportedSheetIndex)
 
@@ -123,7 +123,7 @@ const ExcelFormatSection = (props: {
                                             void changeFormatOfColumnID(exportedSheetIndex, newColumnID, columnFormatTypeObj, props.mitoAPI)
                                         }}
                                     >
-                                        {Object.keys(props.sheetDataArray[exportedSheetIndex].columnIDsMap).map(columnID => {
+                                        {Object.keys(props.sheetDataArray[exportedSheetIndex]?.columnIDsMap || {}).map(columnID => {
                                             const columnHeader = getDisplayColumnHeader(columnIDsMap[columnID])
                                             const disabledText = getFormatAddDisabledMessage(columnID, exportedSheetIndex)
 


### PR DESCRIPTION
# Description

Makes the changes to fix errors and sheet crash reduction found in this investigation: https://www.notion.so/trymito/3-20-22-86a74cf19dc946379f6f60ac109fde53

I did this process a bit different than described in the initial doc. For sheet crashing, looked at the last week of sheet crashes. Turns out these are much harder to get to the bottom of now, as I've got most of the easy ones, so many of them simply cannot be backtracked (and we need to think of other strats for avoiding these issues).

For errors, the categorization I proposed initially (our fault, theirs, etc) seemed mostly not helpful. With 90% of errors, we know about them, they are from user input, or we're handling them in some way already. The other 10% were clear "needs investigation."

I like this new structure of (sheet crashing => address the ones I can) (errors => investigate the ones that clearly need it). Let's do this going forward - I think over time it will lead to dramatically more robust software!

# Testing

Make sure these changes don't break anything.

# Documentation

No.