### PR TITLE
mitosheet: always open filter tab on filter icon click

### DIFF
--- a/mitosheet/src/components/endo/ColumnHeader.tsx
+++ b/mitosheet/src/components/endo/ColumnHeader.tsx
@@ -11,6 +11,7 @@ import Input from '../elements/Input';
 import { focusGrid } from './focusUtils';
 import { getColumnHeaderParts, getDisplayColumnHeader, isPrimitiveColumnHeader, rowIndexToColumnHeaderLevel } from '../../utils/columnHeaders';
 import { DEFAULT_HEIGHT } from './EndoGrid';
+import { ControlPanelTab } from '../taskpanes/ControlPanel/ControlPanelTaskpane';
 
 
 /* 
@@ -227,6 +228,7 @@ const ColumnHeader = (props: {
                     props.setUIState(prevUIState => {
                         return {
                             ...prevUIState,
+                            selectedColumnControlPanelTab: ControlPanelTab.FilterSort,
                             currOpenTaskpane: { type: TaskpaneType.CONTROL_PANEL }
                         }
                     })


### PR DESCRIPTION
# Description

Always open the filter / sort tab when the filter icon or dtype icon is clicked. 

# Testing

Test it! 

# Documentation

No. 