### PR TITLE
Add notebook installer

### DIFF
--- a/docs/getting-started/installing-mito/README.md
+++ b/docs/getting-started/installing-mito/README.md
@@ -1,5 +1,5 @@
 ---
-description: How to get a Mito sheet rendering on your own JupyterLab
+description: How to install the mitosheet package for Jupyter
 ---
 
 # Installing Mito
@@ -30,7 +30,7 @@ Then, run the installer. This command may take a few moments to run:
 python -m mitoinstaller install
 ```
 
-If you have a currently running JupyterLab process, then restart your kernel, and refresh your page to complete installation.
+By default, the installer installs Mito for classic Jupyter Notebook as well as JupyterLab. It will automatically launch JupyterLab, but you can also use the Mitosheet package in a Jupyter Notebook.
 
 {% hint style="warning" %}
 If you run into errors during installation, check our [common installation errors](common-install-errors.md) to resolve them.

--- a/docs/getting-started/installing-mito/common-install-errors.md
+++ b/docs/getting-started/installing-mito/common-install-errors.md
@@ -12,10 +12,10 @@ Want help? [Join our discord for immediate support.](https://discord.com/invite/
 
 #### The sheet does not render when I call mitosheet.sheet().
 
-This is the most common error, and it is likely because you have failed to refresh your JupyterLab. This is usually fixable through the following steps:
+This is the most common error, and it is likely because you have failed to refresh your Jupyter. This is usually fixable through the following steps:
 
-1. Shut down the currently running JupyterLab instance. Close all browser tabs with JupyterLab open.
-2. Relaunch JupyterLab. Retry calling `mitosheet.sheet()`
+1. Shut down the currently running Jupyter instance. Close all browser tabs with Jupyter open.
+2. Relaunch Jupyter. Retry calling `mitosheet.sheet()`
 
 If this does not work, try rerunning the installer and repeating the above steps. 
 
@@ -23,7 +23,7 @@ If this does not work, try rerunning the installer and repeating the above steps
 
 If your installation fails with a `PermissionError`, then you likely will be able to successfully install Mito by rerunning the installation commands with adminstrator privileges.
 
-For Windows, this means[ running the command prompt as an admi](https://grok.lsu.edu/article.aspx?articleid=16850)n, and for Mac/Linux means using the sudo command for the installation commands
+For Windows, this means[ running the command prompt as an admin](https://grok.lsu.edu/article.aspx?articleid=16850), and for Mac/Linux means using the sudo command for the installation commands
 
 #### The installer finished successfully, but the sheet is not rendering when I[ follow the instructions](../../how-to/creating-a-mitosheet/) to create a mitosheet.
 
@@ -33,14 +33,6 @@ This bug can be tricky to resolve. For the best chance of getting sorted, take t
 2. When the developer tab opens up, click the section labeled `console` and scroll to the top. You will likely see a red print out with some error messages.
 3. Screen shot those error messages, and send them in an email to jake@sagacollab.com! We'll respond within a few hours, and should be able to get your issues resolved!
 
-#### I got the error `ValueError: Please install Node.js and npm before continuing installation.`
-
-To resolve this:
-
-1. Download the Node.js installer [here](https://nodejs.org/en/download/) and follow the prompts to install Node.
-2. Restart your terminal.
-3. Rerun the installation commands, and they should work properly.
-
 **I'm getting an SSL error on MacOSX**
 
 You're probably receiving this error because you need to install the SSL certificates**.**&#x20;
@@ -49,8 +41,6 @@ You're probably receiving this error because you need to install the SSL certifi
 * If you installed Python using MacPorts, run `sudo port install curl-ca-bundle` in a terminal.
 
 If you have any other issues installing Mito, or you're looking to install Mito on JupyterHub or Kuberenetes, [get in touch](https://discord.com/invite/XdJSZyejJU). We'd love to help.
-
-
 
 **I do not have Python installed.**
 

--- a/docs/getting-started/installing-mito/installing-mito-in-a-docker-container.md
+++ b/docs/getting-started/installing-mito/installing-mito-in-a-docker-container.md
@@ -7,7 +7,7 @@ description: Instructions for using Mito with Docker.
 ## Before Installing Mito
 
 1. Verify that the docker image is using **Python 3.7** or greater.
-2. Ensure that the docker image can use JupyterLab 3.0.
+2. Ensure that the docker image can use classic Jupyter Notebooks or JupyterLab 3.x.
 
 ## Installing Mito
 
@@ -15,9 +15,11 @@ Add the following command to your docker file:
 
 ```
 RUN pip install --no-cache-dir mitosheet
+RUN jupyter nbextension install mitosheet
+RUN jupyter nbextension enable mitosheet
 ```
 
-Then, after you launch this container and run a **JupyterLab** instance, you should be able to create a Mitosheet following the standard instructions.
+Then, after you launch this container, you can run a classic Jupyter Notebook or JupyterLab instance and create a mitosheet with the following standard instructions.
 
 {% content-ref url="../../how-to/creating-a-mitosheet/" %}
 [creating-a-mitosheet](../../how-to/creating-a-mitosheet/)

--- a/docs/getting-started/overview-of-the-mitosheet.md
+++ b/docs/getting-started/overview-of-the-mitosheet.md
@@ -8,7 +8,7 @@ description: >-
 
 ### The Mitosheet in a notebook
 
-Mitosheet is simply a spreadsheet that exists inside of your JupyterLab notebook. This allows you to _very_ quickly bounce back and forth between doing data analysis in Python and exploring/manipulating your data in the Mitosheet.
+Mitosheet is simply a spreadsheet that exists inside of your Jupyter notebook. This allows you to _very_ quickly bounce back and forth between doing data analysis in Python and exploring/manipulating your data in the Mitosheet.
 
 Because the Mitosheet is optimized for your Python data analysis, every tab inside of your Mitosheet represents a Pandas dataframe. To demonstrate this dataframe aspect, let's take a look at displaying a single dataframe (of Tesla stock prices) in a Mitosheet:
 

--- a/docs/how-to/creating-a-mitosheet/README.md
+++ b/docs/how-to/creating-a-mitosheet/README.md
@@ -7,12 +7,12 @@ description: This documentation will teach you how to create your first Mitoshee
 {% embed url="https://youtu.be/URM6kGfOJuM" %}
 
 {% hint style="warning" %}
-Before rendering a Mitosheet, make sure [you've installed Mito correctly. ](../../getting-started/installing-mito/)If you just installed mito, **make sure to refresh your JupyterLab notebook.**
+Before rendering a Mitosheet, make sure [you've installed Mito correctly. ](../../getting-started/installing-mito/)If you just installed mito, **make sure to refresh your Jupyter notebook.**
 {% endhint %}
 
-To create a Mitosheet, open a new or existing JupyterLab notebook. The common command to start JupyterLab is `python -m jupyter lab`. If you don't know how to create a JupyterLab notebook, you can watch this [8 second video.](https://www.youtube.com/watch?v=QL0IxDAOEc0)
+To create a new mitsoheet, open a new or existing Jupyter notebook. For classic Notebook users, you can launch Jupyter with `python -m jupyter notebook`. For JupyterLab users, you can launch Jupyter with `python -m jupyter lab`.
 
-Once you've created a notebook, copy and paste the code below into a Jupyter code cell.
+Once you've created a new notebook, copy and paste the code below into a Jupyter code cell.
 
 ```python
 import mitosheet

--- a/docs/how-to/importing-data-to-mito.md
+++ b/docs/how-to/importing-data-to-mito.md
@@ -12,7 +12,7 @@ Mito can handle any tabular data. If it's in a dataframe, then it's ready for Mi
 
 ## Passing Dataframes to Mito
 
-Mito displays any dataframe that is passed directly to a `mitosheet.sheet(df1, df2)`. To see an example of displaying a dataframe in a Mitosheet, copy and run the code below in a JupyterLab cell:
+Mito displays any dataframe that is passed directly to a `mitosheet.sheet(df1, df2)`. To see an example of displaying a dataframe in a Mitosheet, copy and run the code below in a Jupyter cell:
 
 ```python
 # import Python packages

--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -14,6 +14,10 @@ See the common installation issues section [here](../getting-started/installing-
 
 ## Where can I use Mito?
 
-Currently, Mito only works in Juptyer Lab 2.0 and 3.0. Mito does not work in Jupyter Notebooks, Google Collab, or Visual Studio Code.&#x20;
+Currently, Mito works in the following enviornments:
+- Classic Jupyter Notebooks
+- JupyterLab 2.x and 3.x
 
-##
+Mito does not support the following enviornments:
+- Google Collab
+- VS Code

--- a/mitoinstaller/mitoinstaller/commands.py
+++ b/mitoinstaller/mitoinstaller/commands.py
@@ -114,6 +114,7 @@ def upgrade_mito_installer() -> None:
     """
     Upgrades the mito installer package itself
     """
+    return # TODO: remove this, just for testing
     run_command([sys.executable, "-m", "pip", "install", 'mitoinstaller', '--upgrade', '--no-cache-dir'])
 
 

--- a/mitoinstaller/mitoinstaller/commands.py
+++ b/mitoinstaller/mitoinstaller/commands.py
@@ -108,7 +108,8 @@ def install_pip_packages(*packages: str, test_pypi: bool=False) -> None:
         sys_call.append(package)
     sys_call.append('--upgrade')
 
-    run_command(sys_call)
+    stdout, stderr = run_command(sys_call)
+    print(stdout, stderr)
 
 def upgrade_mito_installer() -> None:
     """

--- a/mitoinstaller/mitoinstaller/commands.py
+++ b/mitoinstaller/mitoinstaller/commands.py
@@ -114,7 +114,6 @@ def upgrade_mito_installer() -> None:
     """
     Upgrades the mito installer package itself
     """
-    return # TODO: remove this, just for testing
     run_command([sys.executable, "-m", "pip", "install", 'mitoinstaller', '--upgrade', '--no-cache-dir'])
 
 

--- a/mitoinstaller/mitoinstaller/create_startup_file.py
+++ b/mitoinstaller/mitoinstaller/create_startup_file.py
@@ -45,10 +45,12 @@ def create_startup_file():
 
     # Create the startup folder if it does not exist
     if not os.path.exists(IPYTHON_STARTUP_FOLDER):
+        print("MAKING FOLDER")
         os.makedirs(IPYTHON_STARTUP_FOLDER)
         
     # Create the import mitosheet file
     with open(IMPORT_MITOSHEET_FILE_PATH, 'w+') as f:
+        print("WRITING!")
         # And write the default object
         f.write(IMPORT_MITOSHEET_FILE_CONTENTS)
 

--- a/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
@@ -8,27 +8,31 @@ import time
 import analytics
 from mitoinstaller.create_startup_file import create_startup_file
 from mitoinstaller.installer_steps.installer_step import InstallerStep
+from mitoinstaller.jupyter_utils import get_prefered_jupyter_env_variable
 from mitoinstaller.log_utils import log
 from mitoinstaller.starter_notebook import (MITO_STARTER_NOTEBOOK_PATH,
                                             try_create_starter_notebook)
 from mitoinstaller.user_install import is_running_test
 from termcolor import colored  # type: ignore
 
-
-def replace_process_with_jupyter_lab():
+def replace_process_with_jupyter():
     """
-    Switch the currently running process with a running JupyterLab instance.
+    Switch the currently running process with a running lab or notebook
+    instance, depending on which we think the user would prefer.
 
     If we are running tests, then we do not launch JLab. 
     # TODO: we don't want to launch this if we're inside a Docker script?
     """
     if is_running_test():
         return
+    # Get the prefered jupyter to launch, which we saved before
+    prefered_jupyter = get_prefered_jupyter_env_variable()
 
     # Flush analytics before we terminate the process, as it's our last chance
     analytics.flush()
-    
-    os.execl(sys.executable, 'python', '-m', 'jupyter', 'lab', MITO_STARTER_NOTEBOOK_PATH)
+
+    os.execl(sys.executable, 'python', '-m', 'jupyter', prefered_jupyter, MITO_STARTER_NOTEBOOK_PATH)
+
 
 
 def print_success_message():
@@ -55,8 +59,8 @@ FINAL_INSTALLER_STEPS = [
         try_create_starter_notebook
     ),
     InstallerStep(
-        'Start JupyterLab',
-        replace_process_with_jupyter_lab,
+        'Start Jupyter',
+        replace_process_with_jupyter,
         optional=True
     ),
     # We do out best to replace the running process with JupyterLab, but 

--- a/mitoinstaller/mitoinstaller/installer_steps/initial_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/initial_installer_steps.py
@@ -1,9 +1,11 @@
+import importlib
 import os
 import sys
 
 from mitoinstaller import __version__
 from mitoinstaller.commands import upgrade_mito_installer
 from mitoinstaller.installer_steps.installer_step import InstallerStep
+from mitoinstaller.jupyter_utils import set_prefered_jupyter_env_variable
 from mitoinstaller.log_utils import identify, log
 from mitoinstaller.user_install import (USER_JSON_PATH, go_pro,
                                         try_create_user_json_file)
@@ -24,6 +26,18 @@ def initial_install_step_create_user():
         # If the user is going pro, make sure they are set to pro
         go_pro()
 
+def initial_install_step_add_env_for_which_jupyter():
+    """
+    This install steps checks, up front, which very of jupyter we should
+    launch: lab or notebook. It then stores this as an enviornment variable
+    so that the final installer steps can launch it. 
+
+    We do this up front, so that we can see which packages that user has 
+    installed before installing Mito.
+    """
+    set_prefered_jupyter_env_variable()
+
+
 INITIAL_INSTALLER_STEPS = [
     InstallerStep(
         'Create mito user',
@@ -33,5 +47,9 @@ INITIAL_INSTALLER_STEPS = [
         'Upgrade mitoinstaller',
         upgrade_mito_installer,
         optional=True
+    ),
+    InstallerStep(
+        'Setting up enviornment',
+        initial_install_step_add_env_for_which_jupyter,
     ),
 ]

--- a/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
@@ -55,9 +55,8 @@ def install_step_mitosheet_install_mitosheet():
     install_pip_packages('mitosheet', test_pypi='--test-pypi' in sys.argv)
 
 def install_step_mitosheet_activate_notebook_extension():
-    #run_command(['jupyter', 'nbextension', 'install', 'mitosheet'])
-    #run_command(['jupyter', 'nbextension', 'enable', 'mitosheet'])
-    print("TODO: fix this step when mitosheet for notebooks is deployed!")
+    run_command(['jupyter', 'nbextension', 'install', '--py', '--user', 'mitosheet'])
+    run_command(['jupyter', 'nbextension', 'enable', '--py', '--user', 'mitosheet'])
 
     
 MITOSHEET_INSTALLER_STEPS = [

--- a/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
@@ -1,7 +1,7 @@
 import sys
 from time import perf_counter
 from mitoinstaller.commands import (get_jupyterlab_metadata,
-                                    install_pip_packages,
+                                    install_pip_packages, run_command,
                                     uninstall_pip_packages)
 from mitoinstaller.installer_steps.installer_step import InstallerStep
 from mitoinstaller.log_utils import log
@@ -54,6 +54,11 @@ def install_step_mitosheet_install_mitosheet():
     print("This might take a few moments...")
     install_pip_packages('mitosheet', test_pypi='--test-pypi' in sys.argv)
 
+def install_step_mitosheet_activate_notebook_extension():
+    #run_command(['jupyter', 'nbextension', 'install', 'mitosheet'])
+    #run_command(['jupyter', 'nbextension', 'enable', 'mitosheet'])
+    print("TODO: fix this step when mitosheet for notebooks is deployed!")
+
     
 MITOSHEET_INSTALLER_STEPS = [
     InstallerStep(
@@ -68,5 +73,9 @@ MITOSHEET_INSTALLER_STEPS = [
         'Install mitosheet',
         install_step_mitosheet_install_mitosheet,
         should_log_success=True
+    ),
+    InstallerStep(
+        'Activate extension',
+        install_step_mitosheet_activate_notebook_extension
     ),
 ]

--- a/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
@@ -55,8 +55,8 @@ def install_step_mitosheet_install_mitosheet():
     install_pip_packages('mitosheet', test_pypi='--test-pypi' in sys.argv)
 
 def install_step_mitosheet_activate_notebook_extension():
-    run_command(['jupyter', 'nbextension', 'install', '--py', '--user', 'mitosheet'])
-    run_command(['jupyter', 'nbextension', 'enable', '--py', '--user', 'mitosheet'])
+    run_command([sys.executable, "-m", 'jupyter', 'nbextension', 'install', '--py', '--user', 'mitosheet'])
+    run_command([sys.executable, "-m", 'jupyter', 'nbextension', 'enable', '--py', '--user', 'mitosheet'])
 
     
 MITOSHEET_INSTALLER_STEPS = [

--- a/mitoinstaller/mitoinstaller/jupyter_utils.py
+++ b/mitoinstaller/mitoinstaller/jupyter_utils.py
@@ -1,0 +1,47 @@
+
+
+import importlib
+import os
+
+from mitoinstaller.log_utils import log
+
+# The name of the env variable we set
+PREFERED_JUPYTER_ENV_VARIABLE_NAME = 'MITO_PREFFERED_JUPYTER'
+
+# The names of which jupyter is prefered
+JUPYTER_LAB = 'lab'
+JUPYTER_NOTEBOOK = 'notebook'
+
+def set_prefered_jupyter_env_variable():
+    notebook = importlib.util.find_spec('notebook')
+    jupyterlab = importlib.util.find_spec('jupyterlab')
+
+    if notebook is None and jupyterlab is None:
+        # If the user has nothing installed, we default to lab
+        # TODO: in the future, we can randomize here - we just have to log it
+        prefered_jupyter = JUPYTER_LAB
+
+    if notebook is not None and jupyterlab is None:
+        prefered_jupyter = JUPYTER_NOTEBOOK
+
+    elif notebook is None and jupyterlab is not None:
+        prefered_jupyter = JUPYTER_LAB
+
+    else:
+        # In the case that the user has both notebook and lab installed, we 
+        # just default to lab. In the future, we can try and figure out if 
+        # one is running, or we can randomize
+        prefered_jupyter = JUPYTER_LAB
+
+    os.environ[PREFERED_JUPYTER_ENV_VARIABLE_NAME] = prefered_jupyter
+    
+    log('setting_prefered_jupyterlab', {
+        'prefered_jupyter': prefered_jupyter
+    })
+
+def get_prefered_jupyter_env_variable() -> str:
+    if PREFERED_JUPYTER_ENV_VARIABLE_NAME not in os.environ or os.environ[PREFERED_JUPYTER_ENV_VARIABLE_NAME] is None:
+        # If for some reason the variable is not set, then default to lab
+        return JUPYTER_LAB
+
+    return os.environ[PREFERED_JUPYTER_ENV_VARIABLE_NAME]

--- a/mitoinstaller/tests/test_installs.py
+++ b/mitoinstaller/tests/test_installs.py
@@ -40,7 +40,9 @@ def test_create_startup_file(venv: VirtualEnvironment):
     venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])
     venv.run_python_module_command(['pip', 'install', 'jupyterlab==3.0'])
     
-    venv.run_python_module_command(['mitoinstaller', 'install', '--test-pypi'])
+    out = venv.run_python_module_command(['mitoinstaller', 'install', '--test-pypi'])
+    print(out[0])
+    print(out[1])
 
     IMPORT_MITOSHEET_FILE_PATH = os.path.join(os.path.expanduser("~"), '.ipython', 'profile_default', 'startup', 'import_mitosheet.py')
     

--- a/mitoinstaller/tests/test_launch_jupyter.py
+++ b/mitoinstaller/tests/test_launch_jupyter.py
@@ -1,0 +1,14 @@
+
+from mitoinstaller.jupyter_utils import get_prefered_jupyter_env_variable
+from tests.conftest import VirtualEnvironment
+
+def test_detects_notebook_as_prefered(venv: VirtualEnvironment):
+    venv.run_python_module_command(['pip', 'install', 'notebook'])
+    venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])
+    out = venv.run_python_script('from mitoinstaller.jupyter_utils import get_prefered_jupyter_env_variable, set_prefered_jupyter_env_variable; set_prefered_jupyter_env_variable(); print(get_prefered_jupyter_env_variable())')
+    assert out.strip() == 'notebook'
+
+def test_defaults_to_lab(venv: VirtualEnvironment):
+    venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])
+    out = venv.run_python_script('from mitoinstaller.jupyter_utils import get_prefered_jupyter_env_variable, set_prefered_jupyter_env_variable; set_prefered_jupyter_env_variable(); print(get_prefered_jupyter_env_variable())')
+    assert out.strip() == 'lab'

--- a/mitoinstaller/tests/test_static_user_id.py
+++ b/mitoinstaller/tests/test_static_user_id.py
@@ -2,7 +2,7 @@ import pytest
 import json
 import os
 
-from tests.conftest import VirtualEnvironment, clear_user_json
+from tests.conftest import VirtualEnvironment
 
 from mitoinstaller.user_install import get_static_user_id, try_create_user_json_file
 from mitoinstaller.user_install import USER_JSON_PATH
@@ -15,7 +15,7 @@ def get_mitosheet_version_in_user_json():
         return None
 
 
-def test_import_mitosheet_keeps_same_user_id(venv: VirtualEnvironment, clear_user_json):
+def test_import_mitosheet_keeps_same_user_id(venv: VirtualEnvironment):
     venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])    
     # First, check there is no user.json
     static_user_id_installer = get_static_user_id()
@@ -38,7 +38,7 @@ def test_import_mitosheet_keeps_same_user_id(venv: VirtualEnvironment, clear_use
     mitosheet_version = get_mitosheet_version_in_user_json()
     assert mitosheet_version is not None
 
-def test_installer_does_not_overwrite_static_user_id(venv: VirtualEnvironment, clear_user_json):
+def test_installer_does_not_overwrite_static_user_id(venv: VirtualEnvironment):
     venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])    
     # First, check there is no user.json
     static_user_id_installer = get_static_user_id()
@@ -69,7 +69,7 @@ def test_installer_does_not_overwrite_static_user_id(venv: VirtualEnvironment, c
     assert mitosheet_version is not None
 
 
-def test_running_installer_twice_does_not_overwrite_static_user_id(venv: VirtualEnvironment, clear_user_json):
+def test_running_installer_twice_does_not_overwrite_static_user_id(venv: VirtualEnvironment):
     venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])    
     # First, check there is no user.json
     static_user_id_installer = get_static_user_id()

--- a/mitoinstaller/tests/test_static_user_id.py
+++ b/mitoinstaller/tests/test_static_user_id.py
@@ -2,7 +2,7 @@ import pytest
 import json
 import os
 
-from tests.conftest import VirtualEnvironment
+from tests.conftest import VirtualEnvironment, clear_user_json
 
 from mitoinstaller.user_install import get_static_user_id, try_create_user_json_file
 from mitoinstaller.user_install import USER_JSON_PATH
@@ -15,7 +15,7 @@ def get_mitosheet_version_in_user_json():
         return None
 
 
-def test_import_mitosheet_keeps_same_user_id(venv: VirtualEnvironment):
+def test_import_mitosheet_keeps_same_user_id(venv: VirtualEnvironment, clear_user_json):
     venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])    
     # First, check there is no user.json
     static_user_id_installer = get_static_user_id()
@@ -38,7 +38,7 @@ def test_import_mitosheet_keeps_same_user_id(venv: VirtualEnvironment):
     mitosheet_version = get_mitosheet_version_in_user_json()
     assert mitosheet_version is not None
 
-def test_installer_does_not_overwrite_static_user_id(venv: VirtualEnvironment):
+def test_installer_does_not_overwrite_static_user_id(venv: VirtualEnvironment, clear_user_json):
     venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])    
     # First, check there is no user.json
     static_user_id_installer = get_static_user_id()
@@ -69,7 +69,7 @@ def test_installer_does_not_overwrite_static_user_id(venv: VirtualEnvironment):
     assert mitosheet_version is not None
 
 
-def test_running_installer_twice_does_not_overwrite_static_user_id(venv: VirtualEnvironment):
+def test_running_installer_twice_does_not_overwrite_static_user_id(venv: VirtualEnvironment, clear_user_json):
     venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])    
     # First, check there is no user.json
     static_user_id_installer = get_static_user_id()

--- a/mitoinstaller/tests/test_static_user_id.py
+++ b/mitoinstaller/tests/test_static_user_id.py
@@ -25,8 +25,6 @@ def test_import_mitosheet_keeps_same_user_id(venv: VirtualEnvironment, clear_use
     # We get the user id created by the installer
     static_user_id_installer = get_static_user_id()
     assert static_user_id_installer is not None
-    mitosheet_version = get_mitosheet_version_in_user_json()
-    assert mitosheet_version is None
     
     # Then, we import Mito
     venv.run_python_script('import mitosheet')
@@ -54,8 +52,6 @@ def test_installer_does_not_overwrite_static_user_id(venv: VirtualEnvironment, c
     # We get the user id created by the installer
     static_user_id_installer = get_static_user_id()
     assert static_user_id_installer is not None
-    mitosheet_version = get_mitosheet_version_in_user_json()
-    assert mitosheet_version is None
     
     # Then, we import Mito
     venv.run_python_script('import mitosheet')

--- a/mitosheet/mitosheet.json
+++ b/mitosheet/mitosheet.json
@@ -1,0 +1,5 @@
+{
+    "load_extensions": {
+      "mitosheet/extension": true
+    }
+}

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -36,6 +36,7 @@ HERE = Path(__file__).parent.resolve()
 
 package_json = json.loads(open('package.json').read())
 lab_path = Path(pjoin(HERE, 'mitosheet', 'labextension'))
+notebook_path = Path(pjoin(HERE, 'mitosheet', 'nbextension'))
 
 
 # The name of the project
@@ -162,9 +163,15 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
     labext_name = name
 
     data_files_spec = [
+        # Notebook extension data files
+        ('share/jupyter/nbextensions/mitosheet', notebook_path, '*.*'),
+        ('etc/jupyter/nbconfig/notebook.d', '.', 'mitosheet.json'),
+
+        # Lab extension data files
         ("share/jupyter/labextensions/%s" % labext_name, str(lab_path), "**"),
         ("share/jupyter/labextensions/%s" % labext_name, str(HERE), "install.json"),
     ]
+
 
     cmdclass = create_cmdclass("jsdeps",
         package_data_spec=package_data_spec,

--- a/trymito.io/components/CTAButtons/CTAButtons.tsx
+++ b/trymito.io/components/CTAButtons/CTAButtons.tsx
@@ -7,7 +7,7 @@ const CTAButtons = (): JSX.Element => {
     return (
         <div className={styles.cta_buttons_container}> 
             <TextButton 
-                text='Install Mito on JupyterLab'
+                text='Install Mito for Jupyter'
                 href='https://docs.trymito.io/getting-started/installing-mito'
             />
             <p className={styles.cta_subbutton}>

--- a/trymito.io/pages/index.tsx
+++ b/trymito.io/pages/index.tsx
@@ -33,7 +33,7 @@ const Home: NextPage = () => {
 
               <p className={titleStyles.description}>
                 If you can edit an Excel file, you can now write code. <br/>
-                Join thousands using Mito in JupyterLab.
+                Join thousands using Mito in Jupyter.
               </p>
             
               <div className={homeStyles.cta_button_and_video_spacer}>

--- a/trymito.io/pages/plans.tsx
+++ b/trymito.io/pages/plans.tsx
@@ -30,7 +30,7 @@ export interface Feature {
 
 const INTEGRATION_FEATURES: Feature[] = [
   {
-    feature: 'JupyterLab 2 & 3',
+    feature: 'Jupyter Notebooks',
     planSupport: {
       'Open Source': true,
       'Pro': true,


### PR DESCRIPTION
# Description

This PR follows this spec: https://www.notion.so/trymito/Notebooks-Installer-Specification-ed28937abcba413aa27cff012e6274ff. It simplifies the logic for checking which to launch, which I think is fine for now! We can improve on v2 - let's get this out ASAP!

Once we get this merged and dogfooded, we're good to ready to deploy notebooks!

# Testing

Should launch Notebook:
```
deactivate; rm -rf venv; python3 -m venv venv; source venv/bin/activate && pip install -r requirements.txt; pip install notebook; python -m mitoinstaller install --test-pypi
```

Should launch Lab:
```
deactivate; rm -rf venv; python3 -m venv venv; source venv/bin/activate && pip install -r requirements.txt;  python -m mitoinstaller install --test-pypi
```

Feel free to test other configurations.

# Documentation

See new docs, and also changes to website w.r.t. to JupyterLab!