### PR TITLE
mitosheet: only display the first 1500 columns

### DIFF
--- a/mitosheet/mitosheet/parser.py
+++ b/mitosheet/mitosheet/parser.py
@@ -364,7 +364,8 @@ def parse_formula(
     by returning (python_code, functions, column_header_dependencies), where column_headers
     is a list of dependencies that the formula references.
     """
-    if formula is None:
+    # If the column doesn't have a formula, then there are no dependencies, duh!
+    if formula is None or formula is '':
         return '', set(), set()
 
     if throw_errors:

--- a/mitosheet/mitosheet/parser.py
+++ b/mitosheet/mitosheet/parser.py
@@ -365,7 +365,7 @@ def parse_formula(
     is a list of dependencies that the formula references.
     """
     # If the column doesn't have a formula, then there are no dependencies, duh!
-    if formula is None or formula is '':
+    if formula is None or formula == '':
         return '', set(), set()
 
     if throw_errors:

--- a/mitosheet/mitosheet/step_performers/pivot.py
+++ b/mitosheet/mitosheet/step_performers/pivot.py
@@ -4,8 +4,6 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 from copy import copy
-import json
-import sys
 from time import perf_counter
 from typing import Any, Callable, Dict, Collection, List, Optional, Set, Tuple
 import pandas as pd

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -21,7 +21,7 @@ from mitosheet.sheet_functions.types.utils import get_float_dt_td_columns
 # We only send the first 1500 rows of a dataframe; note that this
 # must match this variable defined on the front-end
 MAX_ROWS = 1_500
-
+MAX_COLUMNS = 1_500
 
 def get_first_unused_dataframe_name(existing_df_names: List[str], new_dataframe_name: str) -> str:
     """
@@ -106,8 +106,9 @@ def dfs_to_array_for_json(
                     column_filters_array[sheet_index],
                     column_ids.column_header_to_column_id[sheet_index],
                     column_format_types[sheet_index],
-                    # We only send the first 1500 rows, and this must 
+                    # We only send the first 1500 rows and 1500 columns
                     max_length=MAX_ROWS,
+                    max_columns=MAX_COLUMNS
                 ) 
             )
         else:
@@ -125,6 +126,7 @@ def df_to_json_dumpsable(
         column_headers_to_column_ids: Dict[ColumnHeader, ColumnID],
         column_format_types: Dict[ColumnID, Dict[ColumnID, str]],
         max_length: Optional[int]=MAX_ROWS, # How many items you want to display
+        max_columns: int=MAX_COLUMNS # How many columns you want to display, there's no need for it to be undefined
     ) -> Dict[str, Any]:
     """
     Returns a dataframe represented in a way that can be turned into a 
@@ -158,6 +160,9 @@ def df_to_json_dumpsable(
     else:
         # we only show the first max_length rows!
         df = original_df.head(n=max_length if max_length else num_rows).copy(deep=True)
+
+    # we only show the first max_columns columns!
+    df = df.iloc[: , :max_columns]
 
     float_columns, date_columns, timedelta_columns = get_float_dt_td_columns(df)
     # Second, we figure out which of the columns contain dates, and we

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -125,8 +125,8 @@ def df_to_json_dumpsable(
         column_filters: Dict[ColumnID, Any],
         column_headers_to_column_ids: Dict[ColumnHeader, ColumnID],
         column_format_types: Dict[ColumnID, Dict[ColumnID, str]],
-        max_length: Optional[int]=MAX_ROWS, # How many items you want to display
-        max_columns: int=MAX_COLUMNS # How many columns you want to display, there's no need for it to be undefined
+        max_length: Optional[int]=MAX_ROWS, # How many items you want to display. None when using this function to get unique value counts
+        max_columns: int=MAX_COLUMNS # How many columns you want to display. Unlike max_length, this is always defined
     ) -> Dict[str, Any]:
     """
     Returns a dataframe represented in a way that can be turned into a 

--- a/mitosheet/src/components/endo/widthUtils.tsx
+++ b/mitosheet/src/components/endo/widthUtils.tsx
@@ -23,7 +23,7 @@ export const getWidthData = (sheetData: SheetData | undefined, defaultWidthData:
     const widthArray = new Array<number>(sheetData.numColumns);
     const widthSumArray = new Array<number>(sheetData.numColumns);
 
-    for (let columnIndex = 0; columnIndex < sheetData.numColumns; columnIndex++) {
+    for (let columnIndex = 0; columnIndex < sheetData.data.length; columnIndex++) {
         const columnID = sheetData.data[columnIndex].columnID;
         let columnWidth = DEFAULT_WIDTH;
         if (defaultWidthData !== undefined) {


### PR DESCRIPTION
# Description

- Only displays the first 1500 column in the pandas dataframe to make Mito snappier! 
- Adds logging for the pandas performance warning that occurs when creating a really large pivot table, so that we can figure out how much guidance is appropriate to provide to users. 
- Dramatically improves the efficiency of building the column evaluation graph by short circuiting if the column has no formula!

# Testing

1. Create a pivot table that has over 1500 columns, but not enough data to crash the sheet -- you can achieve this by adding a column and a value, with no row. See that the pivot table loads quickly and that if you rename, delete, or set the formula of a column, the operation finishes in about 30-60 seconds.  

2. Create a new pivot table with a row and column that each have a large number of unique values. Check your mixpanel logs to see a `pivot_table_performance_warning`. Notice that eventually the kernel will shut down and the log for the pivot table will never get logged. 

3. Make sure the column evaluation graph still works properly

# Documentation

Note if any new documentation needs to addressed or reviewed.