### PR TITLE
add scrollbar to tabs

### DIFF
--- a/mitosheet/css/footer.css
+++ b/mitosheet/css/footer.css
@@ -1,5 +1,5 @@
 .footer {
-    height: 32px;
+    height: min-content;
     display: flex;
     justify-content: space-between;
 
@@ -36,10 +36,13 @@
 
 .footer-tab-bar {
     /* Deal with the overflow */
-    overflow-x: auto;
+    overflow: scroll;
     overflow-y: clip;
+
     white-space: nowrap;
     flex: auto;
+    height: min-content;
+
 }
 
 .footer-right-side {
@@ -74,7 +77,7 @@
     border-right: 1px solid var(--mito-border);
     box-sizing: border-box;
 
-    height: 100%;
+    height: 26px;
     padding-left: 10px;
     padding-right: 10px;
 

--- a/mitosheet/css/footer.css
+++ b/mitosheet/css/footer.css
@@ -38,13 +38,21 @@
 }
 
 .footer-tab-bar {
-    /* Deal with the overflow */
-    overflow: auto;
+    /* In order for the scrollbar-gutter css property to work, overflow must be set to auto. */
+    overflow-x: auto;
     overflow-y: clip;
 
     white-space: nowrap;
     flex: auto;
+
+    /* Set the height to min-content so there is space for the tab + scrollbar */
     height: min-content;
+
+    /* 
+        Set a minimum height so that even if there are no tabs, the footer has correct height.
+        Should be the same height as the tab
+    */
+    min-height: 32px; 
 
 }
 
@@ -80,6 +88,7 @@
     border-right: 1px solid var(--mito-border);
     box-sizing: border-box;
 
+    /* Should be the same height as the min-height of the footer-tab-bar */
     height: 32px;
     padding-left: 10px;
     padding-right: 10px;

--- a/mitosheet/css/footer.css
+++ b/mitosheet/css/footer.css
@@ -21,11 +21,14 @@
 }
 
 .footer-add-button {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+
     background-color: var(--mito-light-purple);
 
     padding-left: 10px;
     padding-right: 10px;
-    padding-top: 7.5px;
 
     border-right: 1px solid var(--mito-border);
 }
@@ -36,7 +39,7 @@
 
 .footer-tab-bar {
     /* Deal with the overflow */
-    overflow: scroll;
+    overflow: auto;
     overflow-y: clip;
 
     white-space: nowrap;
@@ -77,7 +80,7 @@
     border-right: 1px solid var(--mito-border);
     box-sizing: border-box;
 
-    height: 26px;
+    height: 32px;
     padding-left: 10px;
     padding-right: 10px;
 

--- a/mitosheet/css/sitewide/scroll.css
+++ b/mitosheet/css/sitewide/scroll.css
@@ -10,3 +10,7 @@
     -ms-overflow-style: none;  /* IE and Edge */
     scrollbar-width: none;  /* Firefox */
   }
+
+  .scrollbar-gutter {
+    scrollbar-gutter: stable;
+  }

--- a/mitosheet/src/components/footer/Footer.tsx
+++ b/mitosheet/src/components/footer/Footer.tsx
@@ -53,7 +53,7 @@ function Footer(props: FooterProps): JSX.Element {
             >
                 <PlusIcon/>
             </div>
-            <div className="footer-tab-bar hide-scrollbar">
+            <div className="footer-tab-bar scrollbar-gutter">
                 {/* First add the data tabs, and then add the graph tabs */}
                 {props.sheetDataArray.map(df => df.dfName).map((dfName, idx) => {
                     return (


### PR DESCRIPTION
# Description

Makes sure that there is always a scrollbar for the user to scroll the sheet tabs even if they don't have a trackpad by using the [scollbar-gutter](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter) css property. 

However, this doesn't work on IE or Safari. 

Note: The scrollbar-gutter property only effects computers whose scrollbars are not floating. On Macs, the scrollabrs float, so this has no effect.  Which unfortunately means the footer is different on macs and windows. 

Windows JupyterLab:

![footer-scroll-gutter](https://user-images.githubusercontent.com/18709905/168305086-7bf161c2-4020-4f53-9d42-1a89ce488001.png)

Windows Notebook: 
![footer-scroll-gutter-notebook](https://user-images.githubusercontent.com/18709905/168305617-fc65fe71-27a5-489b-9ebe-e903f3aad322.png)

If there is no overflow, then it just looks normal:
![footer-no-scroll-bar](https://user-images.githubusercontent.com/18709905/168313311-a8e46391-b78d-4577-abad-cef2b4e7ac4b.png)


# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.