### PR TITLE
mitosheet: update types of step performer to be consistent

### DIFF
--- a/mitosheet/mitosheet/step.py
+++ b/mitosheet/mitosheet/step.py
@@ -143,7 +143,7 @@ class Step:
         params = self.step_performer.saturate(new_prev_state, self.params)
 
         # Actually execute the data transformation
-        post_state_and_execution_data = self.step_performer.execute(new_prev_state, **params)
+        post_state_and_execution_data = self.step_performer.execute(new_prev_state, params)
 
         if post_state_and_execution_data is not None:
             # If we don't get anything new back, then we just make this

--- a/mitosheet/mitosheet/step_performers/bulk_old_rename/bulk_old_rename.py
+++ b/mitosheet/mitosheet/step_performers/bulk_old_rename/bulk_old_rename.py
@@ -16,6 +16,7 @@ from mitosheet.step_performers.bulk_old_rename.deprecated_utils import \
 from mitosheet.step_performers.column_steps.rename_column import \
     rename_column_headers_in_state
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 
 
 class BulkOldRenameStepPerformer(StepPerformer):
@@ -46,12 +47,7 @@ class BulkOldRenameStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        move_to_deprecated_id_algorithm: bool=False,
-        **params: Any
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls,prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
         """
         If move_to_deprecated_id_algorithm, then this step is being
         used at the start of a replayed analysis to stand in for
@@ -62,6 +58,7 @@ class BulkOldRenameStepPerformer(StepPerformer):
         make sure that users who pass dataframes into Mito directly
         do not have their analysis break when they upgrade.
         """
+        move_to_deprecated_id_algorithm: bool = get_param(params, 'move_to_deprecated_id_algorithm') if get_param(params, 'move_to_deprecated_id_algorithm') else False 
 
         post_state = prev_state.copy(deep_sheet_indexes=list(range(len(prev_state.dfs))))
 

--- a/mitosheet/mitosheet/step_performers/column_steps/add_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/add_column.py
@@ -12,6 +12,7 @@ from mitosheet.code_chunks.step_performers.column_steps.add_column_code_chunk im
 from mitosheet.errors import make_column_exists_error, make_no_sheet_error
 from mitosheet.state import FORMAT_DEFAULT, State
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_code
 
 
@@ -34,14 +35,10 @@ class AddColumnStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        column_header: str,
-        column_header_index: int,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index: int = get_param(params, 'sheet_index')
+        column_header: str = get_param(params, 'column_header')
+        column_header_index: int = get_param(params, 'column_header_index')
             
         # if the sheet doesn't exist, throw an error
         if not prev_state.does_sheet_index_exist_within_state(sheet_index):

--- a/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
@@ -28,6 +28,7 @@ from mitosheet.state import FORMAT_DEFAULT, State
 from mitosheet.step_performers.column_steps.set_column_formula import (
     refresh_dependant_columns)
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 from mitosheet.types import ColumnID
 
 
@@ -56,16 +57,12 @@ class ChangeColumnDtypeStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        column_id: ColumnID,
-        old_dtype: str,
-        new_dtype: str,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
-        # Create the post state
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index: int = get_param(params, 'sheet_index')
+        column_id: ColumnID = get_param(params, 'column_id')
+        old_dtype: str = get_param(params, 'old_dtype')
+        new_dtype: str = get_param(params, 'new_dtype')
+
         post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])
 
         column_header = prev_state.column_ids.get_column_header_by_id(sheet_index, column_id)

--- a/mitosheet/mitosheet/step_performers/column_steps/change_column_format.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/change_column_format.py
@@ -9,6 +9,7 @@ from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.code_chunks.empty_code_chunk import EmptyCodeChunk
 from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 from mitosheet.types import ColumnID
 
 class ChangeColumnFormatStepPerformer(StepPerformer):
@@ -29,14 +30,10 @@ class ChangeColumnFormatStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        column_ids: List[ColumnID],
-        format_type: Dict[str, Any],
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index: int = get_param(params, 'sheet_index')
+        column_ids: List[ColumnID] = get_param(params, 'column_ids')
+        format_type: Dict[str, Any] = get_param(params, 'format_type')
 
         # Make a post state, that is a deep copy
         post_state = prev_state.copy()

--- a/mitosheet/mitosheet/step_performers/column_steps/delete_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/delete_column.py
@@ -13,6 +13,7 @@ from mitosheet.errors import make_invalid_column_delete_error
 from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
 from mitosheet.evaluation_graph_utils import create_column_evaluation_graph, topological_sort_columns
+from mitosheet.step_performers.utils import get_param
 from mitosheet.transpiler.transpile_utils import column_header_list_to_transpiled_code
 from mitosheet.types import ColumnID
 
@@ -35,13 +36,9 @@ class DeleteColumnStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        column_ids: List[ColumnID],
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index: int = get_param(params, 'sheet_index')
+        column_ids: List[ColumnID] = get_param(params, 'column_ids')
 
         # Make a post state, that is a deep copy
         post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])

--- a/mitosheet/mitosheet/step_performers/column_steps/rename_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/rename_column.py
@@ -16,6 +16,7 @@ from mitosheet.evaluation_graph_utils import create_column_evaluation_graph
 from mitosheet.parser import safe_replace
 from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 from mitosheet.types import ColumnHeader, ColumnID
 
 
@@ -41,15 +42,12 @@ class RenameColumnStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        column_id: ColumnID,
-        new_column_header: str,
-        level=None,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index: int = get_param(params, 'sheet_index')
+        column_id: ColumnID = get_param(params, 'column_id')
+        new_column_header: str = get_param(params, 'new_column_header')
+        level: int = get_param(params, 'new_column_header')
+
         if new_column_header in prev_state.dfs[sheet_index].keys():
             raise make_column_exists_error(new_column_header)
 

--- a/mitosheet/mitosheet/step_performers/column_steps/reorder_column.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/reorder_column.py
@@ -12,6 +12,7 @@ from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.code_chunks.step_performers.column_steps.reorder_column_code_chunk import ReorderColumnCodeChunk
 from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 from mitosheet.transpiler.transpile_utils import \
     column_header_to_transpiled_code
 from mitosheet.types import ColumnHeader, ColumnID
@@ -47,14 +48,10 @@ class ReorderColumnStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        column_id: ColumnID,
-        new_column_index: int,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index: int = get_param(params, 'sheet_index')
+        column_id: ColumnID = get_param(params, 'column_id')
+        new_column_index: int = get_param(params, 'new_column_index')
 
         column_header = prev_state.column_ids.get_column_header_by_id(sheet_index, column_id)
 

--- a/mitosheet/mitosheet/step_performers/column_steps/set_column_formula.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/set_column_formula.py
@@ -19,6 +19,7 @@ from mitosheet.sheet_functions import FUNCTIONS
 from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
 from mitosheet.evaluation_graph_utils import (create_column_evaluation_graph, creates_circularity, topological_sort_dependent_columns)
+from mitosheet.step_performers.utils import get_param
 from mitosheet.types import ColumnHeader, ColumnID
 
 
@@ -60,15 +61,12 @@ class SetColumnFormulaStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        column_id: ColumnID,
-        old_formula: str,
-        new_formula: str,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index: int = get_param(params, 'sheet_index')
+        column_id: ColumnID = get_param(params, 'column_id')
+        old_formula: str = get_param(params, 'old_formula')
+        new_formula: str = get_param(params, 'new_formula')
+
         column_header = prev_state.column_ids.get_column_header_by_id(sheet_index, column_id)
 
         # If nothings changed, there's no work to do

--- a/mitosheet/mitosheet/step_performers/concat.py
+++ b/mitosheet/mitosheet/step_performers/concat.py
@@ -13,6 +13,7 @@ from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.code_chunks.step_performers.concat_code_chunk import ConcatCodeChunk
 from mitosheet.state import DATAFRAME_SOURCE_CONCAT, State
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 
 
 class ConcatStepPerformer(StepPerformer):
@@ -33,14 +34,11 @@ class ConcatStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        join: str, # inner | outter
-        ignore_index: bool,
-        sheet_indexes: List[int],
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+
+        join = get_param(params, 'join') # inner | outter
+        ignore_index = get_param(params, 'ignore_index') # inner | outter
+        sheet_indexes = get_param(params, 'sheet_indexes') # inner | outter
 
         post_state = prev_state.copy()
 

--- a/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_delete.py
+++ b/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_delete.py
@@ -10,6 +10,7 @@ from mitosheet.code_chunks.step_performers.dataframe_steps.dataframe_delete_code
 
 from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 
 
 class DataframeDeleteStepPerformer(StepPerformer):
@@ -33,14 +34,9 @@ class DataframeDeleteStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        old_dataframe_name: str,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
-        # Create a new step and save the parameters
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index: int = get_param(params, 'sheet_index')
+        
         post_state = prev_state.copy()
 
         # Execute the delete

--- a/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_duplicate.py
+++ b/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_duplicate.py
@@ -12,6 +12,7 @@ from mitosheet.column_headers import get_column_header_id
 
 from mitosheet.state import DATAFRAME_SOURCE_DUPLICATED, State
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 from mitosheet.utils import get_first_unused_dataframe_name
 
 
@@ -33,12 +34,9 @@ class DataframeDuplicateStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index: int = get_param(params, 'sheet_index')
+
         post_state = prev_state.copy()
 
         # Execute the step

--- a/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_rename.py
+++ b/mitosheet/mitosheet/step_performers/dataframe_steps/dataframe_rename.py
@@ -10,6 +10,7 @@ from mitosheet.code_chunks.step_performers.dataframe_steps.dataframe_rename_code
 
 from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 from mitosheet.utils import get_valid_dataframe_name
 
 
@@ -35,14 +36,11 @@ class DataframeRenameStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        old_dataframe_name: str,
-        new_dataframe_name: str,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index: int = get_param(params, 'sheet_index')
+        old_dataframe_name: str = get_param(params, 'old_dataframe_name')
+        new_dataframe_name: str = get_param(params, 'new_dataframe_name')
+
         # Bail early, if there is no change
         if old_dataframe_name == new_dataframe_name:
             return prev_state, None

--- a/mitosheet/mitosheet/step_performers/drop_duplicates.py
+++ b/mitosheet/mitosheet/step_performers/drop_duplicates.py
@@ -5,12 +5,13 @@
 # Distributed under the terms of the GPL License.
 from copy import deepcopy
 from time import perf_counter
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.code_chunks.step_performers.drop_duplicates_code_chunk import DropDuplicatesCodeChunk
 
 from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 from mitosheet.transpiler.transpile_utils import (
     column_header_list_to_transpiled_code, column_header_to_transpiled_code)
 from mitosheet.types import ColumnID
@@ -33,14 +34,11 @@ class DropDuplicatesStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        column_ids: List[ColumnID],
-        keep: Union[str, bool],
-        **params
-    ):
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index = get_param(params, 'sheet_index')
+        column_ids = get_param(params, 'column_ids')
+        keep = get_param(params, 'keep')
+
         column_headers = [
             prev_state.column_ids.get_column_header_by_id(sheet_index, column_id)
             for column_id in column_ids
@@ -49,7 +47,7 @@ class DropDuplicatesStepPerformer(StepPerformer):
         # If the subset is none, then we don't actually do the drop, as there are no
         # duplicates between 0 columns
         if len(column_headers) == 0:
-            return None
+            return prev_state, {}
 
         # We make a new state to modify it
         post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])

--- a/mitosheet/mitosheet/step_performers/filter.py
+++ b/mitosheet/mitosheet/step_performers/filter.py
@@ -13,6 +13,7 @@ from mitosheet.code_chunks.code_chunk import CodeChunk
 
 from mitosheet.step_performers.step_performer import StepPerformer
 from mitosheet.state import State
+from mitosheet.step_performers.utils import get_param
 from mitosheet.types import ColumnHeader, ColumnID
 
 # The constants used in the filter step itself as filter conditions
@@ -81,15 +82,11 @@ class FilterStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute(  # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        column_id: ColumnID,
-        operator: str,
-        filters,
-        **params,
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index: int = get_param(params, 'sheet_index')
+        column_id: ColumnID = get_param(params, 'column_id')
+        operator: str = get_param(params, 'operator')
+        filters: Any = get_param(params, 'filters')
 
         # Get the correct column_header
         column_header = prev_state.column_ids.get_column_header_by_id(

--- a/mitosheet/mitosheet/step_performers/graph_steps/graph.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/graph.py
@@ -18,6 +18,7 @@ from mitosheet.step_performers.graph_steps.plotly_express_graphs import (
     get_plotly_express_graph_code,
 )
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 from mitosheet.types import GraphID
 
 
@@ -75,19 +76,15 @@ class GraphStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute(  # type: ignore
-        cls,
-        prev_state: State,
-        graph_id: GraphID,
-        graph_preprocessing: Dict[str, Any],
-        graph_creation: Dict[str, Any],
-        graph_styling: Dict[str, Any],
-        graph_rendering: Dict[str, Any],
-        **params,
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
         """
         Returns the new post state with the updated graph_data_dict
         """
+        graph_id: GraphID = get_param(params, 'graph_id')
+        graph_preprocessing: Dict[str, Any] = get_param(params, 'graph_preprocessing')
+        graph_creation: Dict[str, Any] = get_param(params, 'graph_creation')
+        graph_styling: Dict[str, Any] = get_param(params, 'graph_styling')
+        graph_rendering: Dict[str, Any] = get_param(params, 'graph_rendering')
 
         # We make a new state to modify it
         post_state = prev_state.copy()

--- a/mitosheet/mitosheet/step_performers/graph_steps/graph_delete.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/graph_delete.py
@@ -10,6 +10,7 @@ from mitosheet.code_chunks.empty_code_chunk import EmptyCodeChunk
 
 from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 from mitosheet.types import GraphID
 
 
@@ -31,12 +32,8 @@ class GraphDeleteStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        graph_id: GraphID,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        graph_id: GraphID = get_param(params, 'graph_id')
 
         # Create a new step and save the parameters
         post_state = prev_state.copy()

--- a/mitosheet/mitosheet/step_performers/graph_steps/graph_duplicate.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/graph_duplicate.py
@@ -11,6 +11,7 @@ from mitosheet.code_chunks.empty_code_chunk import EmptyCodeChunk
 
 from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 from mitosheet.types import GraphID
 
 
@@ -32,13 +33,10 @@ class GraphDuplicateStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        old_graph_id: GraphID,
-        new_graph_id: GraphID,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        old_graph_id: GraphID = get_param(params, 'old_graph_id')
+        new_graph_id: GraphID = get_param(params, 'new_graph_id')
+
         post_state = prev_state.copy()
 
         # Execute the step

--- a/mitosheet/mitosheet/step_performers/graph_steps/graph_rename.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/graph_rename.py
@@ -10,6 +10,7 @@ from mitosheet.code_chunks.empty_code_chunk import EmptyCodeChunk
 
 from mitosheet.state import State
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 from mitosheet.types import GraphID
 
 
@@ -34,14 +35,11 @@ class GraphRenameStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        graph_id: GraphID,
-        old_graph_tab_name: str,
-        new_graph_tab_name: str,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        graph_id: GraphID = get_param(params, 'graph_id')
+        old_graph_tab_name: str = get_param(params, 'old_graph_tab_name')
+        new_graph_tab_name: str = get_param(params, 'new_graph_tab_name')
+
         # Bail early, if there is no change or the new name is empty
         if old_graph_tab_name == new_graph_tab_name or new_graph_tab_name == '' :
             return prev_state, None

--- a/mitosheet/mitosheet/step_performers/import_steps/excel_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/excel_import.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import pandas as pd
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.code_chunks.step_performers.import_steps.excel_import_code_chunk import ExcelImportCodeChunk
+from mitosheet.step_performers.utils import get_param
 
 from mitosheet.utils import get_valid_dataframe_name
 from mitosheet.state import DATAFRAME_SOURCE_IMPORTED, State
@@ -34,16 +35,12 @@ class ExcelImportStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        file_name: str,
-        sheet_names: List[str],
-        has_headers: bool,
-        skiprows: int,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
-        # Create a new step
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        file_name: str = get_param(params, 'file_name')
+        sheet_names: List[str] = get_param(params, 'sheet_names')
+        has_headers: bool = get_param(params, 'has_headers')
+        skiprows: int = get_param(params, 'skiprows')
+
         post_state = prev_state.copy()
 
         read_excel_params = {

--- a/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
@@ -14,6 +14,7 @@ import chardet
 import pandas as pd
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import SimpleImportCodeChunk
+from mitosheet.step_performers.utils import get_param
 
 from mitosheet.utils import get_valid_dataframe_names
 from mitosheet.errors import make_is_directory_error
@@ -41,13 +42,10 @@ class SimpleImportStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        file_names: List[str],
-        use_deprecated_id_algorithm: bool=False,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        file_names: List[str] = get_param(params, 'file_names')
+        use_deprecated_id_algorithm: bool = get_param(params, 'use_deprecated_id_algorithm') if get_param(params, 'use_deprecated_id_algorithm') else False
+
         # If any of the files are directories, we throw an error to let
         # the user know
         for file_name in file_names:

--- a/mitosheet/mitosheet/step_performers/merge.py
+++ b/mitosheet/mitosheet/step_performers/merge.py
@@ -15,6 +15,7 @@ from mitosheet.errors import (make_incompatible_merge_headers_error,
                               make_incompatible_merge_key_error)
 from mitosheet.state import DATAFRAME_SOURCE_MERGED, State
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 from mitosheet.transpiler.transpile_utils import (
     column_header_list_to_transpiled_code, column_header_to_transpiled_code)
 from mitosheet.types import ColumnHeader, ColumnID
@@ -41,18 +42,14 @@ class MergeStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        how: str,
-        sheet_index_one: int,
-        merge_key_column_id_one: ColumnID,
-        selected_column_ids_one: List[ColumnID],
-        sheet_index_two: int,
-        merge_key_column_id_two: ColumnID,
-        selected_column_ids_two: List[ColumnID],
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        how = get_param(params, 'how')
+        sheet_index_one = get_param(params, 'sheet_index_one')
+        merge_key_column_id_one = get_param(params, 'merge_key_column_id_one')
+        selected_column_ids_one = get_param(params, 'selected_column_ids_one')
+        sheet_index_two = get_param(params, 'sheet_index_two')
+        merge_key_column_id_two = get_param(params, 'merge_key_column_id_two')
+        selected_column_ids_two = get_param(params, 'selected_column_ids_two')
 
         merge_key_one = prev_state.column_ids.get_column_header_by_id(sheet_index_one, merge_key_column_id_one)
         merge_key_two = prev_state.column_ids.get_column_header_by_id(sheet_index_two, merge_key_column_id_two)

--- a/mitosheet/mitosheet/step_performers/pivot.py
+++ b/mitosheet/mitosheet/step_performers/pivot.py
@@ -13,6 +13,7 @@ from mitosheet.code_chunks.step_performers.pivot_code_chunk import PivotCodeChun
 from mitosheet.column_headers import flatten_column_header
 from mitosheet.errors import (make_invalid_aggregation_error,
                               make_invalid_pivot_error, make_no_column_error)
+from mitosheet.step_performers.utils import get_param
 from mitosheet.telemetry.telemetry_utils import log
 from mitosheet.state import DATAFRAME_SOURCE_PIVOTED, State
 from mitosheet.step_performers.step_performer import StepPerformer
@@ -75,18 +76,14 @@ class PivotStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        pivot_rows_column_ids: List[ColumnID],
-        pivot_columns_column_ids: List[ColumnID],
-        values_column_ids_map: Dict[ColumnID, Collection[str]],
-        flatten_column_headers: bool,
-        destination_sheet_index: int=None,
-        use_deprecated_id_algorithm: bool=False,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index: int = get_param(params, 'sheet_index')
+        pivot_rows_column_ids: List[ColumnID] = get_param(params, 'pivot_rows_column_ids')
+        pivot_columns_column_ids: List[ColumnID] = get_param(params, 'pivot_columns_column_ids')
+        values_column_ids_map: Dict[ColumnID, Collection[str]] = get_param(params, 'values_column_ids_map')
+        flatten_column_headers: bool = get_param(params, 'flatten_column_headers')
+        destination_sheet_index: int = get_param(params, 'destination_sheet_index')
+        use_deprecated_id_algorithm: bool = get_param(params, 'use_deprecated_id_algorithm') if get_param(params, 'use_deprecated_id_algorithm') else False
 
         pivot_rows = prev_state.column_ids.get_column_headers_by_ids(sheet_index, pivot_rows_column_ids)
         pivot_columns = prev_state.column_ids.get_column_headers_by_ids(sheet_index, pivot_columns_column_ids)

--- a/mitosheet/mitosheet/step_performers/set_cell_value.py
+++ b/mitosheet/mitosheet/step_performers/set_cell_value.py
@@ -23,6 +23,7 @@ from mitosheet.state import State
 from mitosheet.step_performers.column_steps.set_column_formula import \
     refresh_dependant_columns
 from mitosheet.step_performers.step_performer import StepPerformer
+from mitosheet.step_performers.utils import get_param
 from mitosheet.transpiler.transpile_utils import \
     column_header_to_transpiled_code
 from mitosheet.types import ColumnID
@@ -60,16 +61,13 @@ class SetCellValueStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        column_id: ColumnID,
-        row_index: int,
-        old_value: str,
-        new_value: Union[str, None],
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index: int = get_param(params, 'sheet_index')
+        column_id: ColumnID = get_param(params, 'column_id')
+        row_index: int = get_param(params, 'row_index')
+        old_value: str = get_param(params, 'old_value')
+        new_value: Union[str, None] = get_param(params, 'new_value')
+        
         if column_id not in prev_state.column_spreadsheet_code[sheet_index]:
             raise make_no_column_error({column_id}, error_modal=False)
 

--- a/mitosheet/mitosheet/step_performers/sort.py
+++ b/mitosheet/mitosheet/step_performers/sort.py
@@ -3,7 +3,7 @@
 
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
-from copy import deepcopy
+
 from time import perf_counter
 from typing import Any, Dict, List, Optional, Set, Tuple
 from mitosheet.code_chunks.code_chunk import CodeChunk
@@ -14,6 +14,7 @@ from mitosheet.step_performers.step_performer import StepPerformer
 from mitosheet.errors import (
     make_invalid_sort_error
 )
+from mitosheet.step_performers.utils import get_param
 from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_code
 from mitosheet.types import ColumnID
 
@@ -41,19 +42,10 @@ class SortStepPerformer(StepPerformer):
         return params
 
     @classmethod
-    def execute( # type: ignore
-        cls,
-        prev_state: State,
-        sheet_index: int,
-        column_id: ColumnID,
-        sort_direction: str,
-        **params
-    ) -> Tuple[State, Optional[Dict[str, Any]]]:
-        """
-        Returns the new new post state after sorting the sheet
-        at `sheet_index` by the passed `column_id` in the given
-        `sort_direction`
-        """
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
+        sheet_index: int = get_param(params, 'sheet_index')
+        column_id: ColumnID = get_param(params, 'column_id')
+        sort_direction: str = get_param(params, 'sort_direction')
 
         column_header = prev_state.column_ids.get_column_header_by_id(sheet_index, column_id)
 

--- a/mitosheet/mitosheet/step_performers/step_performer.py
+++ b/mitosheet/mitosheet/step_performers/step_performer.py
@@ -41,7 +41,7 @@ class StepPerformer(ABC, object):
         return f'{cls.step_type()}_edit'
 
     @classmethod
-    def saturate(cls, prev_state: State, params: Any) -> Dict[str, str]:
+    def saturate(cls, prev_state: State, params: Dict[str, Any]) -> Dict[str, Any]:
         """
         Given the parameters of the step, will saturate the event with
         more parameters based on the passed prev_state. 
@@ -51,7 +51,7 @@ class StepPerformer(ABC, object):
 
     @classmethod
     @abstractmethod
-    def execute(cls, prev_state: State, **params: Any) -> Tuple[State, Optional[Dict[str, Any]]]:
+    def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
         """
         Execute always returns the post_state, and optionally returns a dictionary
         of execution_data, which is data that may be useful to the transpiler in

--- a/mitosheet/mitosheet/step_performers/utils.py
+++ b/mitosheet/mitosheet/step_performers/utils.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GPL License.
+
+"""
+Utilities for step performers
+"""
+
+from typing import Any, Dict
+
+
+def get_param(params: Dict[str, Any], key: str) -> Any:
+    if key in params:
+        return params[key]
+    return None

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -73,6 +73,7 @@ def check_dataframes_equal(test_wrapper):
     # Then, construct code that is just the code we expect, except at the end
     # it compares the dataframe to the final dataframe we expect
     def check_final_dataframe(df_name, df):
+        print(final_dfs[df_name], df)
         assert final_dfs[df_name].equals(df)
 
     code = "\n".join(


### PR DESCRIPTION
# Description

This PR makes the types of the step performer consistent and type check. This might not seem like a big deal, but I think it's gonna allow us to get substeps in a much easier and less complicated way in the future - just by letting us easily call one step performer from another step performer. Cool!

# Testing

All tests are passing!

# Documentation

N/A.