### PR TITLE
mitosheet: add axis type transformations to graph

### DIFF
--- a/mitosheet/mitosheet/step_performers/graph_steps/graph.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/graph.py
@@ -46,13 +46,15 @@ class GraphStepPerformer(StepPerformer):
             xaxis: {
                 title: string | None,
                 visible: boolean,
+                type: string | None,
                 rangeslider: {
                     visible: boolean
                 }
             },
             yaxis: {
                 title: string | None,
-                visible: boolean
+                visible: boolean,
+                type: string | None
             },
             showlegend: boolean
         },

--- a/mitosheet/mitosheet/step_performers/graph_steps/plotly_express_graphs.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/plotly_express_graphs.py
@@ -232,6 +232,9 @@ def get_graph_styling_param_dict(graph_type: str, column_headers: List[ColumnHea
         # Plotly makes us explicitly handle setting the xaxis title and yaxis title to None
         all_params['xaxis']['title'] = None
 
+    if 'type' in graph_styling_params['xaxis']:
+        all_params['xaxis']['type'] = graph_styling_params['xaxis']['type']
+
     # Create the range slider param
     if graph_styling_params['xaxis']['rangeslider']['visible']:
         all_params['xaxis']['rangeslider'] = dict(visible=True, thickness=0.05)
@@ -252,6 +255,9 @@ def get_graph_styling_param_dict(graph_type: str, column_headers: List[ColumnHea
     else: 
         # Plotly makes us explicitly handle setting the xaxis_title and yaxis_title to None
         all_params['yaxis']['title'] = None
+
+    if 'type' in graph_styling_params['yaxis']:
+        all_params['yaxis']['type'] = graph_styling_params['yaxis']['type']
 
     # Create the barmode param
     barmode = get_barmode(graph_type)

--- a/mitosheet/mitosheet/tests/step_performers/graph_steps/test_graph.py
+++ b/mitosheet/mitosheet/tests/step_performers/graph_steps/test_graph.py
@@ -66,9 +66,11 @@ def test_all_styling_options():
     title_visible=False
     xaxis_title="Custom X Axis Title"
     xaxis_visible=False
+    xaxis_type='category'
     xaxis_rangeslider_visible=False
     yaxis_title="Custom Y Axis Title"
     yaxis_visible=False
+    yaxis_type='linear'
     showlegend=False    
     paper_bgcolor='#FFCCDD'    
     plot_bgcolor='#FFCCEE'    
@@ -85,8 +87,10 @@ def test_all_styling_options():
         title_visible=title_visible,
         xaxis_title=xaxis_title,
         xaxis_visible=xaxis_visible,
+        xaxis_type=xaxis_type,
         xaxis_rangeslider_visible=xaxis_rangeslider_visible,
         yaxis_title=yaxis_title,
+        yaxis_type=yaxis_type,
         yaxis_visible=yaxis_visible,
         showlegend=showlegend,
         paper_bgcolor=paper_bgcolor,
@@ -112,10 +116,12 @@ def test_all_styling_options():
     assert graph_styling_params['xaxis']['title'] == xaxis_title
     assert graph_styling_params['xaxis']['visible'] == xaxis_visible
     assert graph_styling_params['xaxis']['title_font_color'] == xaxis_title_font_color
+    assert graph_styling_params['xaxis']['type'] == xaxis_type
     assert graph_styling_params['xaxis']['rangeslider']['visible'] == xaxis_rangeslider_visible
     assert graph_styling_params['yaxis']['title'] == yaxis_title
     assert graph_styling_params['yaxis']['visible'] == yaxis_visible
     assert graph_styling_params['yaxis']['title_font_color'] == yaxis_title_font_color
+    assert graph_styling_params['yaxis']['type'] == yaxis_type
     assert graph_styling_params['showlegend'] == showlegend
     assert graph_styling_params['paper_bgcolor'] == paper_bgcolor
     assert graph_styling_params['plot_bgcolor'] == plot_bgcolor

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -937,10 +937,12 @@ class MitoWidgetTestWrapper:
         xaxis_title: Optional[str]=None,
         xaxis_visible: bool=True,
         xaxis_title_font_color: str=DO_NOT_CHANGE_TITLE_FONT_COLOR_DEFAULT,
+        xaxis_type: Optional[str]=None,
         xaxis_rangeslider_visible: bool=True,
         yaxis_title: Optional[str]=None,
         yaxis_visible: bool=True,
         yaxis_title_font_color: str=DO_NOT_CHANGE_TITLE_FONT_COLOR_DEFAULT,
+        yaxis_type: Optional[str]=None,
         showlegend: bool=True,
         step_id: str=None,
         paper_bgcolor: str=DO_NOT_CHANGE_PAPER_BGCOLOR_DEFAULT,
@@ -974,6 +976,7 @@ class MitoWidgetTestWrapper:
                             'title': xaxis_title,
                             'visible': xaxis_visible,
                             'title_font_color': xaxis_title_font_color,
+                            'type': xaxis_type,
                             'rangeslider': {
                                 'visible': xaxis_rangeslider_visible
                             }
@@ -982,6 +985,7 @@ class MitoWidgetTestWrapper:
                             'title': yaxis_title,
                             'visible': yaxis_visible,
                             'title_font_color': yaxis_title_font_color,
+                            'type': yaxis_type
                         },
                         'showlegend': showlegend,
                         'paper_bgcolor': paper_bgcolor,

--- a/mitosheet/src/components/taskpanes/Graph/GraphStyleTab.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/GraphStyleTab.tsx
@@ -11,10 +11,12 @@ import Col from '../../spacing/Col';
 import Row from '../../spacing/Row';
 
 export enum AxisType {
+    DEFAULT = 'default',
     LINEAR = 'linear',
     LOG = 'log',
     CATEGORY = 'category',
     DATE = 'date',
+    MULTICATEGORY = 'multicategory',
 }
 /* 
     Contains all of the options for styling graphs,
@@ -197,7 +199,7 @@ function GraphStyleTab(props: {
                 <Row justify='space-between' align='center'>
                     <Col>
                         <p>
-                            Type
+                            Transform
                         </p>
                     </Col>
                     <Select
@@ -223,7 +225,7 @@ function GraphStyleTab(props: {
                         dropdownWidth='medium'
                     >
                         <DropdownItem
-                            title={'default'}
+                            title={AxisType.DEFAULT}
                         />
                         <DropdownItem
                             title={AxisType.LINEAR}
@@ -236,6 +238,9 @@ function GraphStyleTab(props: {
                         />
                         <DropdownItem
                             title={AxisType.CATEGORY}
+                        />
+                        <DropdownItem
+                            title={AxisType.MULTICATEGORY}
                         />
                     </Select>
                 </Row>
@@ -351,12 +356,12 @@ function GraphStyleTab(props: {
                 <Row justify='space-between' align='center'>
                     <Col>
                         <p>
-                            Type
+                            Transform
                         </p>
                     </Col>
                     <Select
                         value={props.graphParams.graphStyling.yaxis.type || 'default'}
-                        onChange={(yAxisType: string | undefined) => {
+                        onChange={(yAxisType: string) => {
                             const newYAxisType = yAxisType !== 'default' ? yAxisType : undefined
                             props.setGraphParams(prevGraphParams => {
                                 const graphParamsCopy: GraphParams = JSON.parse(JSON.stringify(prevGraphParams)); 
@@ -377,7 +382,7 @@ function GraphStyleTab(props: {
                         dropdownWidth='medium'
                     >
                         <DropdownItem
-                            title={'default'}
+                            title={AxisType.DEFAULT}
                         />
                         <DropdownItem
                             title={AxisType.LINEAR}
@@ -390,6 +395,9 @@ function GraphStyleTab(props: {
                         />
                         <DropdownItem
                             title={AxisType.CATEGORY}
+                        />
+                        <DropdownItem
+                            title={AxisType.MULTICATEGORY}
                         />
                     </Select>
                 </Row>

--- a/mitosheet/src/components/taskpanes/Graph/GraphStyleTab.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/GraphStyleTab.tsx
@@ -3,11 +3,19 @@
 import React from 'react';
 import LabelAndColor from '../../../pro/graph/LabelAndColor';
 import { GraphParams, UserProfile } from '../../../types';
+import DropdownItem from '../../elements/DropdownItem';
 import Input from '../../elements/Input';
+import Select from '../../elements/Select';
 import Toggle from '../../elements/Toggle';
 import Col from '../../spacing/Col';
 import Row from '../../spacing/Row';
 
+export enum AxisType {
+    LINEAR = 'linear',
+    LOG = 'log',
+    CATEGORY = 'category',
+    DATE = 'date',
+}
 /* 
     Contains all of the options for styling graphs,
     like setting the title and axis labels
@@ -189,6 +197,51 @@ function GraphStyleTab(props: {
                 <Row justify='space-between' align='center'>
                     <Col>
                         <p>
+                            Type
+                        </p>
+                    </Col>
+                    <Select
+                        value={props.graphParams.graphStyling.xaxis.type || 'default'}
+                        onChange={(xAxisType: string) => {
+                            const newXAxisType = xAxisType !== 'default' ? xAxisType : undefined
+                            props.setGraphParams(prevGraphParams => {
+                                const graphParamsCopy: GraphParams = JSON.parse(JSON.stringify(prevGraphParams)); 
+                                return {
+                                    ...graphParamsCopy,
+                                    graphStyling: {
+                                        ...graphParamsCopy.graphStyling,
+                                        xaxis: {
+                                            ...graphParamsCopy.graphStyling.xaxis,
+                                            type: newXAxisType
+                                        } 
+                                    } 
+                                }
+                            })
+                            props.setGraphUpdatedNumber(old => old + 1)
+                        }}
+                        width='small'
+                        dropdownWidth='medium'
+                    >
+                        <DropdownItem
+                            title={'default'}
+                        />
+                        <DropdownItem
+                            title={AxisType.LINEAR}
+                        />
+                        <DropdownItem
+                            title={AxisType.LOG}
+                        />
+                        <DropdownItem
+                            title={AxisType.DATE}
+                        />
+                        <DropdownItem
+                            title={AxisType.CATEGORY}
+                        />
+                    </Select>
+                </Row>
+                <Row justify='space-between' align='center'>
+                    <Col>
+                        <p>
                             Display range slider
                         </p>
                     </Col>
@@ -295,6 +348,51 @@ function GraphStyleTab(props: {
                         }}
                     />
                 }
+                <Row justify='space-between' align='center'>
+                    <Col>
+                        <p>
+                            Type
+                        </p>
+                    </Col>
+                    <Select
+                        value={props.graphParams.graphStyling.yaxis.type || 'default'}
+                        onChange={(yAxisType: string | undefined) => {
+                            const newYAxisType = yAxisType !== 'default' ? yAxisType : undefined
+                            props.setGraphParams(prevGraphParams => {
+                                const graphParamsCopy: GraphParams = JSON.parse(JSON.stringify(prevGraphParams)); 
+                                return {
+                                    ...graphParamsCopy,
+                                    graphStyling: {
+                                        ...graphParamsCopy.graphStyling,
+                                        yaxis: {
+                                            ...graphParamsCopy.graphStyling.yaxis,
+                                            type: newYAxisType
+                                        } 
+                                    } 
+                                }
+                            })
+                            props.setGraphUpdatedNumber(old => old + 1)
+                        }}
+                        width='small'
+                        dropdownWidth='medium'
+                    >
+                        <DropdownItem
+                            title={'default'}
+                        />
+                        <DropdownItem
+                            title={AxisType.LINEAR}
+                        />
+                        <DropdownItem
+                            title={AxisType.LOG}
+                        />
+                        <DropdownItem
+                            title={AxisType.DATE}
+                        />
+                        <DropdownItem
+                            title={AxisType.CATEGORY}
+                        />
+                    </Select>
+                </Row>
             </div>
             <div>
                 <div className='text-header-2'>

--- a/mitosheet/src/components/taskpanes/Graph/GraphStyleTab.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/GraphStyleTab.tsx
@@ -16,7 +16,6 @@ export enum AxisType {
     LOG = 'log',
     CATEGORY = 'category',
     DATE = 'date',
-    MULTICATEGORY = 'multicategory',
 }
 /* 
     Contains all of the options for styling graphs,
@@ -239,9 +238,6 @@ function GraphStyleTab(props: {
                         <DropdownItem
                             title={AxisType.CATEGORY}
                         />
-                        <DropdownItem
-                            title={AxisType.MULTICATEGORY}
-                        />
                     </Select>
                 </Row>
                 <Row justify='space-between' align='center'>
@@ -395,9 +391,6 @@ function GraphStyleTab(props: {
                         />
                         <DropdownItem
                             title={AxisType.CATEGORY}
-                        />
-                        <DropdownItem
-                            title={AxisType.MULTICATEGORY}
                         />
                     </Select>
                 </Row>

--- a/mitosheet/src/components/taskpanes/Graph/GraphStyleTab.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/GraphStyleTab.tsx
@@ -204,7 +204,7 @@ function GraphStyleTab(props: {
                     <Select
                         value={props.graphParams.graphStyling.xaxis.type || 'default'}
                         onChange={(xAxisType: string) => {
-                            const newXAxisType = xAxisType !== 'default' ? xAxisType : undefined
+                            const newXAxisType = xAxisType !== AxisType.DEFAULT ? xAxisType : undefined
                             props.setGraphParams(prevGraphParams => {
                                 const graphParamsCopy: GraphParams = JSON.parse(JSON.stringify(prevGraphParams)); 
                                 return {
@@ -358,7 +358,7 @@ function GraphStyleTab(props: {
                     <Select
                         value={props.graphParams.graphStyling.yaxis.type || 'default'}
                         onChange={(yAxisType: string) => {
-                            const newYAxisType = yAxisType !== 'default' ? yAxisType : undefined
+                            const newYAxisType = yAxisType !== AxisType.DEFAULT ? yAxisType : undefined
                             props.setGraphParams(prevGraphParams => {
                                 const graphParamsCopy: GraphParams = JSON.parse(JSON.stringify(prevGraphParams)); 
                                 return {

--- a/mitosheet/src/components/taskpanes/Graph/graphUtils.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/graphUtils.tsx
@@ -38,6 +38,7 @@ export const getDefaultGraphParams = (sheetDataArray: SheetData[], sheetIndex: n
                 title: undefined,
                 visible: true,
                 title_font_color: DO_NOT_CHANGE_TITLE_FONT_COLOR_DEFAULT,
+                type: undefined,
                 rangeslider: {
                     visible: true,
                 }
@@ -45,7 +46,8 @@ export const getDefaultGraphParams = (sheetDataArray: SheetData[], sheetIndex: n
             yaxis: {
                 title: undefined,
                 visible: true,
-                title_font_color: DO_NOT_CHANGE_TITLE_FONT_COLOR_DEFAULT
+                title_font_color: DO_NOT_CHANGE_TITLE_FONT_COLOR_DEFAULT,
+                type: undefined,
             },
             showlegend: true,
             paper_bgcolor: DO_NOT_CHANGE_PAPER_BGCOLOR_DEFAULT,

--- a/mitosheet/src/types.tsx
+++ b/mitosheet/src/types.tsx
@@ -242,6 +242,7 @@ export type GraphStylingParams = {
         title: string | undefined; // when undefined, we use Ploty's default title
         visible: boolean;
         title_font_color: string, // defaults to #2f3e5d
+        type: string | undefined // when undefined, we use Plotly's default
         rangeslider: {
             visible: boolean,
         }
@@ -250,6 +251,7 @@ export type GraphStylingParams = {
         title: string | undefined, // when undefined, we use Ploty's default title
         visible: boolean
         title_font_color: string, // defaults to #2f3e5d
+        type: string | undefined // when undefined, we use Plotly's default
     },
     showlegend: boolean,
     plot_bgcolor: string // The inner part of the plot with data background. Defaults to a blue-ish shade


### PR DESCRIPTION
# Description

Adds the ability to set [Plotly's axis type ](https://plotly.com/python/axes/) following this [specification](https://www.notion.so/trymito/Log-graph-transformations-d5b4b08a3cf74c25a25c37b9b828b860) 

# Testing

Create some graphs. 

# Documentation

See proposal for doc changes [here](https://app.gitbook.com/o/-MS4px_3crWEYYdbNPU8/s/-MP_U5ZCmiamDOXEOOTC/~/changes/n37dfGIxRPBQd5cYc79g/how-to/graphing). Merge when releasing. 