### PR TITLE
mitohseet: close cell editor when opening graph tab

### DIFF
--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -62,9 +62,6 @@ import Toolbar from './toolbar/Toolbar';
 import Tour from './tour/Tour';
 import { TourName } from './tour/Tours';
 
-
-
-
 export type MitoProps = {
     model_id: string;
     mitoAPI: MitoAPI;
@@ -791,6 +788,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
                     uiState={uiState}
                     setUIState={setUIState}
                     mitoContainerRef={mitoContainerRef}
+                    setEditorState={setEditorState}
                 />
                 {getCurrentModalComponent()}
                 {uiState.loading > 0 && <LoadingIndicator/>}      

--- a/mitosheet/src/components/footer/Footer.tsx
+++ b/mitosheet/src/components/footer/Footer.tsx
@@ -8,7 +8,7 @@ import "../../../css/footer.css"
 import MitoAPI from '../../jupyter/api';
 import { TaskpaneType } from '../taskpanes/taskpanes';
 import PlusIcon from '../icons/PlusIcon';
-import { GraphDataDict, GridState, SheetData, UIState } from '../../types';
+import { EditorState, GraphDataDict, GridState, SheetData, UIState } from '../../types';
 
 type FooterProps = {
     sheetDataArray: SheetData[];
@@ -20,6 +20,7 @@ type FooterProps = {
     uiState: UIState;
     setUIState: React.Dispatch<React.SetStateAction<UIState>>;
     mitoContainerRef: React.RefObject<HTMLDivElement>;
+    setEditorState: React.Dispatch<React.SetStateAction<EditorState | undefined>>
 };
 
 /*
@@ -68,6 +69,7 @@ function Footer(props: FooterProps): JSX.Element {
                             mitoContainerRef={props.mitoContainerRef}
                             graphDataDict={props.graphDataDict}
                             sheetDataArray={props.sheetDataArray}
+                            setEditorState={props.setEditorState}
                         />
                     )
                 })}
@@ -84,6 +86,7 @@ function Footer(props: FooterProps): JSX.Element {
                             mitoContainerRef={props.mitoContainerRef}
                             graphDataDict={props.graphDataDict}
                             sheetDataArray={props.sheetDataArray}
+                            setEditorState={props.setEditorState}
                         />
                     )
                 })}

--- a/mitosheet/src/components/footer/SheetTab.tsx
+++ b/mitosheet/src/components/footer/SheetTab.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import MitoAPI from '../../jupyter/api';
 import { classNames } from '../../utils/classNames';
 import Input from '../elements/Input';
-import { GraphDataDict, GraphID, SheetData, UIState } from '../../types';
+import { EditorState, GraphDataDict, GraphID, SheetData, UIState } from '../../types';
 import { focusGrid } from '../endo/focusUtils';
 
 // import icons
@@ -79,6 +79,7 @@ type SheetTabProps = {
     mitoContainerRef: React.RefObject<HTMLDivElement>;
     graphDataDict: GraphDataDict;
     sheetDataArray: SheetData[]
+    setEditorState: React.Dispatch<React.SetStateAction<EditorState | undefined>>
 };
 
 /*
@@ -128,6 +129,12 @@ export default function SheetTab(props: SheetTabProps): JSX.Element {
         <div 
             className={classNames('tab', {'tab-graph': props.tabIDObj.tabType === 'graph'}, {'tab-selected': props.isSelectedTab})} 
             onClick={() => {
+
+                if (props.tabIDObj.tabType === 'graph') {
+                    // If opening a graph tab, close the cell editor 
+                    props.setEditorState(undefined)
+                }
+                
                 props.setUIState(prevUIState => {
                     if (props.tabIDObj.tabType === 'data') {
                         // If the user clicks on a data sheet tab, switch to it and make sure the graph taskpane is not open


### PR DESCRIPTION
# Description

Makes sure that the cell editor is not open in the graph. Previously, you could open the cell editor, switch to a graph taskpane, and the cell editor would still be open. 
