### PR TITLE
mitosheet: add right click on column header

### DIFF
--- a/mitosheet/src/components/endo/ColumnHeader.tsx
+++ b/mitosheet/src/components/endo/ColumnHeader.tsx
@@ -54,7 +54,7 @@ const ColumnHeader = (props: {
     mitoAPI: MitoAPI;
 }): JSX.Element => {
 
-    const [showDropdown, setShowDropdown] = useState(false);
+    const [openColumnHeaderDropdown, setOpenColumnHeaderDropdown] = useState(false);
 
     const selected = getIsCellSelected(props.gridState.selections, -1, props.columnIndex);
     const width = props.gridState.widthDataArray[props.gridState.sheetIndex].widthArray[props.columnIndex];
@@ -132,7 +132,7 @@ const ColumnHeader = (props: {
             draggable={!editingColumnHeader ? 'true' : 'false'}
             onContextMenu={(e) => {
                 e.preventDefault()
-                setShowDropdown(true);
+                setOpenColumnHeaderDropdown(true);
             }}
         >
             {lowerLevelColumnHeaders.map((lowerLevelColumnHeader, levelIndex) => {
@@ -360,10 +360,10 @@ const ColumnHeader = (props: {
                     </form>
                 }
             </div>
-            {showDropdown && 
+            {openColumnHeaderDropdown && 
                 <ColumnHeaderDropdown
                     mitoAPI={props.mitoAPI}
-                    setDisplayDropdown={setShowDropdown}
+                    setOpenColumnHeaderDropdown={setOpenColumnHeaderDropdown}
                     setUIState={props.setUIState}
                     openColumnHeaderEditor={openColumnHeaderEditor}
                     sheetIndex={props.gridState.sheetIndex}

--- a/mitosheet/src/components/endo/ColumnHeaderDropdown.tsx
+++ b/mitosheet/src/components/endo/ColumnHeaderDropdown.tsx
@@ -1,0 +1,81 @@
+// Copyright (c) Saga Inc.
+
+import React, { useEffect } from 'react';
+import MitoAPI from '../../jupyter/api';
+import { ColumnID, UIState } from '../../types';
+import Dropdown from '../elements/Dropdown';
+import DropdownItem from '../elements/DropdownItem';
+import DropdownSectionSeperator from '../elements/DropdownSectionSeperator';
+import { TaskpaneType } from '../taskpanes/taskpanes';
+
+/*
+    Displays a set of actions one can perform on a column header
+*/
+export default function ColumnHeaderDropdown(props: {
+    mitoAPI: MitoAPI;
+    setOpenColumnHeaderDropdown: React.Dispatch<React.SetStateAction<boolean>>,
+    setUIState: React.Dispatch<React.SetStateAction<UIState>>;
+    openColumnHeaderEditor: () => void;
+    sheetIndex: number;
+    columnID: ColumnID;
+}): JSX.Element {
+
+    // Log opening this dropdown
+    useEffect(() => {void props.mitoAPI.log('opened_column_header_dropdown')}, [])
+
+    return (
+        <Dropdown
+            closeDropdown={() => props.setOpenColumnHeaderDropdown(false)}
+            width='medium'
+        >
+            <DropdownItem 
+                title='Delete Column'
+                onClick={() => {
+                    props.mitoAPI.editDeleteColumn(props.sheetIndex, [props.columnID]);
+                }}
+            />
+            <DropdownItem 
+                title='Rename Column'
+                onClick={() => {
+                    props.openColumnHeaderEditor()
+                }}
+            />
+            <DropdownSectionSeperator isDropdownSectionSeperator/>
+            <DropdownItem
+                title='Filter'
+                onClick={() => {
+                    props.setUIState(prevUIState => {
+                        return {
+                            ...prevUIState,
+                            currOpenTaskpane: {type: TaskpaneType.CONTROL_PANEL}
+                        }
+                    })
+                }}
+            />
+            
+            <DropdownItem 
+                title='Sort'
+                onClick={() => {
+                    props.setUIState(prevUIState => {
+                        return {
+                            ...prevUIState,
+                            currOpenTaskpane: {type: TaskpaneType.CONTROL_PANEL}
+                        }
+                    })
+                }}
+            />
+            <DropdownItem 
+                title='Change Dtype'
+                onClick={() => {
+                    props.setUIState(prevUIState => {
+                        return {
+                            ...prevUIState,
+                            currOpenTaskpane: {type: TaskpaneType.CONTROL_PANEL}
+                        }
+                    })
+                }}
+            />
+            
+        </Dropdown>
+    )
+}

--- a/mitosheet/src/components/endo/ColumnHeaderDropdown.tsx
+++ b/mitosheet/src/components/endo/ColumnHeaderDropdown.tsx
@@ -32,7 +32,7 @@ export default function ColumnHeaderDropdown(props: {
             <DropdownItem 
                 title='Delete Column'
                 onClick={() => {
-                    props.mitoAPI.editDeleteColumn(props.sheetIndex, [props.columnID]);
+                    void props.mitoAPI.editDeleteColumn(props.sheetIndex, [props.columnID]);
                 }}
             />
             <DropdownItem 

--- a/mitosheet/src/components/endo/ColumnHeaderDropdown.tsx
+++ b/mitosheet/src/components/endo/ColumnHeaderDropdown.tsx
@@ -6,6 +6,7 @@ import { ColumnID, UIState } from '../../types';
 import Dropdown from '../elements/Dropdown';
 import DropdownItem from '../elements/DropdownItem';
 import DropdownSectionSeperator from '../elements/DropdownSectionSeperator';
+import { ControlPanelTab } from '../taskpanes/ControlPanel/ControlPanelTaskpane';
 import { TaskpaneType } from '../taskpanes/taskpanes';
 
 /*
@@ -47,7 +48,8 @@ export default function ColumnHeaderDropdown(props: {
                     props.setUIState(prevUIState => {
                         return {
                             ...prevUIState,
-                            currOpenTaskpane: {type: TaskpaneType.CONTROL_PANEL}
+                            currOpenTaskpane: {type: TaskpaneType.CONTROL_PANEL},
+                            selectedColumnControlPanelTab: ControlPanelTab.FilterSort
                         }
                     })
                 }}
@@ -59,7 +61,8 @@ export default function ColumnHeaderDropdown(props: {
                     props.setUIState(prevUIState => {
                         return {
                             ...prevUIState,
-                            currOpenTaskpane: {type: TaskpaneType.CONTROL_PANEL}
+                            currOpenTaskpane: {type: TaskpaneType.CONTROL_PANEL},
+                            selectedColumnControlPanelTab: ControlPanelTab.FilterSort
                         }
                     })
                 }}
@@ -70,12 +73,41 @@ export default function ColumnHeaderDropdown(props: {
                     props.setUIState(prevUIState => {
                         return {
                             ...prevUIState,
-                            currOpenTaskpane: {type: TaskpaneType.CONTROL_PANEL}
+                            currOpenTaskpane: {type: TaskpaneType.CONTROL_PANEL},
+                            selectedColumnControlPanelTab: ControlPanelTab.FilterSort
                         }
                     })
                 }}
             />
-            
+            <DropdownSectionSeperator isDropdownSectionSeperator/>
+            <DropdownItem 
+                title='View Unique Values'
+                onClick={() => {
+                    props.setUIState(prevUIState => {
+                        return {
+                            ...prevUIState,
+                            currOpenTaskpane: {
+                                type: TaskpaneType.CONTROL_PANEL,
+                            },
+                            selectedColumnControlPanelTab: ControlPanelTab.UniqueValues
+                        }
+                    })
+                }}
+            />
+            <DropdownItem 
+                title='View Summary Stats'
+                onClick={() => {
+                    props.setUIState(prevUIState => {
+                        return {
+                            ...prevUIState,
+                            currOpenTaskpane: {
+                                type: TaskpaneType.CONTROL_PANEL,
+                            },
+                            selectedColumnControlPanelTab: ControlPanelTab.SummaryStats
+                        }
+                    })
+                }}
+            />
         </Dropdown>
     )
 }


### PR DESCRIPTION
# Description

This adds a set of action to the column header. Let me know your thoughts!

The only issue with this is that the open column header dropdown is that it's not in global state so that you can open multiple at once. We can refactor this if we want, but I am kinda ok with it. let me know ur thoughts.

# Testing

Try the actions! 

# Documentation

N/A