### PR TITLE
Dogfood 5 31

### DIFF
--- a/mitosheet/mitosheet/code_chunks/step_performers/column_steps/split_text_to_columns_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/column_steps/split_text_to_columns_code_chunk.py
@@ -21,7 +21,7 @@ class SplitTextToColumnsCodeChunk(CodeChunk):
         column_id: ColumnID = self.get_param('column_id')
         delimiters: List[str] = self.get_param('delimiters')
         column_header = self.post_state.column_ids.get_column_header_by_id(sheet_index, column_id)
-        delimiters_string = (' ,').join(map(lambda x: f'"{x}"', delimiters))
+        delimiters_string = (', ').join(map(lambda x: f'"{x}"', delimiters))
         return f'Split {column_header} on {delimiters_string}'
 
     def get_code(self) -> List[str]:

--- a/mitosheet/mitosheet/code_chunks/step_performers/column_steps/split_text_to_columns_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/column_steps/split_text_to_columns_code_chunk.py
@@ -21,7 +21,7 @@ class SplitTextToColumnsCodeChunk(CodeChunk):
         column_id: ColumnID = self.get_param('column_id')
         delimiters: List[str] = self.get_param('delimiters')
         column_header = self.post_state.column_ids.get_column_header_by_id(sheet_index, column_id)
-        delimiters_string = (' ,').join(delimiters)
+        delimiters_string = (' ,').join(map(lambda x: f'"{x}"', delimiters))
         return f'Split {column_header} on {delimiters_string}'
 
     def get_code(self) -> List[str]:

--- a/mitosheet/src/components/endo/EmptyGridMessages.tsx
+++ b/mitosheet/src/components/endo/EmptyGridMessages.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import MitoAPI from '../../jupyter/api';
 import { SheetData, UIState } from '../../types';
 import TextButton from '../elements/TextButton';
 import { TaskpaneType } from '../taskpanes/taskpanes';
@@ -20,7 +21,7 @@ const GridDataEmptyContainer = (props: {children: React.ReactNode}): JSX.Element
     )
 }
 
-const EmptyGridMessages = (props: {sheetData: SheetData | undefined, setUIState: React.Dispatch<React.SetStateAction<UIState>>}): JSX.Element => {
+const EmptyGridMessages = (props: {sheetData: SheetData | undefined, setUIState: React.Dispatch<React.SetStateAction<UIState>>, mitoAPI: MitoAPI}): JSX.Element => {
 
     return (
         <>
@@ -30,12 +31,16 @@ const EmptyGridMessages = (props: {sheetData: SheetData | undefined, setUIState:
                         <TextButton 
                             variant='dark' 
                             width='medium'
-                            onClick={() => props.setUIState(prevUIState => {
-                                return {
-                                    ...prevUIState,
-                                    currOpenTaskpane: {type: TaskpaneType.IMPORT}
-                                }
-                            })}
+                            onClick={() => {
+                                props.setUIState(prevUIState => {
+                                    return {
+                                        ...prevUIState,
+                                        currOpenTaskpane: {type: TaskpaneType.IMPORT}
+                                    }
+                                })
+
+                                void props.mitoAPI.log('clicked_empty_grid_import_button');
+                            }}
                         >
                             Import Files
                         </TextButton>

--- a/mitosheet/src/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/components/endo/EndoGrid.tsx
@@ -662,6 +662,7 @@ function EndoGrid(props: {
                     <EmptyGridMessages
                         setUIState={props.setUIState}
                         sheetData={sheetData}
+                        mitoAPI={mitoAPI}
                     />
                     {/* 
                         This is the div we actually scroll inside. We make it so it's styled

--- a/mitosheet/src/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/components/endo/EndoGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import '../../../css/endo/EndoGrid.css';
 import '../../../css/sitewide/colors.css';
 import MitoAPI from "../../jupyter/api";
@@ -92,9 +92,13 @@ function EndoGrid(props: {
     // The container for the entire EndoGrid
     const containerRef = useRef<HTMLDivElement>(null);
     // The container for just the empty scroll div, and the rendered grid data
-    const scrollAndRenderedContainerRef = useRef<HTMLDivElement>(null);
+    const scrollAndRenderedContainerRef = useRef<HTMLDivElement | null>(null);
     // Store if the mouse is currently pressed down on the grid
     const [mouseDown, setMouseDown] = useState(false);
+    // Store a resize observer so we can watch for viewport size changes, and size everything correctly off that
+    const [resizeObserver, ] = useState(() => new ResizeObserver(() => {
+        resizeViewport();
+    }))
     
     // Destructure the props, so we access them more directly in the component below
     const {
@@ -142,45 +146,39 @@ function EndoGrid(props: {
         })
     }, [sheetData, setGridState, sheetIndex])
 
-
-    /* 
-        An effect that handles a resizing of the viewport. 
-
-        TODO: move this to the shared hook useEffectOnResizeElement
-    */        
-    useEffect(() => {
-        const resizeViewport = () => {
-            setGridState((gridState) => {
+    // A helper function that should be run when the viewport changes sizes
+    const resizeViewport = () => {
+        setGridState((gridState) => {
+            const scrollAndRenderedContainerDiv = scrollAndRenderedContainerRef?.current;
+            if (scrollAndRenderedContainerDiv) {
+                const newViewport = {
+                    width: scrollAndRenderedContainerDiv.clientWidth,
+                    height: scrollAndRenderedContainerDiv.clientHeight,
+                }
                 return {
                     ...gridState,
-                    viewport: {
-                        width: scrollAndRenderedContainerRef?.current?.clientWidth || 0,
-                        height: scrollAndRenderedContainerRef?.current?.clientHeight || 0,
-                    }
+                    viewport: newViewport
                 }
-            })
-        };
-
-        // Calc the viewport size multiple times, just to make sure it loads properly
-        // even in the case we're replaying an anlaysis and so the headers don't totally
-        // exist yet
-        resizeViewport();
-        setTimeout(() => resizeViewport(), 250)
-        setTimeout(() => resizeViewport(), 10000)
-
-        const resizeObserver = new ResizeObserver(() => {
-            resizeViewport();
+            }
+            return gridState;
         })
+    };
 
-        const containerDiv = containerRef.current; 
-        if (containerDiv) {
-            resizeObserver.observe(containerDiv);
+
+    // This hook is used to set the scrollAndRenderedContainerRef, while also
+    // registering this element with the resize observer, so that we can make sure
+    // to update the viewport size when we need to      
+    const setScrollAndRendererContainerRef = useCallback((unsavedScrollAndRenderedContainerDiv: HTMLDivElement) => {
+        if (unsavedScrollAndRenderedContainerDiv !== null) {
+            scrollAndRenderedContainerRef.current = unsavedScrollAndRenderedContainerDiv;
+            resizeObserver.observe(unsavedScrollAndRenderedContainerDiv)
         }
-        
-        return () => {
-            resizeObserver.disconnect();
-        }
-    }, [setGridState])
+    },[]);
+
+    // An effect that cleans up the resize observer
+    useEffect(() => {
+        return () => {resizeObserver.disconnect();}
+    }, [])
 
     // Handles a scroll inside the grid 
     const onGridScroll = (e: React.UIEvent<HTMLDivElement, UIEvent>) => {
@@ -651,7 +649,7 @@ function EndoGrid(props: {
                     </>
                 }
                 
-                <div className="endo-scroller-and-renderer-container" ref={scrollAndRenderedContainerRef} onScroll={onGridScroll}>
+                <div className="endo-scroller-and-renderer-container" ref={setScrollAndRendererContainerRef} onScroll={onGridScroll}>
                     {/* 
                         We handle the case where this no data in the sheet just by returning an empty
                         container with an optional message of your choosing! 

--- a/mitosheet/src/components/endo/sheetViewUtils.tsx
+++ b/mitosheet/src/components/endo/sheetViewUtils.tsx
@@ -38,12 +38,12 @@ export const calculateCurrentSheetView = (
     for (let i = 0; i < gridState.widthDataArray[gridState.sheetIndex].widthArray.length; i++) {
         const totalWidth = gridState.widthDataArray[gridState.sheetIndex].widthSumArray[i];
 
-        if (!foundStart && totalWidth > (gridState.scrollPositions[gridState.sheetIndex]?.scrollLeft || 0)) {
+        if (!foundStart && totalWidth > gridState.scrollPosition.scrollLeft) {
             startingColumnIndex = i;
             foundStart = true;
         }
 
-        if (foundStart && totalWidth > ((gridState.scrollPositions[gridState.sheetIndex]?.scrollLeft || 0) + gridState.viewport.width)) {
+        if (foundStart && totalWidth > (gridState.scrollPosition.scrollLeft + gridState.viewport.width)) {
             numColumnsRendered = i - startingColumnIndex + 1;
             break;
         } else if (i === gridState.widthDataArray[gridState.sheetIndex].widthArray.length - 1) {
@@ -54,7 +54,7 @@ export const calculateCurrentSheetView = (
     }
 
     return {
-        startingRowIndex: Math.max(Math.floor((gridState.scrollPositions[gridState.sheetIndex]?.scrollTop || 0) / DEFAULT_HEIGHT), 0),
+        startingRowIndex: Math.max(Math.floor(gridState.scrollPosition.scrollTop / DEFAULT_HEIGHT), 0),
         numRowsRendered: Math.ceil(gridState.viewport.height / DEFAULT_HEIGHT) + 3, // For some reason, we add three. It gets weird with multi-index headers, dk why
         startingColumnIndex: startingColumnIndex,
         numColumnsRendered: numColumnsRendered,
@@ -77,8 +77,8 @@ export const calculateTranslate = (gridState: GridState): RendererTranslate => {
     const currentSheetView = calculateCurrentSheetView(gridState);
 
     return {
-        x: (gridState.scrollPositions[gridState.sheetIndex]?.scrollLeft || 0) - (currentSheetView.startingColumnIndex === 0 ? 0 : gridState.widthDataArray[gridState.sheetIndex].widthSumArray[currentSheetView.startingColumnIndex - 1]),
-        y: (gridState.scrollPositions[gridState.sheetIndex]?.scrollTop || 0) % (DEFAULT_HEIGHT),
+        x: gridState.scrollPosition.scrollLeft - (currentSheetView.startingColumnIndex === 0 ? 0 : gridState.widthDataArray[gridState.sheetIndex].widthSumArray[currentSheetView.startingColumnIndex - 1]),
+        y: gridState.scrollPosition.scrollTop % (DEFAULT_HEIGHT),
     }
 }
 

--- a/mitosheet/src/components/endo/utils.tsx
+++ b/mitosheet/src/components/endo/utils.tsx
@@ -39,12 +39,10 @@ export const getDefaultGridState = (sheetDataArray: SheetData[], selectedSheetIn
             width: 0,
             height: 0,
         },
-        scrollPositions: sheetDataArray.map(() => {
-            return {
-                scrollLeft: 0,
-                scrollTop: 0
-            }
-        }),
+        scrollPosition: {
+            scrollLeft: 0,
+            scrollTop: 0
+        },
         selections: [{
             startingColumnIndex: 0,
             endingColumnIndex: 0,

--- a/mitosheet/src/components/endo/visibilityUtils.tsx
+++ b/mitosheet/src/components/endo/visibilityUtils.tsx
@@ -1,26 +1,8 @@
-import { GridState, ScrollPosition, SheetData, SheetView } from "../../types";
+import { GridState, SheetView } from "../../types";
 import { DEFAULT_HEIGHT } from "./EndoGrid";
 import { columnIsVisible, rowIsVisible } from "./sheetViewUtils";
 import { isNumberInRangeInclusive } from "./utils";
 
-
-// A utility for scrolling a container div to a specific position
-export const scrollToScrollPosition = (scrollAndRenderedContainerDiv: HTMLDivElement | null, scrollPosition: ScrollPosition): void => {
-    if (scrollAndRenderedContainerDiv) {
-        scrollAndRenderedContainerDiv.scrollTop = scrollPosition.scrollTop;
-        scrollAndRenderedContainerDiv.scrollLeft = scrollPosition.scrollLeft;
-    }
-}
-
-export const reconciliateScrollPositions = (sheetDataArray: SheetData[], scrollPositions: (ScrollPosition | undefined)[]): ScrollPosition[] => {
-    const newScrollPositions: ScrollPosition[] = []
-    for (let i = 0; i < sheetDataArray.length; i++) {
-        const newScrollPosition = scrollPositions[i] || {scrollTop: 0, scrollLeft: 0};
-        newScrollPositions.push(newScrollPosition);
-    }
-
-    return newScrollPositions;
-}
 
 // A helper to scroll a given row into view
 const scrollRowIntoView = (containerDiv: HTMLDivElement | null, scrollAndRenderedContainerDiv: HTMLDivElement | null, currentSheetView: SheetView, rowIndex: number) => {

--- a/mitosheet/src/components/footer/DataSheetTabActions.tsx
+++ b/mitosheet/src/components/footer/DataSheetTabActions.tsx
@@ -43,13 +43,15 @@ export default function SheetTabActions(props: {
 
     // Log opening the data sheet tab actions
     useEffect(() => {
-        void props.mitoAPI.log(
-            'clicked_data_sheet_tab_actions',
-            {
-                sheet_index: props.sheetIndex
-            }
-        )
-    }, [])
+        if (props.display) {
+            void props.mitoAPI.log(
+                'clicked_data_sheet_tab_actions',
+                {
+                    sheet_index: props.sheetIndex
+                }
+            )
+        }
+    }, [props.display])
 
     const onDelete = async (): Promise<void> => {
         const dependantGraphTabNamesAndIDs = getGraphTabNamesAndIDsFromSheetIndex(props.sheetIndex, props.graphDataDict)

--- a/mitosheet/src/components/footer/GraphSheetTabActions.tsx
+++ b/mitosheet/src/components/footer/GraphSheetTabActions.tsx
@@ -26,13 +26,15 @@ export default function GraphSheetTabActions(props: {
 
     // Log opening the graph sheet tab actions
     useEffect(() => {
-        void props.mitoAPI.log(
-            'clicked_graph_sheet_tab_actions',
-            {
-                graph_id: props.graphID
-            }
-        )
-    }, [])
+        if (props.display) {
+            void props.mitoAPI.log(
+                'clicked_graph_sheet_tab_actions',
+                {
+                    graph_id: props.graphID
+                }
+            )
+        }
+    }, [props.display])
 
     const onDelete = async (): Promise<void> => {
         // Close 

--- a/mitosheet/src/types.tsx
+++ b/mitosheet/src/types.tsx
@@ -471,7 +471,7 @@ export interface WidthData {
 export interface GridState {
     sheetIndex: number;
     viewport: Dimension;
-    scrollPositions: (ScrollPosition | undefined)[];
+    scrollPosition: ScrollPosition;
     selections: MitoSelection[];
     copiedSelections: MitoSelection[];
     columnIDsArray: ColumnID[][];

--- a/mitosheet/src/utils/copy.tsx
+++ b/mitosheet/src/utils/copy.tsx
@@ -16,7 +16,12 @@ const getCopyStringForRow = (sheetData: SheetData, rowIndex: number, lowColIndex
     
     for (let columnIndex = lowColIndex; columnIndex <= highColIndex; columnIndex++) {
         if (rowIndex === -1) {
-            copyString += getDisplayColumnHeader(sheetData.data[columnIndex].columnHeader)
+            if (columnIndex === -1) {
+                // There is nothing to copy here, so just skip it. We just keep this
+                // case for symmetry
+            } else {
+                copyString += getDisplayColumnHeader(sheetData.data[columnIndex].columnHeader)
+            }
         } else {
             if (columnIndex === -1) {
                 copyString += sheetData.index[rowIndex];


### PR DESCRIPTION
# Description

- Fix bug where if you selected the entire dataframe, including all indexes and column headers, copy didn't work. 
- Fix bug with replay anlaysis documented here: https://github.com/mito-ds/monorepo/issues/338
- Reverting scroll saving (because it was so buggy).
- Fix bug where the delimiters where confusingly labeled in comments and step descriptions

# Testing

Test scrolling, and copy.

# Documentation

N/A.