### PR TITLE
mitosheet: add hint for pivot tables

### DIFF
--- a/mitosheet/src/components/taskpanes/PivotTable/PivotTableKeySelection.tsx
+++ b/mitosheet/src/components/taskpanes/PivotTable/PivotTableKeySelection.tsx
@@ -17,6 +17,7 @@ import SelectAndXIconCard from '../../elements/SelectAndXIconCard';
 */
 const PivotTableKeySelection = (props: {
     sectionTitle: string;
+    sectionSubtext?: string;
     rowOrColumn: 'row' | 'column';
     columnIDsMap: ColumnIDsMap;
     selectedColumnIDs: ColumnID[];
@@ -69,6 +70,11 @@ const PivotTableKeySelection = (props: {
                     </DropdownButton>
                 </Col>
             </Row>
+            {props.sectionSubtext !== undefined &&
+                <p className='text-subtext-1'>
+                    {props.sectionSubtext}
+                </p>
+            }
             <PivotInvalidSelectedColumnsError
                 columnIDsMap={props.columnIDsMap}
                 selectedColumnIDs={props.selectedColumnIDs}

--- a/mitosheet/src/components/taskpanes/PivotTable/PivotTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/PivotTable/PivotTaskpane.tsx
@@ -292,7 +292,7 @@ const PivotTaskpane = (props: PivotTaskpaneProps): JSX.Element => {
                 <div className = 'default-taskpane-body-section-div'>
                     <PivotTableKeySelection
                         sectionTitle='Columns'
-                        sectionSubtext='Hint: For best performance, try only using rows and values in your pivot table.'
+                        sectionSubtext={'Select a column with a small number of unique values for best performance.'}
                         columnIDsMap={columnIDsMap}
                         selectedColumnIDs={pivotParams.pivotColumnsColumnIDs}
                         addKey={(columnID) => {addKey('column', columnID)}}

--- a/mitosheet/src/components/taskpanes/PivotTable/PivotTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/PivotTable/PivotTaskpane.tsx
@@ -292,6 +292,7 @@ const PivotTaskpane = (props: PivotTaskpaneProps): JSX.Element => {
                 <div className = 'default-taskpane-body-section-div'>
                     <PivotTableKeySelection
                         sectionTitle='Columns'
+                        sectionSubtext='Hint: For best performance, try only using rows and values in your pivot table.'
                         columnIDsMap={columnIDsMap}
                         selectedColumnIDs={pivotParams.pivotColumnsColumnIDs}
                         addKey={(columnID) => {addKey('column', columnID)}}

--- a/mitosheet/src/components/taskpanes/PivotTable/PivotTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/PivotTable/PivotTaskpane.tsx
@@ -292,7 +292,7 @@ const PivotTaskpane = (props: PivotTaskpaneProps): JSX.Element => {
                 <div className = 'default-taskpane-body-section-div'>
                     <PivotTableKeySelection
                         sectionTitle='Columns'
-                        sectionSubtext={'Select a column with a small number of unique values for best performance.'}
+                        sectionSubtext={'For the best performance, select a column with a small number of unique values.'}
                         columnIDsMap={columnIDsMap}
                         selectedColumnIDs={pivotParams.pivotColumnsColumnIDs}
                         addKey={(columnID) => {addKey('column', columnID)}}


### PR DESCRIPTION
# Description

Add a little hint that tells the user to using only rows and values in their pivot table. 

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.