### PR TITLE
mitosheet: add toggle all to values taskpane, unoptimized

### DIFF
--- a/mitosheet/src/components/taskpanes/ControlPanel/ValuesTab/ValuesTab.tsx
+++ b/mitosheet/src/components/taskpanes/ControlPanel/ValuesTab/ValuesTab.tsx
@@ -232,6 +232,18 @@ export function ValuesTab(
                     isSubset={!isAllData}
                     message={disabledMessage}
                     disabled={disabledMessage !== undefined}
+                    toggleAllIndexes={(indexesToToggle: number[], newValue: boolean) => {
+                        const uniqueValueCountIndexes = indexesToToggle.map(index => getUniqueValueCountIndexFromSortedIndex(index));
+                        setUniqueValueCounts(oldUniqueValueCounts => {
+                            const newUniqueValueCounts = oldUniqueValueCounts.slice();
+                            uniqueValueCountIndexes.forEach(index => {
+                                newUniqueValueCounts[index].isNotFiltered = newValue;
+                            })
+                            return newUniqueValueCounts;
+                        })
+
+                        toggleExclusiveFilters(uniqueValueCountIndexes.map(index => sortedUniqueValueCounts[index].value))
+                    }}
                 >
                     {sortedUniqueValueCounts.map((uniqueValueCount, index) => {
                         const valueToDisplay = formatCellData(uniqueValueCount.value, props.columnDtype, props.columnFormatType);


### PR DESCRIPTION
# Description

I think that as of now, the the that makes the most sense is an unoptimized toggle all in values. This would personally help me the most - I am dying for this feature almost half of the time I use Mito!

As it is currently, the multi toggle box only shows 1k values, so the limit on the size of generated code is somewhat existent. 

@aarondr77 if you think an optimized version of this makes more sense, then I can write a spec and do that). If we're gonna just end up going with the unoptimized version for now, let's not sit on this - not having it makes Mito annoying to use for me!

# Testing

Use it.

# Documentation

No.