### PR TITLE
mitosheet: make us copy less dataframes

### DIFF
--- a/mitosheet/mitosheet/state.py
+++ b/mitosheet/mitosheet/state.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 from collections import OrderedDict
 from copy import deepcopy
-from typing import Any, Collection, List, Dict, Set
+from typing import Any, Collection, List, Dict, Optional, Set
 import pandas as pd
 
 from mitosheet.column_headers import ColumnIDMap
@@ -121,29 +121,17 @@ class State:
         # This is helpful for undoing, for example. 
         self.graph_data_dict: OrderedDict[str, Dict[str, Any]] = graph_data_dict if graph_data_dict is not None else OrderedDict()
 
-    def __copy__(self):
+    def copy(self, deep_sheet_indexes: Optional[List[int]]=None) -> "State":
         """
-        If you copy a state using the copy() function, this Python
-        function is called, and returns a shallow copy of the state
+        Returns a copy of the state, while only making deep copies of
+        those dataframes in the deep_sheet_indexes. Ideally, we'd copy
+        even less than that deeply.
         """
+        if deep_sheet_indexes is None:
+            deep_sheet_indexes = []
+        
         return State(
-            [df.copy(deep=False) for df in self.dfs],
-            df_names=deepcopy(self.df_names),
-            df_sources=deepcopy(self.df_sources),
-            column_ids=deepcopy(self.column_ids),
-            column_spreadsheet_code=deepcopy(self.column_spreadsheet_code),
-            column_filters=deepcopy(self.column_filters),
-            column_format_types=deepcopy(self.column_format_types),
-            graph_data_dict=deepcopy(self.graph_data_dict)
-        )
-
-    def __deepcopy__(self, memo):
-        """
-        If you copy a state using the deepcopy() function, this Python
-        function is called, and returns a deep copy of the state
-        """
-        return State(
-            [df.copy(deep=True) for df in self.dfs],
+            [df.copy(deep=True) if index in deep_sheet_indexes else df.copy(deep=False) for index, df in enumerate(self.dfs)],
             df_names=deepcopy(self.df_names),
             df_sources=deepcopy(self.df_sources),
             column_ids=deepcopy(self.column_ids),

--- a/mitosheet/mitosheet/step_performers/bulk_old_rename/bulk_old_rename.py
+++ b/mitosheet/mitosheet/step_performers/bulk_old_rename/bulk_old_rename.py
@@ -65,7 +65,7 @@ class BulkOldRenameStepPerformer(StepPerformer):
         do not have their analysis break when they upgrade.
         """
 
-        post_state = deepcopy(prev_state)
+        post_state = prev_state.copy(deep_sheet_indexes=list(range(len(prev_state.dfs))))
 
         column_header_renames_list = []
         for sheet_index, df in enumerate(prev_state.dfs):

--- a/mitosheet/mitosheet/step_performers/column_steps/add_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/add_column.py
@@ -57,7 +57,7 @@ class AddColumnStepPerformer(StepPerformer):
             raise make_column_exists_error(column_header)
 
         # We add a new step with the added column
-        post_state = deepcopy(prev_state)
+        post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])
 
         # If the column_header_index is out of range, then make the new column the last column
         if column_header_index < 0 or len(prev_state.dfs[sheet_index].columns) <= column_header_index:

--- a/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
@@ -72,7 +72,7 @@ class ChangeColumnDtypeStepPerformer(StepPerformer):
         **params
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
         # Create the post state
-        post_state = prev_state.copy()
+        post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])
 
         column_header = prev_state.column_ids.get_column_header_by_id(sheet_index, column_id)
         

--- a/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
@@ -72,7 +72,7 @@ class ChangeColumnDtypeStepPerformer(StepPerformer):
         **params
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
         # Create the post state
-        post_state = copy(prev_state)
+        post_state = prev_state.copy()
 
         column_header = prev_state.column_ids.get_column_header_by_id(sheet_index, column_id)
         

--- a/mitosheet/mitosheet/step_performers/column_steps/change_column_format.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/change_column_format.py
@@ -45,7 +45,7 @@ class ChangeColumnFormatStepPerformer(StepPerformer):
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
 
         # Make a post state, that is a deep copy
-        post_state = copy(prev_state)
+        post_state = prev_state.copy()
 
         # Actually update the format of the columns
         for column_id in column_ids:

--- a/mitosheet/mitosheet/step_performers/column_steps/delete_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/delete_column.py
@@ -50,7 +50,7 @@ class DeleteColumnStepPerformer(StepPerformer):
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
 
         # Make a post state, that is a deep copy
-        post_state = deepcopy(prev_state)
+        post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])
 
         # Actually delete the columns and update state
         post_state, pandas_processing_time = delete_column_ids(post_state, sheet_index, column_ids)

--- a/mitosheet/mitosheet/step_performers/column_steps/rename_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/rename_column.py
@@ -66,7 +66,7 @@ class RenameColumnStepPerformer(StepPerformer):
             return prev_state, None
 
         # Create a new post state for this step
-        post_state = deepcopy(prev_state)
+        post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])
 
         old_level_value, pandas_processing_time = rename_column_headers_in_state(
             post_state,

--- a/mitosheet/mitosheet/step_performers/column_steps/reorder_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/reorder_column.py
@@ -67,7 +67,7 @@ class ReorderColumnStepPerformer(StepPerformer):
         new_column_index = get_valid_index(prev_state.dfs, sheet_index, new_column_index)
             
         # Create a new post state
-        post_state = deepcopy(prev_state)
+        post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])
 
         # Actually execute the column reordering
         pandas_start_time = perf_counter()

--- a/mitosheet/mitosheet/step_performers/column_steps/set_column_formula.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/set_column_formula.py
@@ -120,7 +120,7 @@ class SetColumnFormulaStepPerformer(StepPerformer):
             raise make_circular_reference_error(error_modal=False)
 
         # We check out a new step
-        post_state = deepcopy(prev_state)
+        post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])
 
         # Update the column formula, and then execute the new formula graph
         try:

--- a/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_delete.py
+++ b/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_delete.py
@@ -47,7 +47,7 @@ class DataframeDeleteStepPerformer(StepPerformer):
         **params
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
         # Create a new step and save the parameters
-        post_state = copy(prev_state)
+        post_state = prev_state.copy()
 
         # Execute the delete
         post_state.column_ids.remove_df(sheet_index)

--- a/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_duplicate.py
+++ b/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_duplicate.py
@@ -44,7 +44,7 @@ class DataframeDuplicateStepPerformer(StepPerformer):
         sheet_index: int,
         **params
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
-        post_state = copy(prev_state)
+        post_state = prev_state.copy()
 
         # Execute the step
         pandas_start_time = perf_counter()

--- a/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_rename.py
+++ b/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_rename.py
@@ -54,7 +54,7 @@ class DataframeRenameStepPerformer(StepPerformer):
             return prev_state, None
 
         # Create a new step and save the parameters
-        post_state = copy(prev_state)
+        post_state = prev_state.copy()
 
         post_state.df_names[sheet_index] = get_valid_dataframe_name(post_state.df_names, new_dataframe_name)
 

--- a/mitosheet/mitosheet/step_performers/drop_duplicates.py
+++ b/mitosheet/mitosheet/step_performers/drop_duplicates.py
@@ -66,7 +66,7 @@ class DropDuplicatesStepPerformer(StepPerformer):
             return None
 
         # We make a new state to modify it
-        post_state = deepcopy(prev_state)
+        post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])
 
         pandas_start_time = perf_counter()
         final_df = post_state.dfs[sheet_index].drop_duplicates(

--- a/mitosheet/mitosheet/step_performers/filter.py
+++ b/mitosheet/mitosheet/step_performers/filter.py
@@ -235,7 +235,7 @@ class FilterStepPerformer(StepPerformer):
         )
 
         # If no errors we create a new step for this filter
-        post_state = deepcopy(prev_state)
+        post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])
 
         # Execute the filter
         final_df, pandas_processing_time = _execute_filter(

--- a/mitosheet/mitosheet/step_performers/graph_steps/graph.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/graph.py
@@ -96,7 +96,7 @@ class GraphStepPerformer(StepPerformer):
         """
 
         # We make a new state to modify it
-        post_state = deepcopy(prev_state)
+        post_state = prev_state.copy()
 
         # Extract variables from graph parameters
         graph_type = graph_creation["graph_type"]

--- a/mitosheet/mitosheet/step_performers/graph_steps/graph_delete.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/graph_delete.py
@@ -49,7 +49,7 @@ class GraphDeleteStepPerformer(StepPerformer):
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
 
         # Create a new step and save the parameters
-        post_state = copy(prev_state)
+        post_state = prev_state.copy()
 
         # Execute the graph delete
         del post_state.graph_data_dict[graph_id]

--- a/mitosheet/mitosheet/step_performers/graph_steps/graph_duplicate.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/graph_duplicate.py
@@ -45,7 +45,7 @@ class GraphDuplicateStepPerformer(StepPerformer):
         new_graph_id: GraphID,
         **params
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
-        post_state = deepcopy(prev_state)
+        post_state = prev_state.copy()
 
         # Execute the step
         graph_copy = deepcopy(post_state.graph_data_dict[old_graph_id])

--- a/mitosheet/mitosheet/step_performers/graph_steps/graph_rename.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/graph_rename.py
@@ -54,7 +54,7 @@ class GraphRenameStepPerformer(StepPerformer):
             return prev_state, None
 
         # Create a new step and save the parameters
-        post_state = copy(prev_state)
+        post_state = prev_state.copy()
 
         post_state.graph_data_dict[graph_id]["graphTabName"] = new_graph_tab_name
         

--- a/mitosheet/mitosheet/step_performers/import_steps/excel_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/excel_import.py
@@ -50,7 +50,7 @@ class ExcelImportStepPerformer(StepPerformer):
         **params
     ) -> Tuple[State, Optional[Dict[str, Any]]]:
         # Create a new step
-        post_state = copy(prev_state)
+        post_state = prev_state.copy()
 
         read_excel_params = {
             'sheet_name': sheet_names,

--- a/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
@@ -61,7 +61,7 @@ class SimpleImportStepPerformer(StepPerformer):
                 raise make_is_directory_error(file_name)
 
         # Create a new step
-        post_state = copy(prev_state)
+        post_state = prev_state.copy()
 
         file_delimeters = []
         file_encodings = []

--- a/mitosheet/mitosheet/step_performers/merge.py
+++ b/mitosheet/mitosheet/step_performers/merge.py
@@ -67,7 +67,7 @@ class MergeStepPerformer(StepPerformer):
         selected_columns_two = prev_state.column_ids.get_column_headers_by_ids(sheet_index_two, selected_column_ids_two)
 
         # We create a shallow copy to make the new post state
-        post_state = copy(prev_state)
+        post_state = prev_state.copy()
 
         pandas_start_time = perf_counter()
         new_df = _execute_merge(

--- a/mitosheet/mitosheet/step_performers/pivot.py
+++ b/mitosheet/mitosheet/step_performers/pivot.py
@@ -113,7 +113,7 @@ class PivotStepPerformer(StepPerformer):
             raise make_no_column_error(missing_pivot_keys)
 
         # Create the post state, it can be a shallow copy
-        post_state = copy(prev_state)
+        post_state = prev_state.copy()
 
         try:
             # Actually execute the pivoting

--- a/mitosheet/mitosheet/step_performers/set_cell_value.py
+++ b/mitosheet/mitosheet/step_performers/set_cell_value.py
@@ -83,7 +83,7 @@ class SetCellValueStepPerformer(StepPerformer):
         if old_value == new_value:
             return prev_state, None
 
-        post_state = deepcopy(prev_state)
+        post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])
 
         column_header = post_state.column_ids.get_column_header_by_id(sheet_index, column_id)
 

--- a/mitosheet/mitosheet/step_performers/sort.py
+++ b/mitosheet/mitosheet/step_performers/sort.py
@@ -63,7 +63,7 @@ class SortStepPerformer(StepPerformer):
         column_header = prev_state.column_ids.get_column_header_by_id(sheet_index, column_id)
 
         # We make a new state to modify it
-        post_state = deepcopy(prev_state)
+        post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])
 
         try: 
             pandas_start_time = perf_counter()


### PR DESCRIPTION
# Description

Makes us copy less dataframes. This is pretty much a strict improvement in performance, as in most cases we move from a deep copy of dataframes to shallow ones for most dataframes. In the wild, when the user is working on large datasets, I would not be surprised if this sped up all operations by 2x or so (that's a random guess though). 

To see what I meant with issue with benchmarking in Mixpanel, see here: https://mixpanel.com/s/22suFM

Try and mess with it. I've tried pretty much every configuration, and cannot get it to give me data in any useful format...

Given that this is just a strict improvement, I think we should deploy. I do think we need to rethink our benchmarking strategy at some point to work around these mixpanel limitations. 

# Testing

Make sure the ops work, boi.

# Documentation

No.