### PR TITLE
[WIP] Add copy and paste

### DIFF
--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -425,11 +425,17 @@ export const Mito = (props: MitoProps): JSX.Element => {
     }, [uiState])
 
     // This is the effect that waits for copy and pastes within Mito, and then copies!
-    // TODO: explain why we debounce it for performance
+    // NOTE: this effect must be debounced so that we're not reregistering these event
+    // listeners 100 times during every single scroll. In practice, this works perf!
     useDebouncedEffect(() => {
         const checkCopy = (e: KeyboardEvent) => {
-             // Then, we check the user is doing a copy
-             if (e.key !== 'c' || (!e.ctrlKey && !e.metaKey)){
+            // First, check that this was actually done by a focus on this mitosheet
+            if (!mitoContainerRef.current?.contains(document.activeElement)) {
+                return;
+            }
+
+            // Then, we check the user is doing a copy
+            if (e.key !== 'c' || (!e.ctrlKey && !e.metaKey)){
                 return;
             }
 

--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -424,26 +424,30 @@ export const Mito = (props: MitoProps): JSX.Element => {
 
     }, [uiState])
 
-    // This is the effect that waits for copy and pastes within Mito, and then copies!
+    // This is the effect that waits for keyboard shortcuts within Mito, and then copies!
     // NOTE: this effect must be debounced so that we're not reregistering these event
     // listeners 100 times during every single scroll. In practice, this works perf!
     useDebouncedEffect(() => {
-        const checkCopy = (e: KeyboardEvent) => {
+        const checkKeyboardShortcut = (e: KeyboardEvent) => {
+            console.log(e.key, )
             // First, check that this was actually done by a focus on this mitosheet
             if (!mitoContainerRef.current?.contains(document.activeElement)) {
                 return;
             }
 
+
             // Then, we check the user is doing a copy
-            if (e.key !== 'c' || (!e.ctrlKey && !e.metaKey)){
-                return;
+            if (e.key === 'c' && (e.ctrlKey || e.metaKey)){
+                actions[ActionEnum.Copy].actionFunction();
+            } else if (e.key === 'z' && (e.ctrlKey || e.metaKey)){
+                actions[ActionEnum.Undo].actionFunction();
+            } else if (e.key === 'y' && (e.ctrlKey || e.metaKey)){
+                actions[ActionEnum.Redo].actionFunction();
             }
-
-            actions[ActionEnum.Copy].actionFunction();
         }
-        document.addEventListener('keydown', checkCopy)
+        document.addEventListener('keydown', checkKeyboardShortcut)
 
-        return () => {document.removeEventListener('keydown', checkCopy)}
+        return () => {document.removeEventListener('keydown', checkKeyboardShortcut)}
     }, [gridState, sheetDataArray], 50)
 
 
@@ -746,7 +750,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
     })
 
     return (
-        <div className="mito-container" data-jp-suppress-context-menu ref={mitoContainerRef}>
+        <div tabIndex={0} className="mito-container" data-jp-suppress-context-menu ref={mitoContainerRef}>
             <ErrorBoundary mitoAPI={props.mitoAPI}>
                 <Toolbar 
                     mitoAPI={props.mitoAPI}

--- a/mitosheet/src/components/endo/GridData.tsx
+++ b/mitosheet/src/components/endo/GridData.tsx
@@ -43,7 +43,7 @@ const GridData = (props: {
                                 return null;
                             }
 
-                            const className = classNames('mito-grid-cell', {
+                            const className = classNames('mito-grid-cell', 'text-unselectable', {
                                 'mito-grid-cell-selected': getIsCellSelected(props.gridState.selections, rowIndex, columnIndex),
                                 'mito-grid-cell-hidden': props.editorState !== undefined && props.editorState.rowIndex === rowIndex && props.editorState.columnIndex === columnIndex,
                                 'right-align-number-series': isNumberDtype(columnDtype)

--- a/mitosheet/src/components/toolbar/ToolbarEditDropdown.tsx
+++ b/mitosheet/src/components/toolbar/ToolbarEditDropdown.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Action, ActionEnum, UIState } from '../../types';
 import Dropdown from '../elements/Dropdown';
+import DropdownSectionSeperator from '../elements/DropdownSectionSeperator';
 import { makeToolbarDropdownItem } from './utils';
 
 
@@ -36,6 +37,8 @@ const ToolbarEditDropdown = (props: ToolbarEditDropdownProps): JSX.Element => {
                     {makeToolbarDropdownItem(props.actions[ActionEnum.Undo])}
                     {makeToolbarDropdownItem(props.actions[ActionEnum.Redo])}
                     {makeToolbarDropdownItem(props.actions[ActionEnum.Clear])}
+                    <DropdownSectionSeperator isDropdownSectionSeperator/>
+                    {makeToolbarDropdownItem(props.actions[ActionEnum.Copy])}
                 </Dropdown>
             }
         </>

--- a/mitosheet/src/hooks/useDebouncedEffect.tsx
+++ b/mitosheet/src/hooks/useDebouncedEffect.tsx
@@ -3,10 +3,24 @@ import { useEffect } from "react";
 /* 
     https://stackoverflow.com/questions/54666401/how-to-use-throttle-or-debounce-with-react-hook
 */
-export const useDebouncedEffect = (effect: () => void, deps: unknown[], delay: number): void => {
+export const useDebouncedEffect = (
+    effect: () => (void | (() => void)), deps: unknown[], 
+    delay: number,
+): void => {
     useEffect(() => {
-        const handler = setTimeout(() => effect(), delay);
+        // Cleanup defaults to a noop, but you can also return a function 
+        // from the effect to have it run on cleanup
+        let cleanup = () => {}
+        const handler = setTimeout(() => {
+            let result = effect()
+            if (result instanceof Object) {
+                cleanup = result;
+            }
+        }, delay);
 
-        return () => clearTimeout(handler);
+        return () => {
+            clearTimeout(handler);
+            cleanup();
+        };
     }, [...deps || [], delay])
 }

--- a/mitosheet/src/hooks/useDebouncedEffect.tsx
+++ b/mitosheet/src/hooks/useDebouncedEffect.tsx
@@ -10,9 +10,10 @@ export const useDebouncedEffect = (
     useEffect(() => {
         // Cleanup defaults to a noop, but you can also return a function 
         // from the effect to have it run on cleanup
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         let cleanup = () => {}
         const handler = setTimeout(() => {
-            let result = effect()
+            const result = effect()
             if (result instanceof Object) {
                 cleanup = result;
             }

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -10,7 +10,7 @@ import { INotebookTracker, NotebookActions } from '@jupyterlab/notebook';
 import { Application, IPlugin } from 'application';
 import { Widget } from 'widgets';
 import MitoAPI from './jupyter/api';
-import { getCellAtIndex, getCellCallingMitoshetWithAnalysis, getCellText, getMostLikelyMitosheetCallingCell, getParentMitoContainer, isEmptyCell, tryOverwriteAnalysisToReplayParameter, tryWriteAnalysisToReplayParameter, writeToCell } from './jupyter/lab/pluginUtils';
+import { getCellAtIndex, getCellCallingMitoshetWithAnalysis, getCellText, getMostLikelyMitosheetCallingCell, isEmptyCell, tryOverwriteAnalysisToReplayParameter, tryWriteAnalysisToReplayParameter, writeToCell } from './jupyter/lab/pluginUtils';
 import { containsGeneratedCodeOfAnalysis, containsMitosheetCallWithAnyAnalysisToReplay, getAnalysisNameFromOldGeneratedCode, getArgsFromMitosheetCallCode, getCodeString, getLastNonEmptyLine, isMitosheetCallCode } from './utils/code';
 import { MODULE_NAME, MODULE_VERSION } from './version';
 import * as widgetExports from './jupyter/widget';
@@ -263,87 +263,18 @@ function activateWidgetExtension(
         }
     });
 
-    /* 
-        To make Command + F focus on search, we add these commands as a key-binding
-        that specifically is captured inside the mito-container.
+    // When in Mito, we capture any keyboard commands and do nothing with them. Within Mito.tsx,
+    // we have event listeners that handle these keyboard shortcuts, but JupyterLab gets involved
+    // unless we tell it not to
+    //app.commands.addKeyBinding({command: 'do-nothing', args: {}, keys: ['Accel Z'], selector: '.mito-container'});
+    //app.commands.addKeyBinding({command: 'do-nothing', args: {}, keys: ['Accel Y'], selector: '.mito-container'});
+    //app.commands.addKeyBinding({command: 'do-nothing', args: {}, keys: ['Accel C'], selector: '.mito-container'});
+    app.commands.addKeyBinding({command: 'do-nothing', args: {}, keys: ['Shift Enter'], selector: '.mito-container'});
 
-        If Command + F is pressed in this context, we go and get the search input, and
-        focus on it, so the user can just starting typing in it!
-    */
-    app.commands.addKeyBinding({
-        command: 'focus-on-search',
-        args: {},
-        keys: ['Accel F'],
-        selector: '.mito-container'
-    });
-    app.commands.addCommand('focus-on-search', {
-        label: 'Focuses on search of the currently selected mito notebook',
-        execute: async (): Promise<void> => {
-            // First, get the mito container that this element is a part of
-            const mitoContainer = getParentMitoContainer();
-
-            // Get the search input, and click + focus on it
-            const searchInput = mitoContainer?.querySelector('#action-search-bar-id') as HTMLInputElement | null;
-
-            // Focusing on the searchInput so that we begin typing there
-            searchInput?.focus();
-        }
-    });
-
-    app.commands.addKeyBinding({
-        command: 'mito-undo',
-        args: {},
-        keys: ['Accel Z'],
-        selector: '.mito-container'
-    });
-    app.commands.addCommand('mito-undo', {
-        label: 'Clicks the undo button once',
-        execute: async (): Promise<void> => {
-            // First, get the mito container that this element is a part of
-            const mitoContainer = getParentMitoContainer();
-
-            // Get the undo button, and click it
-            const undoButton = mitoContainer?.querySelector('#mito-undo-button') as HTMLDivElement | null;
-            undoButton?.click()
-        }
-    });
-
-    app.commands.addKeyBinding({
-        command: 'mito-redo',
-        args: {},
-        keys: ['Accel Y'],
-        selector: '.mito-container'
-    });
-    app.commands.addCommand('mito-redo', {
-        label: 'Clicks the redo button once',
-        execute: async (): Promise<void> => {
-            // First, get the mito container that this element is a part of
-            const mitoContainer = getParentMitoContainer();
-
-            // Get the undo button, and click it
-            const redoButton = mitoContainer?.querySelector('#mito-redo-button') as HTMLDivElement | null;
-            redoButton?.click()
-        }
-    });
-
-
-    /* 
-        Since Shift + Enter reruns the cell, we don't want this to happen
-        when the user has Mito selected. So we supress this.
-
-        TODO: there is a bug where maybe this is contributing to the fact
-        that I cannot detect Shift + Enter in inputs within Mito.. it's really
-        annoying.
-    */
-    app.commands.addKeyBinding({
-        command: 'do-nothing',
-        args: {},
-        keys: ['Shift Enter'],
-        selector: '.mito-container'
-    });
     app.commands.addCommand('do-nothing', {
         label: 'Does nothing',
         execute: async (): Promise<void> => {
+            console.log("DOING NOTHING");
             // Do nothing, doh
         }
     });

--- a/mitosheet/src/types.tsx
+++ b/mitosheet/src/types.tsx
@@ -649,6 +649,7 @@ export enum ActionEnum {
     Clear = 'clear',
     Change_Dtype = 'change dtype',
     Column_Summary = 'column summary',
+    Copy = 'copy',
     Delete_Column = 'delete column',
     Delete_Dataframe = 'delete dataframe',
     Delete_Graph = 'delete graph',

--- a/mitosheet/src/utils/actions.tsx
+++ b/mitosheet/src/utils/actions.tsx
@@ -178,18 +178,9 @@ export const createActions = (
         },
         [ActionEnum.Copy]: {
             type: ActionEnum.Copy,
-            shortTitle: 'Copy Data',
-            longTitle: 'Copy data to the clipboard',
+            shortTitle: 'Copy',
+            longTitle: 'Copy',
             actionFunction: () => {
-
-                // First, we check if we're inside this current mitosheet
-                // as we don't want to copy from everywhere
-                if (!mitoContainerRef.current?.contains(document.activeElement)) {
-                    return;
-                }
-                
-                // TODO: check a sheet tab is selected
-
 
                 const stringToCopy = getStringForClipboard(
                     sheetData,
@@ -212,8 +203,7 @@ export const createActions = (
                 });
             },
             isDisabled: () => {
-                // TODO: make this do better
-                return undefined;
+                return getDataframeIsSelected(uiState, sheetDataArray) ? undefined : "There is no selected data to copy."
             },
             searchTerms: ['copy', 'paste', 'export'],
             tooltip: "Copy the currently selection to the clipboard."

--- a/mitosheet/src/utils/actions.tsx
+++ b/mitosheet/src/utils/actions.tsx
@@ -12,6 +12,7 @@ import { FunctionDocumentationObject, functionDocumentationObjects } from "../da
 import { Action, ActionEnum, DFSource, EditorState, GridState, SheetData, UIState } from "../types"
 import { getColumnHeaderParts, getDisplayColumnHeader } from "./columnHeaders";
 import { FORMAT_DISABLED_MESSAGE } from "./formatColumns";
+import { getStringForClipboard } from "./copy";
 
 
 export const createActions = (
@@ -174,6 +175,46 @@ export const createActions = (
             },
             searchTerms: ['column summary', 'describe', 'stats'],
             tooltip: "Learn about the distribution of the data in the selected column."
+        },
+        [ActionEnum.Copy]: {
+            type: ActionEnum.Copy,
+            shortTitle: 'Copy Data',
+            longTitle: 'Copy data to the clipboard',
+            actionFunction: () => {
+
+                // First, we check if we're inside this current mitosheet
+                // as we don't want to copy from everywhere
+                if (!mitoContainerRef.current?.contains(document.activeElement)) {
+                    return;
+                }
+                
+                // TODO: check a sheet tab is selected
+
+
+                const stringToCopy = getStringForClipboard(
+                    sheetData,
+                    gridState.selections
+                );
+
+                console.log(stringToCopy);
+
+                if (stringToCopy === undefined) {
+                    return;
+                }
+                
+                navigator.clipboard.writeText(stringToCopy).then(function() {
+                    /* clipboard successfully set */
+                    // TODO: do we want to do some reporting to the user here?
+                }, function() {
+                    /* clipboard write failed */
+                });
+            },
+            isDisabled: () => {
+                // TODO: make this do better
+                return undefined;
+            },
+            searchTerms: ['copy', 'paste', 'export'],
+            tooltip: "Copy the currently selection to the clipboard."
         },
         [ActionEnum.Delete_Column]: {
             type: ActionEnum.Delete_Column,

--- a/mitosheet/src/utils/actions.tsx
+++ b/mitosheet/src/utils/actions.tsx
@@ -196,8 +196,6 @@ export const createActions = (
                     gridState.selections
                 );
 
-                console.log(stringToCopy);
-
                 if (stringToCopy === undefined) {
                     return;
                 }
@@ -207,6 +205,10 @@ export const createActions = (
                     // TODO: do we want to do some reporting to the user here?
                 }, function() {
                     /* clipboard write failed */
+                });
+
+                void mitoAPI.log('copied_data', {
+                    'num_selections': gridState.selections.length
                 });
             },
             isDisabled: () => {

--- a/mitosheet/src/utils/copy.tsx
+++ b/mitosheet/src/utils/copy.tsx
@@ -1,0 +1,64 @@
+import { MitoSelection, SheetData } from "../types";
+
+const copy_stringValueToString = (value: string): string => {
+    // If there is no white space, we don't need to do anything
+    if (value.includes('\t')) {
+        return `\"${value}\"`
+    }
+    return value;
+
+}
+
+const copy_valueToString = (value: string | number | boolean): string => {
+    if (typeof value === 'string') {
+        return copy_stringValueToString(value);
+    }
+
+    return '' + value;
+}
+
+
+const copy_getStringForRow = (sheetData: SheetData, rowIndex: number, lowColIndex: number, highColIndex: number): string => {
+    let copyString = '';
+
+    for (let columnIndex = lowColIndex; columnIndex <= highColIndex; columnIndex++) {
+        copyString += copy_valueToString(sheetData.data[columnIndex].columnData[rowIndex])
+        if (columnIndex !== highColIndex) {
+            copyString += '\t'
+        }
+    }
+    
+    return copyString;
+}
+
+
+const copy_getStringForSelection = (sheetData: SheetData, selection: MitoSelection): string => {
+    const lowRowIndex = Math.min(selection.startingRowIndex, selection.endingRowIndex);
+    const highRowIndex = Math.max(selection.startingRowIndex, selection.endingRowIndex);
+    const lowColIndex = Math.min(selection.startingColumnIndex, selection.endingColumnIndex);
+    const highColIndex = Math.max(selection.startingColumnIndex, selection.endingColumnIndex);
+
+    let copyString = '';
+    for (let rowIndex = lowRowIndex; rowIndex <= highRowIndex; rowIndex++) {
+        copyString += copy_getStringForRow(sheetData, rowIndex, lowColIndex, highColIndex);
+        if (rowIndex !== highRowIndex) {
+            copyString += '\n'
+        }
+    }
+
+    return copyString;
+}
+
+
+export const getStringForClipboard = (sheetData: SheetData | undefined, selections: MitoSelection[]): string | undefined => {
+    if (sheetData === undefined || selections.length === 0) {
+        console.log("HERE")
+        return undefined;
+    }
+
+    if (selections.length === 1) {
+        return copy_getStringForSelection(sheetData, selections[0]);
+    }
+
+    return "More than one selection..."
+}

--- a/mitosheet/src/utils/copy.tsx
+++ b/mitosheet/src/utils/copy.tsx
@@ -59,5 +59,7 @@ export const getStringForClipboard = (sheetData: SheetData | undefined, selectio
         return copy_getStringForSelection(sheetData, selections[0]);
     }
 
+    // TODO: if the user has a column header selected, we have to copy the full column!
+
     return "More than one selection..."
 }

--- a/mitosheet/src/utils/copy.tsx
+++ b/mitosheet/src/utils/copy.tsx
@@ -1,12 +1,11 @@
 import { MitoSelection, SheetData } from "../types";
 
-const copy_stringValueToString = (value: string): string => {
-    // If there is no white space, we don't need to do anything
-    if (value.includes('\t')) {
-        return `\"${value}\"`
-    }
-    return value;
 
+// TODO: actually create a well-researched specification about how things should work (potentially argue for simplicity)
+// TODO: fix the focus issue on Notebooks
+
+const copy_stringValueToString = (value: string): string => {
+    return value;
 }
 
 const copy_valueToString = (value: string | number | boolean): string => {


### PR DESCRIPTION
# Description

This PR adds copy and paste to Mito. Turns out, doing so wasn't that complex, and as usual I wish I did it a long time ago and spent much less time talking about it. 

There is two things left to figure out: 

## handling tabs within data. 
Right now, if there are tabs in data, and you copy and paste to Excel, the spacing gets messed up. I spent a while trying to fix this and don't really know how to.

My general concern is that in trying to fix this I'm gonna break some other way people use copy and paste - given that I'm gonna have to do some complex encoding or escaping to fix this. I vote we move forward with this solution, see how used copy and paste is, and (potentially) add a log if for if there are tabs so we can see if this is something actually worth fixing. Thoughts?

## Focus handling
When you click a button, it goes and focuses on it. Let's make it not do this!

# Testing

Windows, Mac, Lab and Notebooks. I didn't test on windows yet...

# Documentation

N/A.