### PR TITLE
mitosheet: remove setting on warnings errors

### DIFF
--- a/mitosheet/mitosheet/tests/test_mito_widget.py
+++ b/mitosheet/mitosheet/tests/test_mito_widget.py
@@ -132,9 +132,10 @@ def test_sheet_json_holds_all_columns():
     df = pd.DataFrame({i: [1, 2, 3] for i in range(MAX_COLUMNS + 100)})
     mito = create_mito_wrapper_dfs(df)
     sheet_data = json.loads(mito.mito_widget.sheet_data_json)[0]
-    assert sheet_data['columnIDsMap'][str(MAX_COLUMNS + 1)] is not None
-    assert sheet_data['columnSpreadsheetCodeMap'][str(MAX_COLUMNS + 1)] is not None
-    assert sheet_data['columnFiltersMap'][str(MAX_COLUMNS + 1)] is not None
-    assert sheet_data['columnIDsMap'][str(MAX_COLUMNS + 1)] is not None
-    assert sheet_data['columnDtypeMap'][str(MAX_COLUMNS + 1)] is not None
-    assert sheet_data['columnFormatTypeObjMap'][str(MAX_COLUMNS + 1)] is not None
+    for i in range(MAX_COLUMNS, MAX_COLUMNS + 100):
+        assert sheet_data['columnIDsMap'][str(i)] is not None
+        assert sheet_data['columnSpreadsheetCodeMap'][str(i)] is not None
+        assert sheet_data['columnFiltersMap'][str(i)] is not None
+        assert sheet_data['columnIDsMap'][str(i)] is not None
+        assert sheet_data['columnDtypeMap'][str(i)] is not None
+        assert sheet_data['columnFormatTypeObjMap'][str(i)] is not None

--- a/mitosheet/mitosheet/tests/test_mito_widget.py
+++ b/mitosheet/mitosheet/tests/test_mito_widget.py
@@ -3,13 +3,16 @@
 
 # Copyright (c) Mito.
 # Distributed under the terms of the Modified BSD License.
+import json
 import os
 import pandas as pd
 import pytest
 
 from mitosheet.mito_widget import MitoWidget, sheet
+from mitosheet.tests.test_utils import create_mito_wrapper, create_mito_wrapper_dfs
 from mitosheet.transpiler.transpile import transpile
 from mitosheet.tests.decorators import pandas_post_1_only
+from mitosheet.utils import MAX_COLUMNS
 
 
 def test_example_creation_blank():
@@ -124,3 +127,14 @@ def test_can_call_with_indexes():
 
     multi_index = df.set_index(['B', 'D'])
     sheet(multi_index)
+
+def test_sheet_json_holds_all_columns():
+    df = pd.DataFrame({i: [1, 2, 3] for i in range(MAX_COLUMNS + 100)})
+    mito = create_mito_wrapper_dfs(df)
+    sheet_data = json.loads(mito.mito_widget.sheet_data_json)[0]
+    assert sheet_data['columnIDsMap'][str(MAX_COLUMNS + 1)] is not None
+    assert sheet_data['columnSpreadsheetCodeMap'][str(MAX_COLUMNS + 1)] is not None
+    assert sheet_data['columnFiltersMap'][str(MAX_COLUMNS + 1)] is not None
+    assert sheet_data['columnIDsMap'][str(MAX_COLUMNS + 1)] is not None
+    assert sheet_data['columnDtypeMap'][str(MAX_COLUMNS + 1)] is not None
+    assert sheet_data['columnFormatTypeObjMap'][str(MAX_COLUMNS + 1)] is not None

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -175,7 +175,7 @@ def df_to_json_dumpsable(
         for row in json_obj['data']:
             # If we're beyond the max columns, we might not have data, and we leave column data empty
             # in this case and don't append anything
-            column_final_data['columnData'].append(row[column_index] if column_index < len(row) else None)
+            column_final_data['columnData'].append(row[column_index] if column_index < MAX_COLUMNS else None)
         
         final_data.append(column_final_data)     
     

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -156,14 +156,12 @@ def df_to_json_dumpsable(
     """
 
     (num_rows, num_columns) = original_df.shape 
-    df = original_df.iloc[: , :max_columns]
 
-    json_obj = convert_df_to_parsed_json(df, max_rows=max_rows, max_columns=max_columns)
+    json_obj = convert_df_to_parsed_json(original_df, max_rows=max_rows, max_columns=max_columns)
 
     final_data = []
     column_dtype_map = {}
-    for column_index, _ in enumerate(json_obj['columns']):
-        column_header = df.columns[column_index]
+    for column_index, column_header in enumerate(original_df.columns):
         column_id = column_headers_to_column_ids[column_header]
 
         column_final_data: Dict[str, Any] = {
@@ -175,7 +173,9 @@ def df_to_json_dumpsable(
         }
         column_dtype_map[column_id] = str(original_df[column_header].dtype)
         for row in json_obj['data']:
-            column_final_data['columnData'].append(row[column_index])
+            # If we're beyond the max columns, we might not have data, and we leave column data empty
+            # in this case and don't append anything
+            column_final_data['columnData'].append(row[column_index] if column_index < len(row) else None)
         
         final_data.append(column_final_data)     
     
@@ -189,7 +189,7 @@ def df_to_json_dumpsable(
         # front-end and we don't have to worry about sorting
         'columnIDsMap': {
             column_headers_to_column_ids[column_header]: get_column_header_display(column_header)
-            for column_header in df.keys()
+            for column_header in original_df.keys()
         },
         'columnSpreadsheetCodeMap': column_spreadsheet_code,
         'columnFiltersMap': column_filters,

--- a/mitosheet/mitosheet/utils.py
+++ b/mitosheet/mitosheet/utils.py
@@ -108,7 +108,7 @@ def dfs_to_array_for_json(
                     column_ids.column_header_to_column_id[sheet_index],
                     column_format_types[sheet_index],
                     # We only send the first 1500 rows and 1500 columns
-                    max_length=MAX_ROWS,
+                    max_rows=MAX_ROWS,
                     max_columns=MAX_COLUMNS
                 ) 
             )
@@ -126,8 +126,8 @@ def df_to_json_dumpsable(
         column_filters: Dict[ColumnID, Any],
         column_headers_to_column_ids: Dict[ColumnHeader, ColumnID],
         column_format_types: Dict[ColumnID, Dict[ColumnID, str]],
-        max_length: Optional[int]=MAX_ROWS, # How many items you want to display. None when using this function to get unique value counts
-        max_columns: int=MAX_COLUMNS # How many columns you want to display. Unlike max_length, this is always defined
+        max_rows: Optional[int]=MAX_ROWS, # How many items you want to display. None when using this function to get unique value counts
+        max_columns: int=MAX_COLUMNS # How many columns you want to display. Unlike max_rows, this is always defined
     ) -> Dict[str, Any]:
     """
     Returns a dataframe and other metadata represented in a way that can be turned into a 
@@ -156,17 +156,9 @@ def df_to_json_dumpsable(
     """
 
     (num_rows, num_columns) = original_df.shape 
+    df = original_df.iloc[: , :max_columns]
 
-    if max_length is None:
-        df = original_df.copy(deep=True) 
-    else:
-        # we only show the first max_length rows!
-        df = original_df.head(n=max_length if max_length else num_rows).copy(deep=True)
-
-    # we only show the first max_columns columns!
-    df = df.iloc[: , :max_columns]
-
-    json_obj = convert_df_to_parsed_json(df)
+    json_obj = convert_df_to_parsed_json(df, max_rows=max_rows, max_columns=max_columns)
 
     final_data = []
     column_dtype_map = {}
@@ -214,10 +206,18 @@ def get_row_data_array(df: pd.DataFrame) -> List[Any]:
     json_obj = convert_df_to_parsed_json(df)
     return json_obj['data']
 
-def convert_df_to_parsed_json(df: pd.DataFrame) -> Dict[str, Any]:
+def convert_df_to_parsed_json(original_df: pd.DataFrame, max_rows: Optional[int]=MAX_ROWS, max_columns: int=MAX_COLUMNS) -> Dict[str, Any]:
     """
     Returns a dataframe as a json object with the correct formatting
     """
+    if max_rows is None:
+        df = original_df.copy(deep=True) 
+    else:
+        # we only show the first max_rows rows!
+        df = original_df.head(n=max_rows).copy(deep=True)
+
+    # we only show the first max_columns columns!
+    df = df.iloc[: , :max_columns]
 
     float_columns, date_columns, timedelta_columns = get_float_dt_td_columns(df)
     # We figure out which of the columns contain dates, and we


### PR DESCRIPTION
# Description

Fixes a warning we were getting with SettingWithCopyWarning in the utils file, which you can read about here: https://www.dataquest.io/blog/settingwithcopywarning/

It was an invalid warning (it wasn't real), but rather than silencing it I just moved where we copy to fix it up. No functionality changes.

Had to do this because warnings on Notebooks appear in the notebook rather than printed elsewhere, which looks awful.

# Testing

Testing nothing broke.

# Documentation

N/A.