### PR TITLE
mitoinstaller: get smarter about when we launch notebooks

### DIFF
--- a/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
@@ -9,7 +9,6 @@ import analytics
 from mitoinstaller.create_startup_file import create_startup_file
 from mitoinstaller.installer_steps.installer_step import InstallerStep
 from mitoinstaller.jupyter_utils import get_prefered_jupyter_env_variable
-from mitoinstaller.log_utils import log
 from mitoinstaller.starter_notebook import (MITO_STARTER_NOTEBOOK_PATH,
                                             try_create_starter_notebook)
 from mitoinstaller.user_install import is_running_test

--- a/mitoinstaller/mitoinstaller/jupyter_utils.py
+++ b/mitoinstaller/mitoinstaller/jupyter_utils.py
@@ -2,6 +2,8 @@
 
 import importlib
 import os
+import sys
+from mitoinstaller.commands import run_command
 
 from mitoinstaller.log_utils import log
 
@@ -12,31 +14,54 @@ PREFERED_JUPYTER_ENV_VARIABLE_NAME = 'MITO_PREFFERED_JUPYTER'
 JUPYTER_LAB = 'lab'
 JUPYTER_NOTEBOOK = 'notebook'
 
+def is_jupyter_notebook_running() -> bool:
+    """
+    Format of command output: 
+
+    Currently running servers:
+    http://localhost:8888/?token=wenflwenflqnwdlkqmwldkm :: Path/to/launch
+    """
+    try:
+        return '::' in run_command([sys.executable, "-m", 'jupyter', 'notebook', 'list'])[0]
+    except:
+        return False
+
 def set_prefered_jupyter_env_variable():
     notebook = importlib.util.find_spec('notebook')
     jupyterlab = importlib.util.find_spec('jupyterlab')
+
+    reason = 'default'
 
     if notebook is None and jupyterlab is None:
         # If the user has nothing installed, we default to lab
         # TODO: in the future, we can randomize here - we just have to log it
         prefered_jupyter = JUPYTER_LAB
+        reason = 'neither notebook or lab installed'
 
     if notebook is not None and jupyterlab is None:
         prefered_jupyter = JUPYTER_NOTEBOOK
+        reason = 'only notebook installed'
 
     elif notebook is None and jupyterlab is not None:
         prefered_jupyter = JUPYTER_LAB
+        reason = 'only lab installed'
 
     else:
-        # In the case that the user has both notebook and lab installed, we 
-        # just default to lab. In the future, we can try and figure out if 
-        # one is running, or we can randomize
-        prefered_jupyter = JUPYTER_LAB
+        # In the case that the user has both notebook and lab installed, we
+        # check if the user has any notebooks running. If they do, we use
+        # notebooks. Otherwise, we default to lab
+        if is_jupyter_notebook_running():
+            prefered_jupyter = JUPYTER_NOTEBOOK
+            reason = 'both installed and notebook running'
+        else:
+            prefered_jupyter = JUPYTER_LAB
+            reason = 'both installed and notebook not running'
 
     os.environ[PREFERED_JUPYTER_ENV_VARIABLE_NAME] = prefered_jupyter
     
     log('setting_prefered_jupyterlab', {
-        'prefered_jupyter': prefered_jupyter
+        'prefered_jupyter': prefered_jupyter,
+        'prefered_jupyter_reason': reason
     })
 
 def get_prefered_jupyter_env_variable() -> str:

--- a/mitoinstaller/mitoinstaller/jupyter_utils.py
+++ b/mitoinstaller/mitoinstaller/jupyter_utils.py
@@ -52,10 +52,10 @@ def set_prefered_jupyter_env_variable():
         # notebooks. Otherwise, we default to lab
         if is_jupyter_notebook_running():
             prefered_jupyter = JUPYTER_NOTEBOOK
-            reason = 'both installed and notebook running'
+            reason = 'both notebook and lab installed and notebook running'
         else:
             prefered_jupyter = JUPYTER_LAB
-            reason = 'both installed and notebook not running'
+            reason = 'both notebook and lab installed and notebook not running'
 
     os.environ[PREFERED_JUPYTER_ENV_VARIABLE_NAME] = prefered_jupyter
     


### PR DESCRIPTION
# Description

See Zulip. We should launch them into notebook if they are running notebook.

# Testing

```
deactivate; rm -rf venv; python3 -m venv venv; source venv/bin/activate && pip install -r requirements.txt; pip install jupyterlab; jupyter notebook
```
Then, run the local install command, and you should launch in notebook.

# Documentation

Nope.