### PR TITLE
mitosheet: add user install option

### DIFF
--- a/mitoinstaller/mitoinstaller/commands.py
+++ b/mitoinstaller/mitoinstaller/commands.py
@@ -88,7 +88,7 @@ def uninstall_pip_packages(*packages: str) -> None:
     run_command(sys_call)
 
 
-def install_pip_packages(*packages: str, test_pypi: bool=False) -> None:
+def install_pip_packages(*packages: str, test_pypi: bool=False, user_install: bool=False) -> None:
     """
     This function installs the given packages in a single pass
     using pip, through the command line.
@@ -103,6 +103,10 @@ def install_pip_packages(*packages: str, test_pypi: bool=False) -> None:
     # Handle TestPyPi
     if test_pypi:
         sys_call.extend(['--index-url', 'https://test.pypi.org/simple/', '--extra-index-url', 'https://pypi.org/simple/'])
+
+    # Handle user install
+    if user_install:
+        sys_call.append('--user')
 
     # Pass through no cache dir if it is there
     if '--no-cache-dir' in sys.argv:

--- a/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
@@ -4,7 +4,7 @@ from mitoinstaller.commands import (get_jupyterlab_metadata,
                                     install_pip_packages, run_command,
                                     uninstall_pip_packages)
 from mitoinstaller.installer_steps.installer_step import InstallerStep
-from mitoinstaller.log_utils import log
+from mitoinstaller.log_utils import get_recent_traceback, log
 
 
 def install_step_mitosheet_check_dependencies():
@@ -52,7 +52,24 @@ def remove_mitosheet_3_if_present():
 
 def install_step_mitosheet_install_mitosheet():
     print("This might take a few moments...")
-    install_pip_packages('mitosheet', test_pypi='--test-pypi' in sys.argv)
+    try:
+        install_pip_packages('mitosheet', test_pypi='--test-pypi' in sys.argv)
+    except:
+        # If the user hits an install error because of permission issues, we ask them if 
+        # they want to try a user install
+        error_traceback_last_line = get_recent_traceback().strip().split('\n')[-1].strip()
+        if error_traceback_last_line == 'Consider using the `--user` option or check the permissions.':
+            do_user_install = input("The installer hit a permission error while trying to install Mito. Would you like to do a user install? [y/n] ")
+            if do_user_install.lower().startswith('y'):
+                # Log do user install
+                log('install_mitosheet_user')
+                install_pip_packages('mitosheet', test_pypi='--test-pypi' in sys.argv, user_install=True)
+                return
+        
+        # Otherwise, if it is some other error, we just bubble it up
+        raise
+
+
 
 def install_step_mitosheet_activate_notebook_extension():
     run_command([sys.executable, "-m", 'jupyter', 'nbextension', 'install', '--py', '--user', 'mitosheet'])

--- a/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
@@ -61,6 +61,7 @@ def install_step_mitosheet_install_mitosheet():
         if error_traceback_last_line == 'Consider using the `--user` option or check the permissions.':
             do_user_install = input("The installer hit a permission error while trying to install Mito. Would you like to do a user install? Note that this will not work inside a virtual enviornment. [y/n] ")
             if do_user_install.lower().startswith('y'):
+                print("Doing user install")
                 # Log do user install
                 log('install_mitosheet_user')
                 install_pip_packages('mitosheet', test_pypi='--test-pypi' in sys.argv, user_install=True)

--- a/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
@@ -59,7 +59,7 @@ def install_step_mitosheet_install_mitosheet():
         # they want to try a user install
         error_traceback_last_line = get_recent_traceback().strip().split('\n')[-1].strip()
         if error_traceback_last_line == 'Consider using the `--user` option or check the permissions.':
-            do_user_install = input("The installer hit a permission error while trying to install Mito. Would you like to do a user install? [y/n] ")
+            do_user_install = input("The installer hit a permission error while trying to install Mito. Would you like to do a user install? Note that this will not work inside a virtual enviornment. [y/n] ")
             if do_user_install.lower().startswith('y'):
                 # Log do user install
                 log('install_mitosheet_user')


### PR DESCRIPTION
# Description

This adds the option for users to do a user install with the mitoinstaller, which hopefully will address.

# Testing

This is very hard to test. Here's what you can do:
1. Change `Consider using the `--user` option or check the permissions.` to `KeyboardInterrupt`, and then press control + c during this step (and then see if you enter the condition correctly). 
2. Confirm that you get an error when trying to do a user install inside a venv - this confirms that we are at least trying to do a user install.

This might lead to more bugs with notebook installs or something, but it's very hard to say before we deploy. Given how uncommon this is, I think we should sanity check per above and then see how common this is in the future before doing much more. We know user installs will work in many cases, so this is at least an improvement for many users who cannot even get started as of now!

# Documentation

No.