### PR TITLE
Communicate Result

### DIFF
--- a/mitosheet/src/components/taskpanes/Concat/ConcatTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/Concat/ConcatTaskpane.tsx
@@ -7,6 +7,7 @@ import DropdownItem from "../../elements/DropdownItem";
 import Select from "../../elements/Select";
 import SelectAndXIconCard from "../../elements/SelectAndXIconCard";
 import Toggle from "../../elements/Toggle";
+import Tooltip from "../../elements/Tooltip";
 import Col from "../../spacing/Col";
 import Row from "../../spacing/Row";
 import DefaultEmptyTaskpane from "../DefaultTaskpane/DefaultEmptyTaskpane";
@@ -92,9 +93,9 @@ const ConcatTaskpane = (props: ConcatTaskpaneProps): JSX.Element => {
                 />
                 {notIncludedColumnsArray !== undefined &&
                     <Row className='text-subtext-1' >
-                        {notIncludedColumnsArray[sheetIndex].length === 0 ? `\u2713 All columns are included in the concatenated sheet` : 
-                            notIncludedColumnsArray[sheetIndex].length < 4 ? `Columns ${notIncludedColumnsArray[sheetIndex].join(', ')} are not included` :
-                                `Columns ${notIncludedColumnsArray[sheetIndex].slice(0,3).join(', ')} and ${notIncludedColumnsArray[sheetIndex].length} others are not included`
+                        {notIncludedColumnsArray[sheetIndex].length === 0 ? `\u2713 All columns are included in the concatenated sheet.` : 
+                            notIncludedColumnsArray[sheetIndex].length < 4 ? `Columns ${notIncludedColumnsArray[sheetIndex].join(', ')} are not included.` :
+                                `Columns ${notIncludedColumnsArray[sheetIndex].slice(0,3).join(', ')} and ${notIncludedColumnsArray[sheetIndex].length - 3} others are not included.`
                         }
                     </Row>
                 }
@@ -141,9 +142,13 @@ const ConcatTaskpane = (props: ConcatTaskpaneProps): JSX.Element => {
                 </Row>
                 <Row justify='space-between' align='center'>
                     <Col>
-                        <p className='text-header-3'>
-                            Ignore Existing Indexes
-                        </p>
+                        <Row align='center' suppressTopBottomMargin>
+                            <p className='text-header-3'>
+                                Ignore Existing Indexes &nbsp;
+                            </p>
+                            <Tooltip title={"When on, the resulting dataframe will have indexes 0, 1, 2, etc.. This is useful if you're concatenating objects that don't have meaningful indexing information."}/>
+                        </Row>
+                        
                     </Col>
                     <Col>
                         <Toggle 

--- a/mitosheet/src/components/taskpanes/Concat/ConcatTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/Concat/ConcatTaskpane.tsx
@@ -93,9 +93,9 @@ const ConcatTaskpane = (props: ConcatTaskpaneProps): JSX.Element => {
                 />
                 {notIncludedColumnsArray !== undefined &&
                     <Row className='text-subtext-1' >
-                        {notIncludedColumnsArray[sheetIndex].length === 0 ? `\u2713 All columns are included in the concatenated sheet.` : 
-                            notIncludedColumnsArray[sheetIndex].length < 4 ? `Columns ${notIncludedColumnsArray[sheetIndex].join(', ')} are not included.` :
-                                `Columns ${notIncludedColumnsArray[sheetIndex].slice(0,3).join(', ')} and ${notIncludedColumnsArray[sheetIndex].length - 3} others are not included.`
+                        {notIncludedColumnsArray[arrIndex].length === 0 ? `\u2713 All columns are included in the concatenated sheet.` : 
+                            notIncludedColumnsArray[arrIndex].length < 4 ? `Columns ${notIncludedColumnsArray[arrIndex].join(', ')} are not included.` :
+                                `Columns ${notIncludedColumnsArray[arrIndex].slice(0,3).join(', ')} and ${notIncludedColumnsArray[arrIndex].length - 3} others are not included.`
                         }
                     </Row>
                 }

--- a/mitosheet/src/components/taskpanes/ControlPanel/ControlPanelTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/ControlPanel/ControlPanelTaskpane.tsx
@@ -58,6 +58,8 @@ export const ControlPanelTaskpane = (props: ControlPanelTaskpaneProps): JSX.Elem
     const [operator, setOperator] = useState(columnFilters !== undefined ? columnFilters.operator : 'And');
     const [stepID, setStepID] = useState('');
 
+    const originalNumRows = useRef(props.sheetData?.numRows || 0);
+    const editedFilter = useRef(false)
 
     // When the filters or operator changes, send a new message, as long as this is not
     // the first time that this rendered. We use a ref to avoid sending a message the first 
@@ -136,6 +138,7 @@ export const ControlPanelTaskpane = (props: ControlPanelTaskpaneProps): JSX.Elem
             props.tab
         )
 
+        editedFilter.current = true  
         setStepID(_stepID);    
     }
 
@@ -185,6 +188,8 @@ export const ControlPanelTaskpane = (props: ControlPanelTaskpaneProps): JSX.Elem
                                 columnDtype={columnDtype}
                                 operator={operator}
                                 mitoAPI={props.mitoAPI}
+                                rowDifference={originalNumRows.current - (props.sheetData?.numRows || 0)}
+                                editedFilter={editedFilter}
                             />
                         </React.Fragment>
                     }

--- a/mitosheet/src/components/taskpanes/ControlPanel/ControlPanelTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/ControlPanel/ControlPanelTaskpane.tsx
@@ -58,8 +58,8 @@ export const ControlPanelTaskpane = (props: ControlPanelTaskpaneProps): JSX.Elem
     const [operator, setOperator] = useState(columnFilters !== undefined ? columnFilters.operator : 'And');
     const [stepID, setStepID] = useState('');
 
-    const originalNumRows = useRef(props.sheetData?.numRows || 0);
-    const editedFilter = useRef(false)
+    const [originalNumRows, ] = useState(props.sheetData?.numRows || 0)
+    const [editedFilter, setEditedFilter] = useState(false)
 
     // When the filters or operator changes, send a new message, as long as this is not
     // the first time that this rendered. We use a ref to avoid sending a message the first 
@@ -138,7 +138,7 @@ export const ControlPanelTaskpane = (props: ControlPanelTaskpaneProps): JSX.Elem
             props.tab
         )
 
-        editedFilter.current = true  
+        setEditedFilter(true) 
         setStepID(_stepID);    
     }
 
@@ -188,7 +188,7 @@ export const ControlPanelTaskpane = (props: ControlPanelTaskpaneProps): JSX.Elem
                                 columnDtype={columnDtype}
                                 operator={operator}
                                 mitoAPI={props.mitoAPI}
-                                rowDifference={originalNumRows.current - (props.sheetData?.numRows || 0)}
+                                rowDifference={originalNumRows - (props.sheetData?.numRows || 0)}
                                 editedFilter={editedFilter}
                             />
                         </React.Fragment>

--- a/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/filter/FilterCard.tsx
+++ b/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/filter/FilterCard.tsx
@@ -25,7 +25,7 @@ interface FilterCardProps {
     columnDtype: string;
     mitoAPI: MitoAPI;
     rowDifference: number;
-    editedFilter: React.MutableRefObject<boolean>
+    editedFilter: boolean
 }
 
 export const ADD_FILTER_SELECT_TITLE = '+ Add Filter'
@@ -258,7 +258,7 @@ function FilterCard (props: FilterCardProps): JSX.Element {
                     onClick={addFilterGroup}
                 />
             </DropdownButton>
-            {props.editedFilter.current && 
+            {props.editedFilter && 
                 <Row className='text-subtext-1'>
                     {props.rowDifference >= 0 ?
                         `Removed an additional ${Math.abs(props.rowDifference)} rows` : 

--- a/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/filter/FilterCard.tsx
+++ b/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/filter/FilterCard.tsx
@@ -24,6 +24,8 @@ interface FilterCardProps {
     columnID: ColumnID;
     columnDtype: string;
     mitoAPI: MitoAPI;
+    rowDifference: number;
+    editedFilter: React.MutableRefObject<boolean>
 }
 
 export const ADD_FILTER_SELECT_TITLE = '+ Add Filter'
@@ -256,6 +258,14 @@ function FilterCard (props: FilterCardProps): JSX.Element {
                     onClick={addFilterGroup}
                 />
             </DropdownButton>
+            {props.editedFilter.current && 
+                <Row className='text-subtext-1'>
+                    {props.rowDifference >= 0 ?
+                        `Removed an additional ${Math.abs(props.rowDifference)} rows` : 
+                        `Added back ${Math.abs(props.rowDifference)} rows`
+                    }
+                </Row>
+            }
         </div>
     )
 }


### PR DESCRIPTION
# Description

What are your thoughts on when the original number of rows variable in the filter taskpane should update now that you see it? I'm leaning towards ideally it would update when you either 1) open the taskpane or 2) add/remove a filter condition. 

However, there's a lot more complexity that comes with condition 2 that I'm not sure is worth it. Let me know your thoughts. 

# Testing

Concat files together and make sure that if they have all the same column headers, then the text says they are all included. If a column header is not shared, make sure it shows up in the text. 

Filter and make sure the number of values that it says are removed is correct. 

# Documentation

No. 