### PR TITLE
mitosheet: add a csv config taskpane

### DIFF
--- a/mitosheet/mitosheet/api/api.py
+++ b/mitosheet/mitosheet/api/api.py
@@ -9,6 +9,7 @@ Contains handlers for the Mito API
 from queue import Queue
 from threading import Thread
 from typing import Any, Callable, Dict, List, NoReturn, Union
+from mitosheet.api.get_csv_file_metadata import get_csv_file_metadata
 from mitosheet.api.get_params import get_params
 from mitosheet.api.get_column_describe import get_column_describe
 from mitosheet.api.get_dataframe_as_csv import get_dataframe_as_csv
@@ -132,6 +133,8 @@ def handle_api_event(
         result = get_params(params, steps_manager)
     elif event["type"] == "get_excel_file_metadata":
         result = get_excel_file_metadata(params, steps_manager)
+    elif event["type"] == "get_csv_file_metadata":
+        result = get_csv_file_metadata(params, steps_manager)
     elif event["type"] == "get_unique_value_counts":
         result = get_unique_value_counts(params, steps_manager)
     elif event["type"] == "get_split_text_to_columns_preview":

--- a/mitosheet/mitosheet/api/get_csv_file_metadata.py
+++ b/mitosheet/mitosheet/api/get_csv_file_metadata.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GPL License.
+import json
+import os
+from typing import Any, Dict
+
+import pandas as pd
+from mitosheet.step_performers.import_steps.simple_import import read_csv_get_delimeter_and_encoding
+from mitosheet.types import StepsManagerType
+
+
+def get_csv_file_metadata(params: Dict[str, Any], steps_manager: StepsManagerType) -> str:
+    """
+    Given a list of 'file_names' that should be CSV files,
+    this returns our guesses for delimeters and encodings
+    for these files.
+    """
+    file_names = params['file_names']
+
+    delimeters = []
+    encodings = []
+    for file_name in file_names:
+        _, delimiter, encoding = read_csv_get_delimeter_and_encoding(file_name)
+        delimeters.append(delimiter)
+        encodings.append(encoding)
+
+    return json.dumps({
+        'delimeters': delimeters,
+        'encodings': encodings
+    })
+
+

--- a/mitosheet/mitosheet/errors.py
+++ b/mitosheet/mitosheet/errors.py
@@ -446,6 +446,21 @@ def make_invalid_promote_row_to_header(error_modal: bool=True) -> MitoError:
         error_modal=error_modal
     )
 
+def make_invalid_simple_import_error(error_modal: bool=False) -> MitoError:
+    """
+    Helper function for creating a invalid_simple_import_error.
+
+    Occurs when a user tries to simple import and it fails
+    """
+    to_fix = f'This row has duplicated values in it. As such, making this row a header would make column references ambigious, so we cannot make it a header row.' 
+    
+    return MitoError(
+        'invalid_simple_import_error', 
+        "Cannot create duplicate headers",
+        to_fix,
+        error_modal=error_modal
+    )
+
 ARG_FULL_NAME = {
     'int': 'number',
     'float': 'number',

--- a/mitosheet/mitosheet/tests/step_performers/import_steps/test_simple_import_step.py
+++ b/mitosheet/mitosheet/tests/step_performers/import_steps/test_simple_import_step.py
@@ -21,6 +21,35 @@ FAKE_FILE_PATHS = [
     'never_exists.csv'
 ]
 
+SIMPLE_IMPORT_TESTS = [
+    (
+        pd.DataFrame({'A': [1, 2, 3]}),
+        ';', 
+        'utf-8',
+        False
+    ),
+    (
+        pd.DataFrame({'A': [1, 2, 3]}),
+        '|', 
+        'big5',
+        True
+    ),
+]
+@pytest.mark.parametrize("input_df, delimeter, encoding, error_bad_lines", SIMPLE_IMPORT_TESTS)
+def test_simple_import(input_df, delimeter, encoding, error_bad_lines):
+    input_df.to_csv(TEST_FILE_PATHS[0], index=False, sep=delimeter, encoding=encoding)
+
+    # Create with no dataframes
+    mito = create_mito_wrapper_dfs()
+    # And then import just a test file
+    mito.simple_import([TEST_FILE_PATHS[0]], [delimeter], [encoding], [error_bad_lines])
+
+    # Remove the test file
+    os.remove(TEST_FILE_PATHS[0])
+
+    assert len(mito.dfs) == 1
+    assert mito.dfs[0].equals(input_df)
+
 def test_rolls_back_on_failed_import():
 
     # Create with no dataframes
@@ -396,3 +425,5 @@ def test_multiple_imports_optimize_stopped_by_rename():
 
     # Remove the test file
     os.remove(TEST_FILE_PATHS[0])
+
+# TODO: test skip invalid lines!

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -725,7 +725,7 @@ class MitoWidgetTestWrapper:
         )
 
     @check_transpiled_code_after_call
-    def simple_import(self, file_names: List[str]) -> bool:
+    def simple_import(self, file_names: List[str], delimeters: Optional[List[str]]=None, encodings: Optional[List[str]]=None, error_bad_lines: Optional[List[bool]]=None) -> bool:
         return self.mito_widget.receive_message(
             self.mito_widget,
             {
@@ -734,7 +734,10 @@ class MitoWidgetTestWrapper:
                 'type': 'simple_import_edit',
                 'step_id': get_new_id(),
                 'params': {
-                    'file_names': file_names
+                    'file_names': file_names,
+                    'delimeters': delimeters,
+                    'encodings': encodings,
+                    'error_bad_lines': error_bad_lines,
                 }
             }
         )

--- a/mitosheet/src/components/taskpanes/Import/CSVImport.tsx
+++ b/mitosheet/src/components/taskpanes/Import/CSVImport.tsx
@@ -1,0 +1,365 @@
+// Copyright (c) Mito
+
+import React, { useEffect, useState } from 'react';
+
+// Import 
+import MitoAPI from '../../../jupyter/api';
+import Select from '../../elements/Select';
+import TextButton from '../../elements/TextButton';
+import DropdownItem from '../../elements/DropdownItem';
+import { AnalysisData, MitoError, StepType, UIState } from '../../../types';
+import { FileElement, ImportTaskpaneState } from './ImportTaskpane';
+import useSendEditOnClick from '../../../hooks/useSendEditOnClick';
+import DefaultTaskpane from '../DefaultTaskpane/DefaultTaskpane';
+import DefaultTaskpaneHeader from '../DefaultTaskpane/DefaultTaskpaneHeader';
+import DefaultTaskpaneBody from '../DefaultTaskpane/DefaultTaskpaneBody';
+import DefaultTaskpaneFooter from '../DefaultTaskpane/DefaultTaskpaneFooter';
+import Spacer from '../../spacing/Spacer';
+import Row from '../../spacing/Row';
+import Col from '../../spacing/Col';
+import Input from '../../elements/Input';
+import Toggle from '../../elements/Toggle';
+import { isMitoError } from '../../../utils/errors';
+import Tooltip from '../../elements/Tooltip';
+import RedoIcon from '../../icons/RedoIcon';
+
+const ENCODINGS = [
+    "utf_8",
+    "ascii",
+    "latin_1",
+    "big5",
+    "big5hkscs",
+    "cp037",
+    "cp273",
+    "cp424",
+    "cp437",
+    "cp500",
+    "cp720",
+    "cp737",
+    "cp775",
+    "cp850",
+    "cp852",
+    "cp855",
+    "cp856",
+    "cp857",
+    "cp858",
+    "cp860",
+    "cp861",
+    "cp862",
+    "cp863",
+    "cp864",
+    "cp865",
+    "cp866",
+    "cp869",
+    "cp874",
+    "cp875",
+    "cp932",
+    "cp949",
+    "cp950",
+    "cp1006",
+    "cp1026",
+    "cp1125",
+    "",
+    "",
+    "",
+    "cp1140",
+    "cp1250",
+    "cp1251",
+    "cp1252",
+    "cp1253",
+    "cp1254",
+    "cp1255",
+    "cp1256",
+    "cp1257",
+    "cp1258",
+    "euc_jp",
+    "euc_jis_2004",
+    "euc_jisx0213",
+    "euc_kr",
+    "gb2312",
+    "gbk",
+    "gb18030",
+    "hz",
+    "iso2022_jp",
+    "iso2022_jp_1",
+    "iso2022_jp_2",
+    "iso2022_jp_2004",
+    "iso2022_jp_3",
+    "iso2022_jp_ext",
+    "iso2022_kr",
+    "iso8859_2",
+    "iso8859_3",
+    "iso8859_4",
+    "iso8859_5",
+    "iso8859_6",
+    "iso8859_7",
+    "iso8859_8",
+    "iso8859_9",
+    "iso8859_10",
+    "iso8859_11",
+    "iso8859_13",
+    "iso8859_14",
+    "iso8859_15",
+    "iso8859_16",
+    "johab",
+    "koi8_r",
+    "koi8_t",
+    "koi8_u",
+    "kz1048",
+    "mac_cyrillic",
+    "mac_greek",
+    "mac_iceland",
+    "mac_latin2",
+    "mac_roman",
+    "mac_turkish",
+    "ptcp154",
+    "shift_jis",
+    "shift_jis_2004",
+    "shift_jisx0213",
+    "utf_32",
+    "utf_32_be",
+    "utf_32_le",
+    "utf_16",
+    "utf_16_be",
+    "utf_16_le",
+    "utf_7",
+    "utf_8_sig"
+] 
+
+const DELIMETER_TOOLTIP = 'TODO DELIM'
+const ENCODING_TOOLTIP = 'TODO ENCODING'
+const ERROR_BAD_LINES_TOOLTIP = 'TODO Error'
+
+
+interface CSVImportProps {
+    mitoAPI: MitoAPI;
+    analysisData: AnalysisData;
+    fileName: string;
+    importState: ImportTaskpaneState;
+    setImportState: React.Dispatch<React.SetStateAction<ImportTaskpaneState>>;
+    setUIState: React.Dispatch<React.SetStateAction<UIState>>;
+    fileForImportWizard: FileElement | undefined,
+    setFileForImportWizard: React.Dispatch<React.SetStateAction<FileElement | undefined>>;
+    error: MitoError | undefined;
+}
+
+// This is our guesses about the metadata of the file
+export interface CSVFileMetadata {
+    delimeters: string[],
+    encodings: string[]
+}
+
+interface CSVImportParams {
+    file_names: string[],
+    delimeters: string[],
+    encodings: string[],
+    error_bad_lines: boolean[],
+}
+
+const getDefaultParams = (fileName: string): CSVImportParams => {
+    return {
+        file_names: [fileName],
+        delimeters: [','],
+        encodings: ['default'],
+        error_bad_lines: [true]
+    }
+}
+
+const getButtonMessage = (fileElement: FileElement, loading: boolean): string => {
+    if (loading) {
+        return `Importing...`
+    }
+    return `Import ${fileElement.name}`;
+}
+
+
+function getSuccessMessage(fileElement: FileElement): string {
+    return `Imported ${fileElement.name}`
+}
+
+
+/* 
+    Allows a user to configure the import for a specific CSV file
+*/
+function CSVImport(props: CSVImportProps): JSX.Element {
+
+    // NOTE: this loading state is just for getting the metadata about the sheets
+    // and not for importing the file
+    const [fileMetadata, setFileMetadata] = useState<CSVFileMetadata | undefined>(undefined);
+    const {params, setParams, loading, edit, editApplied} = useSendEditOnClick(
+        () => getDefaultParams(props.fileName),
+        StepType.SimpleImport,
+        props.mitoAPI, props.analysisData,
+        {allowSameParamsToReapplyTwice: true}
+    )
+
+
+    useEffect(() => {
+        const loadMetadata = async () => {
+            const loadedFileMetadata = await props.mitoAPI.getCSVFileMetadata(params?.file_names || []);
+
+            setFileMetadata(loadedFileMetadata);
+
+            setParams(prevParams => {
+                return {
+                    ...prevParams,
+                    delimeters: loadedFileMetadata?.delimeters || [','],
+                    encodings: loadedFileMetadata?.encodings || ['default']
+                }
+            })
+        }
+
+        void loadMetadata()
+    }, []);
+
+    const resetParams = () => {
+        setParams(prevParams => {
+            return {
+                ...prevParams,
+                delimeters: fileMetadata?.delimeters || [','],
+                encodings: fileMetadata?.encodings || ['default'],
+                error_bad_lines: [true]
+            }
+        })
+    }
+
+    if (params === undefined || props.fileForImportWizard === undefined) {
+        return (
+            <div className='text-body-1'>
+                There has been an error loading your CSV file encodings. Please try again, or contact support.
+            </div>
+        )
+    }
+
+    const currentDelimeter = params.delimeters[0];
+    const currentEncoding = params.encodings[0] === 'default' ? 'utf-8' : params.encodings[0];
+    const currentErrorBadLines = params.error_bad_lines[0];
+    
+    return (
+        <DefaultTaskpane>
+            <DefaultTaskpaneHeader
+                header={`Import ${props.fileForImportWizard?.name}`}
+                setUIState={props.setUIState}
+                backCallback={() => props.setFileForImportWizard(undefined)}
+            />
+            <DefaultTaskpaneBody noScroll>
+                {isMitoError(props.error) && 
+                    <p className='text-color-error'> We were unable to automatically determine a delimeter and encoding. Please select a delemeter and encoding.</p>
+                }
+                <Row justify='space-between' align='center' title={DELIMETER_TOOLTIP}>
+                    <Col>
+                        <Row justify='start' align='center' suppressTopBottomMargin>
+                            <p className='text-header-3'>
+                                Delimeter
+                            </p>
+                            <Tooltip title={DELIMETER_TOOLTIP}/>
+                        </Row>
+                    </Col>
+                    <Col>
+                        <Input
+                            width='medium'
+                            value={currentDelimeter}
+                            onChange={(e) => {
+                                const newDelimeter = e.target.value;
+                                setParams(prevParams => {
+                                    return {
+                                        ...prevParams,
+                                        delimeters: [newDelimeter]
+                                    }
+                                })
+                            }} 
+                        />
+                    </Col>
+                </Row>
+                <Row justify='space-between' align='center' title={ENCODING_TOOLTIP}>
+                    <Col>
+                        <Row justify='start' align='center' suppressTopBottomMargin>
+                            <p className='text-header-3'>
+                                Encoding
+                            </p>
+                            <Tooltip title={ENCODING_TOOLTIP}/>
+                        </Row>
+                    </Col>
+                    <Col>
+                        <Select 
+                            searchable
+                            width='medium' 
+                            value={currentEncoding} 
+                            onChange={(newEncoding) => {
+                                setParams(prevParams => {
+                                    return {
+                                        ...prevParams,
+                                        encodings: [newEncoding]
+                                    }
+                                })
+                            }}>
+                            {(ENCODINGS).map((encoding) => {
+                                return <DropdownItem title={encoding}/>
+                            })}
+                        </Select>
+                    </Col>
+                </Row>
+                <Row justify='space-between' align='center' title={ERROR_BAD_LINES_TOOLTIP}>
+                    <Col>
+                        <Row justify='start' align='center' suppressTopBottomMargin>
+
+                            <p className='text-header-3'>
+                                Error on Invalid Lines
+                            </p>
+                            <Tooltip title={ERROR_BAD_LINES_TOOLTIP}/>
+                        </Row>
+                    </Col>
+                    <Col>
+                        <Toggle value={currentErrorBadLines} onChange={() => {
+                            setParams(prevParams => {
+                                return {
+                                    ...prevParams,
+                                    error_bad_lines: [!prevParams.error_bad_lines[0]]
+                                }
+                            })
+                        }}/>
+                    </Col>
+                </Row>
+                <Row justify='start' >
+                    <Col onClick={resetParams}>
+                        <p className='text-underline text-header-3 text-color-medium-gray-important'>
+                            Reset parameters
+                        </p>
+                    </Col>
+                    <Col onClick={resetParams} offset={.5}>
+                        {/** TODO: merge in bulk filter, and use the stroke width! */}
+                        <RedoIcon/>
+                    </Col>
+
+                </Row>
+            </DefaultTaskpaneBody>
+            <DefaultTaskpaneFooter>
+                {!isMitoError(props.error) &&
+                    <p className='text-body-2 text-color-medium-gray-important mb-5px'>
+                        Mito guesses the above parameters correct above 90% of the time. Try importing Mito's detected configuration. <span className='text-underline' onClick={resetParams}>Reset parameters. </span> 
+                    </p>
+                }
+                <TextButton
+                    variant='dark'
+                    width='block'
+                    onClick={() => {
+                        edit();
+                    }}
+                    autoFocus
+                >
+                    {getButtonMessage(props.fileForImportWizard, loading)}
+                </TextButton>
+                {editApplied && !loading &&
+                    <p className='text-subtext-1'>
+                        {getSuccessMessage(props.fileForImportWizard)} 
+                    </p>
+                } 
+                {!editApplied && 
+                    <Spacer px={16}/>
+                }
+            </DefaultTaskpaneFooter>
+        </DefaultTaskpane>
+    )
+}
+
+export default CSVImport;

--- a/mitosheet/src/components/taskpanes/Import/XLSXImport.tsx
+++ b/mitosheet/src/components/taskpanes/Import/XLSXImport.tsx
@@ -11,7 +11,7 @@ import Select from '../../elements/Select';
 import TextButton from '../../elements/TextButton';
 import DropdownItem from '../../elements/DropdownItem';
 import { AnalysisData, StepType, UIState } from '../../../types';
-import { ImportTaskpaneState } from './ImportTaskpane';
+import { FileElement, ImportTaskpaneState } from './ImportTaskpane';
 import useSendEditOnClick from '../../../hooks/useSendEditOnClick';
 import { toggleInArray } from '../../../utils/arrays';
 import DefaultTaskpane from '../DefaultTaskpane/DefaultTaskpane';
@@ -28,8 +28,8 @@ interface XLSXImportProps {
     importState: ImportTaskpaneState;
     setImportState: React.Dispatch<React.SetStateAction<ImportTaskpaneState>>;
     setUIState: React.Dispatch<React.SetStateAction<UIState>>;
-    fileForImportWizard: string | undefined,
-    setFileForImportWizard: React.Dispatch<React.SetStateAction<string | undefined>>;
+    fileForImportWizard: FileElement | undefined,
+    setFileForImportWizard: React.Dispatch<React.SetStateAction<FileElement | undefined>>;
 }
 
 export interface ExcelFileMetadata {
@@ -117,7 +117,7 @@ function XLSXImport(props: XLSXImportProps): JSX.Element {
     return (
         <DefaultTaskpane>
             <DefaultTaskpaneHeader
-                header={`Import ${props.fileForImportWizard}`}
+                header={`Import ${props.fileForImportWizard?.name}`}
                 setUIState={props.setUIState}
                 backCallback={() => props.setFileForImportWizard(undefined)}
             />

--- a/mitosheet/src/components/taskpanes/Import/importUtils.tsx
+++ b/mitosheet/src/components/taskpanes/Import/importUtils.tsx
@@ -101,6 +101,10 @@ export const getImportButtonStatus = (selectedElement: FileElement | undefined, 
     };
 }
 
+export const isExcelFile = (element: FileElement | undefined): boolean => {
+    return element !== undefined && !element?.isDirectory && element?.name.toLowerCase().endsWith('.xlsx');
+}
+
 export const getElementsToDisplay = (importState: ImportTaskpaneState): FileElement[] => {
 
     const allElements: FileElement[] = [...importState.pathContents.elements];

--- a/mitosheet/src/jupyter/api.tsx
+++ b/mitosheet/src/jupyter/api.tsx
@@ -4,6 +4,7 @@ import { ControlPanelTab } from "../components/taskpanes/ControlPanel/ControlPan
 import { SortDirection } from "../components/taskpanes/ControlPanel/FilterAndSortTab/SortCard";
 import { GraphObject } from "../components/taskpanes/ControlPanel/SummaryStatsTab/ColumnSummaryGraph";
 import { UniqueValueCount, UniqueValueSortType } from "../components/taskpanes/ControlPanel/ValuesTab/ValuesTab";
+import { CSVFileMetadata } from "../components/taskpanes/Import/CSVImport";
 import { FileElement } from "../components/taskpanes/Import/ImportTaskpane";
 import { ExcelFileMetadata } from "../components/taskpanes/Import/XLSXImport";
 import { valuesArrayToRecord } from "../components/taskpanes/PivotTable/pivotUtils";
@@ -446,6 +447,27 @@ export default class MitoAPI {
 
         if (excelFileMetadataString !== undefined && excelFileMetadataString !== '') {
             return JSON.parse(excelFileMetadataString);
+        }
+        return undefined;
+    }
+
+    /*
+        Gets metadata about an Excel file
+    */
+    async getCSVFileMetadata(
+        fileNames: string[]
+    ): Promise<CSVFileMetadata | undefined> {
+
+        const csvFileMetadataString = await this.send<string>({
+            'event': 'api_call',
+            'type': 'get_csv_file_metadata',
+            'params': {
+                'file_names': fileNames
+            },
+        }, {})
+
+        if (csvFileMetadataString !== undefined && csvFileMetadataString !== '') {
+            return JSON.parse(csvFileMetadataString);
         }
         return undefined;
     }
@@ -1069,14 +1091,11 @@ export default class MitoAPI {
     */
     async editSimpleImport(
         fileNames: string[],
-        stepID?: string,
-    ): Promise<string> {
+    ): Promise<MitoError | undefined> {
 
-        if (stepID === undefined || stepID == '') {
-            stepID = getRandomId();
-        }
+        const stepID = getRandomId();
 
-        await this.send({
+        const result: MitoError | undefined = await this.send({
             'event': 'edit_event',
             'type': 'simple_import_edit',
             'step_id': stepID,
@@ -1085,7 +1104,7 @@ export default class MitoAPI {
             }
         }, {})
 
-        return stepID;
+        return result;
     }
 
     /*


### PR DESCRIPTION
# Description

Implements: https://www.notion.so/trymito/Import-Improvements-bb65727e1ba1479ea91ed176077fe589

# Testing

Add something that causes an error to the path where we try to guess the delimeter, to see if it automatically opens the config.

# Documentation

We should update our import documentation!