### PR TITLE
Sheet crashing error reduction

### DIFF
--- a/mitosheet/src/components/taskpanes/Concat/ConcatTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/Concat/ConcatTaskpane.tsx
@@ -85,7 +85,7 @@ const ConcatTaskpane = (props: ConcatTaskpaneProps): JSX.Element => {
     const [selectableSheetIndexes] = useState(props.sheetDataArray.map((sd, index) => index));
 
     // For each sheet concatonated together, find all of the columns that are not included in the final result
-    const concatSheetColumnHeaders = Object.values(props.sheetDataArray[props.sheetDataArray.length - 1].columnIDsMap)
+    const concatSheetColumnHeaders = Object.values(props.sheetDataArray[props.sheetDataArray.length - 1]?.columnIDsMap || {})
     const notIncludedColumnsArray = params?.sheet_indexes.map(sheetIndex => {
         return Object.values(props.sheetDataArray[sheetIndex]?.columnIDsMap || {}).filter(columnHeader => {
             // Because concat_edit makes a new sheet and you can't reopen the concat taskpane or reorder sheets,

--- a/mitosheet/src/components/taskpanes/Graph/GraphSetupTab.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/GraphSetupTab.tsx
@@ -155,6 +155,8 @@ function GraphSetupTab(
         ? `${props.graphParams.graphCreation.graph_type} does not support further breaking down data using color.`
         : 'Use an additional column to further breakdown the data by color.';
 
+    const columnIDsMap = props.columnIDsMapArray[graphSheetIndex] || {};
+
     return (  
         <Fragment>
             <div className='graph-sidebar-toolbar-content'>
@@ -247,7 +249,7 @@ function GraphSetupTab(
                 </Row>
 
                 <AxisSection
-                    columnIDsMap={props.columnIDsMapArray[graphSheetIndex]}
+                    columnIDsMap={columnIDsMap}
                     graphType={props.graphParams.graphCreation.graph_type}
                     graphAxis={GraphAxisType.X_AXIS}
                     selectedColumnIDs={props.graphParams.graphCreation.x_axis_column_ids}
@@ -256,7 +258,7 @@ function GraphSetupTab(
                     mitoAPI={props.mitoAPI}
                 />
                 <AxisSection
-                    columnIDsMap={props.columnIDsMapArray[graphSheetIndex]}
+                    columnIDsMap={columnIDsMap}
                     graphType={props.graphParams.graphCreation.graph_type}
                     graphAxis={GraphAxisType.Y_AXIS}
                     selectedColumnIDs={props.graphParams.graphCreation.y_axis_column_ids}
@@ -281,7 +283,7 @@ function GraphSetupTab(
                         </Col>
                         <Col>
                             <Select 
-                                value={props.graphParams.graphCreation.color ? getDisplayColumnHeader(props.columnIDsMapArray[graphSheetIndex][props.graphParams.graphCreation.color]) : 'None'}
+                                value={props.graphParams.graphCreation.color ? getDisplayColumnHeader(columnIDsMap[props.graphParams.graphCreation.color]) : 'None'}
                                 disabled={GRAPHS_THAT_DONT_SUPPORT_COLOR.includes(props.graphParams.graphCreation.graph_type)}
                                 width='small'
                                 searchable

--- a/mitosheet/src/utils/actions.tsx
+++ b/mitosheet/src/utils/actions.tsx
@@ -50,6 +50,10 @@ export const createActions = (
             shortTitle: 'Add Col',
             longTitle: 'Add a column',
             actionFunction: () => {
+                if (sheetDataArray.length === 0) {
+                    return;
+                }
+
                 // We turn off editing mode, if it is on
                 setEditorState(undefined);
 


### PR DESCRIPTION
# Description

See work here: https://www.notion.so/trymito/4-16-22-b05459f5e10d47dd9839c377d70ef8f2. The main fix is a sheet crashing bug if you opened concat with no data. Only one user hit it so far, so nbd, but we can do a better job testing for no data in the future.

NOTE: the number of sheet crashing bugs is down 4x from a month ago. That's awesome.

# Testing

Test changed things from the doc!

# Documentation

Nope.