### PR TITLE
mitosheet: unify replay analysis errors

### DIFF
--- a/docs/misc/release-notes.md
+++ b/docs/misc/release-notes.md
@@ -4,6 +4,16 @@ description: Want to see what is new in the Mitosheet? Check it out below.
 
 # Release Notes
 
+## 2022-4-5 <a href="#2022-4-5" id="2022-4-5"></a>
+
+
+Bug Fixes:
+* Make sheets with massive numbers of columns work with Mito better, by only displaying the first 1500 columns.
+* Add a warning to pivot tables letting users know that adding a `column` key with a large number of unique values will cause performance problems.
+* Make analysis replaying much more robust by adding an `analysis_to_replay` parameter to the `mitosheet.sheet()` call. This will stop Mito generated code from getting deleted from the sheet, as it did in the past!
+
+
+
 ## 2022-3-29 <a href="#2022-3-29" id="2022-3-29"></a>
 
 New Features:

--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -37,7 +37,7 @@ import ClearAnalysisModal from './modals/ClearAnalysisModal';
 import DeleteGraphsModal from './modals/DeleteGraphsModal';
 import ErrorModal from './modals/ErrorModal';
 import { ModalEnum } from './modals/modals';
-import { InvalidReplayedAnalysisModal, NonexistantReplayedAnalysisModal } from './modals/ReplayAnalysisModals';
+import ErrorReplayedAnalysisModal from './modals/ReplayAnalysisModals';
 import SignUpModal from './modals/SignupModal';
 import UpgradeModal from './modals/UpgradeModal';
 import ConcatTaskpane from './taskpanes/Concat/ConcatTaskpane';
@@ -174,7 +174,10 @@ export const Mito = (props: MitoProps): JSX.Element => {
                             return {
                                 ...prevUIState,
                                 currOpenModal: {
-                                    type: ModalEnum.NonexistantReplayAnalysis,
+                                    type: ModalEnum.ErrorReplayedAnalysis,
+                                    header: 'analysis_to_replay does not exist',
+                                    message: `We\'re unable to replay ${analysisToReplayName} because you don't have access to it. This is probably because the analysis was created on a different computer.`,
+                                    error: undefined,
                                     oldAnalysisName: analysisToReplayName,
                                     newAnalysisName: analysisData.analysisName
                                 }
@@ -196,7 +199,9 @@ export const Mito = (props: MitoProps): JSX.Element => {
                             return {
                                 ...prevUIState,
                                 currOpenModal: {
-                                    type: ModalEnum.InvalidReplayedAnalysis,
+                                    type: ModalEnum.ErrorReplayedAnalysis,
+                                    header: 'Analysis Could Not Be Replayed',
+                                    message: 'There was an error replaying your analysis because of changes in the input data. You can see the previous analysis in the code cell below.',
                                     error: error,
                                     oldAnalysisName: analysisToReplayName,
                                     newAnalysisName: analysisData.analysisName
@@ -489,18 +494,12 @@ export const Mito = (props: MitoProps): JSX.Element => {
                     mitoAPI={props.mitoAPI}
                 />
             )
-            case ModalEnum.NonexistantReplayAnalysis: return (
-                <NonexistantReplayedAnalysisModal
+            case ModalEnum.ErrorReplayedAnalysis: return (
+                <ErrorReplayedAnalysisModal
                     setUIState={setUIState}
                     mitoAPI={props.mitoAPI}
-                    newAnalysisName={uiState.currOpenModal.newAnalysisName}
-                    oldAnalysisName={uiState.currOpenModal.oldAnalysisName}
-                />
-            )
-            case ModalEnum.InvalidReplayedAnalysis: return (
-                <InvalidReplayedAnalysisModal
-                    setUIState={setUIState}
-                    mitoAPI={props.mitoAPI}
+                    header={uiState.currOpenModal.header}
+                    message={uiState.currOpenModal.message}
                     error={uiState.currOpenModal.error}
                     newAnalysisName={uiState.currOpenModal.newAnalysisName}
                     oldAnalysisName={uiState.currOpenModal.oldAnalysisName}

--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -176,7 +176,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
                                 currOpenModal: {
                                     type: ModalEnum.ErrorReplayedAnalysis,
                                     header: 'analysis_to_replay does not exist',
-                                    message: `We\'re unable to replay ${analysisToReplayName} because you don't have access to it. This is probably because the analysis was created on a different computer.`,
+                                    message: `We're unable to replay ${analysisToReplayName} because you don't have access to it. This is probably because the analysis was created on a different computer.`,
                                     error: undefined,
                                     oldAnalysisName: analysisToReplayName,
                                     newAnalysisName: analysisData.analysisName

--- a/mitosheet/src/components/modals/ReplayAnalysisModals.tsx
+++ b/mitosheet/src/components/modals/ReplayAnalysisModals.tsx
@@ -8,29 +8,48 @@ import DefaultModal from '../DefaultModal';
 import TextButton from '../elements/TextButton';
 import { ModalEnum } from './modals';
 
+
+
 /*
-    This modal displays to the user when the analysis that they are 
-    replaying does not exist on their computer
+    This modal displays to the user when:
+    1. the analysis that they are replaying does not exist on their computer
+    2. the analysis errors during replay for some other reason
 */
-export const NonexistantReplayedAnalysisModal = (
+const ErrorReplayedAnalysisModal = (
     props: {
         setUIState: React.Dispatch<React.SetStateAction<UIState>>;
         mitoAPI: MitoAPI,
+
+        header: string,
+        message: string,
+        error: MitoError | undefined,
+
         oldAnalysisName: string;
         newAnalysisName: string;
     }): JSX.Element => {
 
+    const [viewTraceback, setViewTraceback] = useState(false);
+
     return (
         <DefaultModal
-            header={"analysis_to_replay does not exist"}
+            header={props.header}
             modalType={ModalEnum.Error}
             wide
             viewComponent={
                 <Fragment>
-                    
-                    <div className='text-align-left text-body-1'>
-                        We&apos;re unable to replay {props.oldAnalysisName} because you don&apos;t have access to it. This is probably because the analysis was created on a different computer.
+                    <div className='text-align-left text-body-1' onClick={() => setViewTraceback((viewTraceback) => !viewTraceback)}>
+                        {props.message} {' '}
+                        {props.error?.traceback && 
+                            <span className='text-body-1-link'>
+                                Click to view full traceback.
+                            </span>
+                        }
                     </div>
+                    {props.error?.traceback && viewTraceback &&
+                        <div className='flex flex-column text-align-left text-overflow-hidden text-overflow-scroll mt-5px' style={{height: '200px', border: '1px solid var(--mito-purple)', borderRadius: '2px', padding: '5px'}}>
+                            <pre>{props.error.traceback}</pre>
+                        </div>
+                    }
                 </Fragment>
             }
             buttons={
@@ -69,77 +88,4 @@ export const NonexistantReplayedAnalysisModal = (
     )    
 };
 
-/*
-    This modal displays to the user when the analysis that they are 
-    replaying fails to run correctly.
-*/
-export const InvalidReplayedAnalysisModal = (
-    props: {
-        error: MitoError | undefined, 
-        setUIState: React.Dispatch<React.SetStateAction<UIState>>;
-        mitoAPI: MitoAPI;
-        oldAnalysisName: string;
-        newAnalysisName: string;
-    }): JSX.Element => {
-    const [viewTraceback, setViewTraceback] = useState(false);
-
-    if (props.error === undefined) {
-        return (<></>)
-    }
-
-    return (
-        <DefaultModal
-            header={"Analysis Could Not Be Replayed"}
-            modalType={ModalEnum.Error}
-            wide
-            viewComponent={
-                <Fragment>
-                    {props.error.to_fix &&
-                        <div className='text-align-left text-body-1' onClick={() => setViewTraceback((viewTraceback) => !viewTraceback)}>
-                            There was an error replaying your analysis because of changes in the input data. You can see the previous analysis in the code cell below. {' '}
-                            {props.error.traceback && 
-                                <span className='text-body-1-link'>
-                                    Click to view full traceback.
-                                </span>
-                            }
-                        </div>
-                    }
-                    {props.error.traceback && viewTraceback &&
-                        <div className='flex flex-column text-align-left text-overflow-hidden text-overflow-scroll mt-5px' style={{height: '200px', border: '1px solid var(--mito-purple)', borderRadius: '2px', padding: '5px'}}>
-                            <pre>{props.error.traceback}</pre>
-                        </div>
-                    }
-                </Fragment>
-            }
-            buttons={
-                <>
-                    <TextButton
-                        variant='dark'
-                        width='medium'
-                        onClick={() => {
-                            /**
-                             * We also need to actually change the analysis to replay in the code cell, 
-                             * so that we know something happened to invalidate this analysis to replay,
-                             * and we can write new code
-                             */
-                            window.commands?.execute('overwrite-analysis-to-replay-to-mitosheet-call', {
-                                oldAnalysisName: props.oldAnalysisName,
-                                newAnalysisName: props.newAnalysisName,
-                                mitoAPI: props.mitoAPI
-                            });
-
-                            props.setUIState(prevUIState => {
-                                return {
-                                    ...prevUIState,
-                                    currOpenModal: {type: ModalEnum.None}
-                                }
-                            })
-                        }}
-                    >
-                        Start New Analysis
-                    </TextButton>
-                </> 
-            }
-        />
-    )    
-};
+export default ErrorReplayedAnalysisModal;

--- a/mitosheet/src/components/modals/modals.tsx
+++ b/mitosheet/src/components/modals/modals.tsx
@@ -12,8 +12,7 @@ export enum ModalEnum {
     Upgrade = 'Upgrade',
     Feedback = 'Feedback',
     DeleteGraphs = 'DeleteGraphs',
-    NonexistantReplayAnalysis = 'NonexistantReplayAnalysis',
-    InvalidReplayedAnalysis = 'InvalidReplayedAnalysis'
+    ErrorReplayedAnalysis = 'ErrorReplayAnalysis',
 }
 
 /* 
@@ -43,14 +42,11 @@ interface UpgradeModalInfo {
 interface ClearAnalysisInfo {
     type: ModalEnum.ClearAnalysis;
 }
-interface NonexistantReplayedAnalysisInfo {
-    type: ModalEnum.NonexistantReplayAnalysis;
-    oldAnalysisName: string;
-    newAnalysisName: string;
-}
-interface InvalidReplayedAnalysisInfo {
-    type: ModalEnum.InvalidReplayedAnalysis;
-    error: MitoError;
+interface ErrorReplayedAnalysisInfo {
+    type: ModalEnum.ErrorReplayedAnalysis;
+    header: string,
+    message: string,
+    error: MitoError | undefined;
     oldAnalysisName: string;
     newAnalysisName: string;
 }
@@ -71,5 +67,4 @@ export type ModalInfo =
     | UpgradeModalInfo
     | ClearAnalysisInfo
     | DeleteGraphsModalInfo
-    | NonexistantReplayedAnalysisInfo
-    | InvalidReplayedAnalysisInfo
+    | ErrorReplayedAnalysisInfo


### PR DESCRIPTION
# Description

Now you get offered support + create a new analysis in both cases of failure, which is nice. The other change I merged into dev already was a minor change to the pivot table language to make it fit on one line.

# Testing

Test that the two types of failure of replaying (nonexistent, failure) give correct modals.

# Documentation

Adds release notes.