### PR TITLE
[WIP] Formula Bar

### DIFF
--- a/mitosheet/css/FormulaBar.css
+++ b/mitosheet/css/FormulaBar.css
@@ -1,6 +1,10 @@
+:root {
+    --formula-bar-height: 30px;
+}
+
 .formula-bar-column-header {
-    max-width: 200px;
-    height: 30px;
+    width: 100px;
+    height: var(--formula-bar-height);
     display: flex;
     justify-content: center;
     flex-direction: column;
@@ -18,7 +22,7 @@
 
 .formula-bar-vertical-line {
     border-left: 1px solid var(--mito-gray);
-    height: 11px;
+    height: var(--formula-bar-height);
     margin-left: 10px;
     margin-right: 10px;
 }

--- a/mitosheet/css/endo/CellEditor.css
+++ b/mitosheet/css/endo/CellEditor.css
@@ -4,7 +4,6 @@
     z-index: 2;
     position: absolute;
     box-sizing: border-box;
-    background: white;
 }
 
 .cell-editor-form {
@@ -14,7 +13,7 @@
 }
 
 .cell-editor-input {
-    height: 25px;
+    height: 26px;
     width: 100%;
     border: none;
     box-sizing: border-box;
@@ -26,7 +25,8 @@
     
     display: flex;
     flex-direction: column;
-    overflow-x: hidden;
+    overflow-wrap: break-word;
+    white-space: normal; 
 }
 
 .cell-editor-suggestion {

--- a/mitosheet/css/endo/CellEditor.css
+++ b/mitosheet/css/endo/CellEditor.css
@@ -4,12 +4,26 @@
     z-index: 2;
     position: absolute;
     box-sizing: border-box;
+
+    /* 
+        Set the pointer-events: none allows the user to select elements that are behind the 
+        cell editor. The formula bar cell editor's rectangular div covers the column headers. 
+        However, most of the rectangle is translucent. 
+
+        We set the entire cell-editor to have no pointer events, and we turn on the pointer events
+        for the specific parts of the cell editor that are displayed. This lets the user interact with 
+        all of the visible elements as they would expect. 
+    */
+    pointer-events: none;
 }
 
 .cell-editor-form {
     border: 2px solid var(--mito-purple);
     width: 100%;
     box-sizing: border-box;
+
+    /* Let the user click on the cell editor form */
+    pointer-events: all 
 }
 
 .cell-editor-input {
@@ -27,6 +41,9 @@
     flex-direction: column;
     overflow-wrap: break-word;
     white-space: normal; 
+
+    /* Let the user click on the dropdown box */
+    pointer-events: all;
 }
 
 .cell-editor-suggestion {

--- a/mitosheet/css/sitewide/flexbox.css
+++ b/mitosheet/css/sitewide/flexbox.css
@@ -19,3 +19,7 @@
 .flexbox-justify-end {
     justify-content: end;
 }
+
+.flexbox-align-items-center {
+    align-items: center;
+}

--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -749,6 +749,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
                             setGridState={setGridState}
                             editorState={editorState}
                             setEditorState={setEditorState}
+                            mitoContainerRef={mitoContainerRef}
                         />
                     </div>
                     {uiState.currOpenTaskpane.type !== TaskpaneType.NONE && 

--- a/mitosheet/src/components/endo/CellEditor.tsx
+++ b/mitosheet/src/components/endo/CellEditor.tsx
@@ -170,8 +170,6 @@ const CellEditor = (props: {
             // Focus the input
             cellEditorInputRef.current?.focus();
 
-            console.log('here')
-
             // If there is a pendingSelectedColumns, then we set the selection to be 
             // at the _end_ of them!
             if (props.editorState.pendingSelectedColumns !== undefined) {
@@ -497,8 +495,15 @@ const CellEditor = (props: {
         }
     }
 
-    console.log(props.containerRef)
-    const width = props.editorState.editorLocation === 'cell' ? `${CELL_EDITOR_WIDTH}px` : '100%'
+    let width = '80%';
+    if (props.editorState.editorLocation === 'cell') {
+        width = `${CELL_EDITOR_WIDTH}px`
+    } else if (props.containerRef.current !== undefined && props.containerRef.current !== null) {
+        // When the editorLocation is the formula bar, the containerRef is the MitoContainer. 
+        // So to find the correct width, we need to subtract the space used to display the column header and padding
+        width = `${props.containerRef.current.clientWidth - 120}px`
+    } 
+    
     return (
         <div 
             className='cell-editor' 

--- a/mitosheet/src/components/endo/CellEditor.tsx
+++ b/mitosheet/src/components/endo/CellEditor.tsx
@@ -71,8 +71,15 @@ const CellEditor = (props: {
     // and it really don't effect the experience of using the cell editor at all!
     // If you want to make the editor refresh it's location, just make it subscribe to 
     // grid state changes
-    useEffect(() => {        
+    useEffect(() => {   
+
         const updateCellEditorPosition = () => {
+            if (props.editorState.editorLocation === 'formula bar') {
+                setEditorStyle({
+                    top: 47, // Must be the same as the toolbar-container height in toolbar.css,
+                    left: 100 // Must be the same as the --formula-bar-height in FormulaBar.css
+                });
+            }
     
             const scrollAndRenderedContainerRect = props.scrollAndRenderedContainerRef.current?.getBoundingClientRect();
             if (scrollAndRenderedContainerRect === undefined) {
@@ -487,12 +494,14 @@ const CellEditor = (props: {
         }
     }
 
+    const width = props.editorState.editorLocation === 'cell' ? `${CELL_EDITOR_WIDTH}px` : '100%'
     return (
         <div 
             className='cell-editor' 
             style={{
                 ...editorStyle,
-                width: `${CELL_EDITOR_WIDTH}px`
+                width: width,
+                flexGrow: 1
             }}
         >
             <form

--- a/mitosheet/src/components/endo/CellEditor.tsx
+++ b/mitosheet/src/components/endo/CellEditor.tsx
@@ -76,9 +76,10 @@ const CellEditor = (props: {
         const updateCellEditorPosition = () => {
             if (props.editorState.editorLocation === 'formula bar') {
                 setEditorStyle({
-                    top: 47, // Must be the same as the toolbar-container height in toolbar.css,
-                    left: 100 // Must be the same as the --formula-bar-height in FormulaBar.css
+                    top: 49, // Must be the same as the toolbar-container height in toolbar.css,
+                    left: 120 // Must be the same as the --formula-bar-height in FormulaBar.css
                 });
+                return 
             }
     
             const scrollAndRenderedContainerRect = props.scrollAndRenderedContainerRef.current?.getBoundingClientRect();
@@ -168,6 +169,8 @@ const CellEditor = (props: {
         setTimeout(() => {
             // Focus the input
             cellEditorInputRef.current?.focus();
+
+            console.log('here')
 
             // If there is a pendingSelectedColumns, then we set the selection to be 
             // at the _end_ of them!
@@ -494,6 +497,7 @@ const CellEditor = (props: {
         }
     }
 
+    console.log(props.containerRef)
     const width = props.editorState.editorLocation === 'cell' ? `${CELL_EDITOR_WIDTH}px` : '100%'
     return (
         <div 
@@ -554,7 +558,7 @@ const CellEditor = (props: {
                 In the dropdown box, we either show an error, a loading message, suggestions
                 or the documentation for the last function, depending on the cases below
             */}
-            <div className='cell-editor-dropdown-box'>
+            <div className='cell-editor-dropdown-box' style={{width: props.editorState.editorLocation === 'formula bar' ? `${CELL_EDITOR_WIDTH}px` : undefined}}>
                 {cellEditorError === undefined && 
                     <p className={classNames('cell-editor-label', 'text-subtext-1', 'ml-5px')}>
                         {isFormulaColumn ? "You're setting the formula of this column" : "You're changing the value of this cell"}

--- a/mitosheet/src/components/endo/ColumnHeader.tsx
+++ b/mitosheet/src/components/endo/ColumnHeader.tsx
@@ -151,6 +151,7 @@ const ColumnHeader = (props: {
                                         rowIndex: rowIndex,
                                         columnIndex: props.columnIndex,
                                         formula: getDisplayColumnHeader(lowerLevelColumnHeader),
+                                        editorLocation: 'cell'
                                     })
                                 }}
                             >
@@ -258,6 +259,7 @@ const ColumnHeader = (props: {
                                     rowIndex: -1,
                                     columnIndex: props.columnIndex,
                                     formula: getDisplayColumnHeader(finalColumnHeader),
+                                    editorLocation: 'cell'
                                 })
                             }}
                             key={props.columnIndex}

--- a/mitosheet/src/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/components/endo/EndoGrid.tsx
@@ -595,8 +595,6 @@ function EndoGrid(props: {
                 gridState={gridState}
                 setGridState={setGridState}
                 setEditorState={setEditorState}
-                scrollAndRenderedContainerRef={scrollAndRenderedContainerRef}
-                containerRef={containerRef}
                 mitoAPI={mitoAPI}
             />
             <div 

--- a/mitosheet/src/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/components/endo/EndoGrid.tsx
@@ -76,6 +76,7 @@ function EndoGrid(props: {
     */
     editorState: EditorState | undefined,
     setEditorState: React.Dispatch<React.SetStateAction<EditorState | undefined>>
+    mitoContainerRef: React.RefObject<HTMLDivElement>;
 }): JSX.Element {
 
     // The container for the entire EndoGrid
@@ -91,7 +92,7 @@ function EndoGrid(props: {
         gridState, setGridState, 
         editorState, setEditorState, 
         uiState, setUIState,
-        mitoAPI
+        mitoAPI, mitoContainerRef
     } = props;
 
     const sheetData = sheetDataArray[sheetIndex];
@@ -596,6 +597,7 @@ function EndoGrid(props: {
                 setGridState={setGridState}
                 setEditorState={setEditorState}
                 mitoAPI={mitoAPI}
+                mitoContainerRef={mitoContainerRef}
             />
             <div 
                 className='endo-grid-container' 

--- a/mitosheet/src/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/components/endo/EndoGrid.tsx
@@ -480,7 +480,8 @@ function EndoGrid(props: {
             formula: startingFormula,
             // As in google sheets, if the starting formula is non empty, we default to the 
             // arrow keys scrolling in the editor
-            arrowKeysScrollInFormula: startingFormula.length > 0
+            arrowKeysScrollInFormula: startingFormula.length > 0,
+            editorLocation: 'cell'
         })
     }
     
@@ -536,7 +537,8 @@ function EndoGrid(props: {
                         formula: startingFormula,
                         // As in google sheets, if the starting formula is non empty, we default to the 
                         // arrow keys scrolling in the editor
-                        arrowKeysScrollInFormula: startingFormula.length > 0
+                        arrowKeysScrollInFormula: startingFormula.length > 0,
+                        editorLocation: 'cell'
                     });
 
                     e.preventDefault();
@@ -589,6 +591,13 @@ function EndoGrid(props: {
                 sheetData={sheetData}
                 selection={gridState.selections[gridState.selections.length - 1]}
                 editorState={editorState}
+                sheetIndex={sheetIndex}
+                gridState={gridState}
+                setGridState={setGridState}
+                setEditorState={setEditorState}
+                scrollAndRenderedContainerRef={scrollAndRenderedContainerRef}
+                containerRef={containerRef}
+                mitoAPI={mitoAPI}
             />
             <div 
                 className='endo-grid-container' 
@@ -660,7 +669,7 @@ function EndoGrid(props: {
                         />
                     </div>
                 </div>
-                {sheetData !== undefined && editorState !== undefined && editorState.rowIndex > -1 &&
+                {sheetData !== undefined && editorState !== undefined && editorState.editorLocation === 'cell' && editorState.rowIndex > -1 &&
                     <CellEditor
                         sheetData={sheetData}
                         sheetIndex={sheetIndex}

--- a/mitosheet/src/components/endo/FormulaBar.tsx
+++ b/mitosheet/src/components/endo/FormulaBar.tsx
@@ -5,24 +5,38 @@ import React from 'react';
 // Import css
 import "../../../css/FormulaBar.css";
 import "../../../css/mito.css"
-import { EditorState, SheetData, MitoSelection } from '../../types';
+import { EditorState, SheetData, MitoSelection, GridState } from '../../types';
 import { getFullFormula } from './cellEditorUtils';
 import { getCellDataFromCellIndexes } from './utils';
 import Col from '../spacing/Col';
 import Row from '../spacing/Row';
+import CellEditor from './CellEditor';
+import MitoAPI from '../../api';
+import { getIsHeader } from './selectionUtils';
 
 const FormulaBar = (props: {
-    sheetData: SheetData | undefined,
+    sheetData: SheetData, // TODO: Make this potentially udnefiend
     selection: MitoSelection,
     editorState: EditorState | undefined;
+    sheetIndex: number,
+    gridState: GridState,
+    setEditorState: React.Dispatch<React.SetStateAction<EditorState | undefined>>,
+    setGridState: React.Dispatch<React.SetStateAction<GridState>>,
+    scrollAndRenderedContainerRef: React.RefObject<HTMLDivElement>,
+    containerRef: React.RefObject<HTMLDivElement>,
+    mitoAPI: MitoAPI,
 }): JSX.Element => {
+    const rowIndex = props.selection.endingRowIndex
+    const columnIndex = props.selection.endingColumnIndex
 
-    const {columnHeader, columnFormula, cellValue} = getCellDataFromCellIndexes(props.sheetData, props.selection.endingRowIndex, props.selection.endingColumnIndex);
+    const {columnHeader, columnFormula, cellValue} = getCellDataFromCellIndexes(props.sheetData, rowIndex, columnIndex);
     const originalFormulaBarValue = '' + (columnFormula !== undefined && columnFormula !== '' ? columnFormula : (cellValue !== undefined ? cellValue : ''));
     const cellEditingCellData = props.editorState === undefined ? undefined : getCellDataFromCellIndexes(props.sheetData, props.editorState.rowIndex, props.editorState.columnIndex);
     const formulaBarColumnHeader = props.editorState === undefined ? columnHeader : cellEditingCellData?.columnHeader;
     const formulaBarValue = props.editorState === undefined ? originalFormulaBarValue : getFullFormula(props.editorState.formula, formulaBarColumnHeader || '', props.editorState.pendingSelectedColumns);
 
+    console.log(props.editorState !== undefined && props.editorState.editorLocation === 'formula bar')
+    console.log(formulaBarValue)
 
     return(
         <Row 
@@ -44,7 +58,42 @@ const FormulaBar = (props: {
                 <div className="formula-bar-vertical-line"/>
             </Col>
             <Col flex='1'>
-                <input className="formula-bar-formula text-header-3 text-overflow-hide element-width-block" value={formulaBarValue} disabled />
+                {props.editorState !== undefined && props.editorState.editorLocation === 'formula bar' &&
+                    <CellEditor 
+                        sheetData={props.sheetData}
+                        sheetIndex={props.sheetIndex}
+                        gridState={props.gridState}
+                        editorState={props.editorState}
+                        setGridState={props.setGridState}
+                        setEditorState={props.setEditorState}
+                        scrollAndRenderedContainerRef={props.scrollAndRenderedContainerRef}
+                        containerRef={props.containerRef}
+                        mitoAPI={props.mitoAPI}
+                    />
+                }
+                {(props.editorState === undefined || props.editorState.editorLocation !== 'formula bar') &&
+                    <p 
+                        className="formula-bar-formula text-header-3 text-overflow-hide element-width-block" 
+                        onDoubleClick={() => {
+                            // Don't open for headers
+                            if ((rowIndex === undefined || columnIndex === undefined) || getIsHeader(rowIndex, columnIndex)) {
+                                return;
+                            }
+
+                            props.setEditorState({
+                                rowIndex: rowIndex,
+                                columnIndex: columnIndex,
+                                formula: formulaBarValue,
+                                // As in google sheets, if the starting formula is non empty, we default to the 
+                                // arrow keys scrolling in the editor
+                                arrowKeysScrollInFormula: false,
+                                editorLocation: 'formula bar'
+                            })
+                        }}
+                    >
+                        {formulaBarValue} 
+                    </p>
+                }
             </Col>
         </Row>
     )

--- a/mitosheet/src/components/endo/FormulaBar.tsx
+++ b/mitosheet/src/components/endo/FormulaBar.tsx
@@ -33,7 +33,7 @@ const FormulaBar = (props: {
     const formulaBarColumnHeader = props.editorState === undefined ? columnHeader : cellEditingCellData?.columnHeader;
     const formulaBarValue = props.editorState === undefined ? originalFormulaBarValue : getFullFormula(props.editorState.formula, formulaBarColumnHeader || '', props.editorState.pendingSelectedColumns);
 
-    // The formula bar ref
+    // The container for the entire formula bar
     const containerRef = useRef<HTMLDivElement>(null);
 
     return(
@@ -48,9 +48,9 @@ const FormulaBar = (props: {
             suppressTopBottomMargin
         >
             <Col offset={.25}>
-                <p className="formula-bar-column-header text-header-3 text-overflow-hide">
+                <div className="formula-bar-column-header text-header-3 text-overflow-hide">
                     {formulaBarColumnHeader}
-                </p>
+                </div>
             </Col>
             {(props.editorState === undefined || props.editorState.editorLocation !== 'formula bar') &&
                 <>
@@ -83,10 +83,7 @@ const FormulaBar = (props: {
                 </>
             }
             {props.editorState !== undefined && props.editorState.editorLocation === 'formula bar' &&
-                <Col flex='1' ref={containerRef}>
-                    <div>
-                        cell Editor
-                    </div>
+                <Col flex='1'>
                     <CellEditor 
                         sheetData={props.sheetData}
                         sheetIndex={props.sheetIndex}

--- a/mitosheet/src/components/endo/FormulaBar.tsx
+++ b/mitosheet/src/components/endo/FormulaBar.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Mito
 
-import React, { useRef } from 'react';
+import React from 'react';
 
 // Import css
 import "../../../css/FormulaBar.css";
@@ -23,6 +23,7 @@ const FormulaBar = (props: {
     setEditorState: React.Dispatch<React.SetStateAction<EditorState | undefined>>,
     setGridState: React.Dispatch<React.SetStateAction<GridState>>,
     mitoAPI: MitoAPI,
+    mitoContainerRef: React.RefObject<HTMLDivElement>;
 }): JSX.Element => {
     const rowIndex = props.selection.endingRowIndex
     const columnIndex = props.selection.endingColumnIndex
@@ -32,9 +33,6 @@ const FormulaBar = (props: {
     const cellEditingCellData = props.editorState === undefined ? undefined : getCellDataFromCellIndexes(props.sheetData, props.editorState.rowIndex, props.editorState.columnIndex);
     const formulaBarColumnHeader = props.editorState === undefined ? columnHeader : cellEditingCellData?.columnHeader;
     const formulaBarValue = props.editorState === undefined ? originalFormulaBarValue : getFullFormula(props.editorState.formula, formulaBarColumnHeader || '', props.editorState.pendingSelectedColumns);
-
-    // The container for the entire formula bar
-    const containerRef = useRef<HTMLDivElement>(null);
 
     return(
         <Row 
@@ -91,8 +89,9 @@ const FormulaBar = (props: {
                         editorState={props.editorState}
                         setGridState={props.setGridState}
                         setEditorState={props.setEditorState}
-                        scrollAndRenderedContainerRef={containerRef}
-                        containerRef={containerRef}
+                        // Since no scrolling effects the formula bar cell editor, we just pass the mitoContainerRef for both
+                        scrollAndRenderedContainerRef={props.mitoContainerRef}  
+                        containerRef={props.mitoContainerRef}
                         mitoAPI={props.mitoAPI}
                     />
                 </Col>

--- a/mitosheet/src/components/endo/cellEditorUtils.tsx
+++ b/mitosheet/src/components/endo/cellEditorUtils.tsx
@@ -5,7 +5,6 @@ import { ColumnHeader, ColumnID, SheetData } from "../../types";
 import { getDisplayColumnHeader, isPrimitiveColumnHeader, rowIndexToColumnHeaderLevel } from "../../utils/columnHeaders";
 import { getCellDataFromCellIndexes } from "./utils";
 
-
 /* 
     Given a formula and and optional pending columns that are inserted
     at some location, creates the formula that would result if the user

--- a/mitosheet/src/components/modals/ErrorModal.tsx
+++ b/mitosheet/src/components/modals/ErrorModal.tsx
@@ -42,7 +42,7 @@ const ErrorModal = (
                         </div>
                     }
                     {props.error.traceback && viewTraceback &&
-                        <div className='flex flex-column text-align-left text-overflow-hidden text-overflow-scroll mt-5px' style={{height: '200px', border: '1px solid var(--mito-purple)', borderRadius: '2px', padding: '5px'}}>
+                        <div className='flex text-align-left text-overflow-hidden text-overflow-scroll mt-5px' style={{height: '200px', border: '1px solid var(--mito-purple)', borderRadius: '2px', padding: '5px'}}>
                             <pre>{props.error.traceback}</pre>
                         </div>
                     }

--- a/mitosheet/src/components/modals/ReplayAnalysisModals.tsx
+++ b/mitosheet/src/components/modals/ReplayAnalysisModals.tsx
@@ -46,7 +46,7 @@ const ErrorReplayedAnalysisModal = (
                         }
                     </div>
                     {props.error?.traceback && viewTraceback &&
-                        <div className='flex flex-column text-align-left text-overflow-hidden text-overflow-scroll mt-5px' style={{height: '200px', border: '1px solid var(--mito-purple)', borderRadius: '2px', padding: '5px'}}>
+                        <div className='flex text-align-left text-overflow-hidden text-overflow-scroll mt-5px' style={{height: '200px', border: '1px solid var(--mito-purple)', borderRadius: '2px', padding: '5px'}}>
                             <pre>{props.error.traceback}</pre>
                         </div>
                     }

--- a/mitosheet/src/components/spacing/Col.tsx
+++ b/mitosheet/src/components/spacing/Col.tsx
@@ -40,6 +40,10 @@ interface ColProps {
        * @param [title] - Title to put on the column div
     */
     title?: string;
+    /**
+     * @param [ref] - A ref to register on this row
+    */
+    ref?: React.RefObject<HTMLDivElement>
 }
 
 
@@ -65,6 +69,7 @@ const Col = (props: ColProps): JSX.Element => {
             }}
             onClick={props.onClick}
             title={props.title}
+            ref={props.ref}
         >
             {props.children}
         </div>

--- a/mitosheet/src/components/spacing/Row.tsx
+++ b/mitosheet/src/components/spacing/Row.tsx
@@ -37,6 +37,11 @@ interface RowProps {
      */
     title?: string
 
+    /**
+     * @param [ref] - A ref to register on this row
+     */
+    ref?: React.RefObject<HTMLDivElement>
+
 }
 
 /**
@@ -80,7 +85,9 @@ const Row = (props: RowProps): JSX.Element => {
                 ...props.style,
                 justifyContent: props.justify,
                 alignItems: props.align,
-            }}>
+            }}
+            ref={props.ref}
+        >
             {props.children}
         </div>
     )

--- a/mitosheet/src/components/spacing/Row.tsx
+++ b/mitosheet/src/components/spacing/Row.tsx
@@ -36,12 +36,6 @@ interface RowProps {
      * @param [title] - Tooltip to be displayed when the user's mouse hovers over the row
      */
     title?: string
-
-    /**
-     * @param [ref] - A ref to register on this row
-     */
-    ref?: React.RefObject<HTMLDivElement>
-
 }
 
 /**
@@ -86,7 +80,6 @@ const Row = (props: RowProps): JSX.Element => {
                 justifyContent: props.justify,
                 alignItems: props.align,
             }}
-            ref={props.ref}
         >
             {props.children}
         </div>

--- a/mitosheet/src/types.tsx
+++ b/mitosheet/src/types.tsx
@@ -412,6 +412,7 @@ export type EditorState = {
     rowIndex: number;
     columnIndex: number;
     formula: string;
+    editorLocation: 'cell' | 'formula bar'
 
     pendingSelectedColumns?: {
         columnHeaders: (ColumnHeader)[]

--- a/mitosheet/src/utils/actions.tsx
+++ b/mitosheet/src/utils/actions.tsx
@@ -587,6 +587,7 @@ export const createActions = (
                     rowIndex: -1,
                     columnIndex: startingColumnIndex,
                     formula: getDisplayColumnHeader(finalColumnHeader),
+                    editorLocation: 'cell'
                 })
 
             },
@@ -677,7 +678,8 @@ export const createActions = (
                     columnIndex: startingColumnIndex,
                     formula: startingFormula,
                     // Since you can't reference other cells in a data column, we default to scrolling in the formula
-                    arrowKeysScrollInFormula: true
+                    arrowKeysScrollInFormula: true,
+                    editorLocation: 'cell'
                 })
             },
             isDisabled: () => {
@@ -709,7 +711,8 @@ export const createActions = (
                     formula: columnFormula !== undefined ? columnFormula : '',
                     // As in google sheets, if the starting formula is non empty, we default to the 
                     // arrow keys scrolling in the editor
-                    arrowKeysScrollInFormula: columnFormula !== undefined && columnFormula.length > 0
+                    arrowKeysScrollInFormula: columnFormula !== undefined && columnFormula.length > 0,
+                    editorLocation: 'cell'
                 })
             },
             isDisabled: () => {
@@ -1174,7 +1177,8 @@ export const getSpreadsheetFormulaAction = (
                 rowIndex: rowIndex,
                 columnIndex: columnIndex,
                 formula: "=" + spreadsheetAction?.function + "(",
-                arrowKeysScrollInFormula: false
+                arrowKeysScrollInFormula: false,
+                editorLocation: 'cell'
             })
         },
         isDisabled: () => {


### PR DESCRIPTION
# Description

This was pretty difficult to implement, in particular setting the location and the size of the formula bar was rough. I don't think the current implementation is the smoothest, as it doesn't use the same approach that we use for in-cell cell editors, but I couldn't really figure out how to do it otherwise. In particular, using the refs was difficult. 

The two known remaining things to do are:
- [ ] Currently, if you use your mouse to select a column while using the formula bar cell editor, the column always gets added to the front of the formula. Not sure why, I have to look into it. 
- [ ] When using the formula bar cell editor, we always want the arrow keys to move inside of the formula, like Excel. This is easy. 

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.