### PR TITLE
mitosheet: make drop duplicates start with no columns selected

### DIFF
--- a/mitosheet/src/components/taskpanes/DropDuplicates/DropDuplicates.tsx
+++ b/mitosheet/src/components/taskpanes/DropDuplicates/DropDuplicates.tsx
@@ -48,7 +48,7 @@ export const getDefaultParams = (selectedSheetIndex: number, sheetDataArray: She
 
     return {
         sheet_index: selectedSheetIndex,
-        column_ids: sheetDataArray[selectedSheetIndex]?.data?.map(c => c.columnID) || [],
+        column_ids: [],
         keep: 'first',
     }
 }


### PR DESCRIPTION
# Description

Removes the confusion caused by drop duplicates automatically deduplicating the data when the taskpane is open by starting the taskpane with no columns selected. This means that no data is dropped until the user configured the taskpane + they have a better idea of how to get back to a state where no duplicates are dropped. 

# Testing


# Documentation

No. 