### PR TITLE
mitosheet: make copy and paste work in non-secure contexts

### DIFF
--- a/mitosheet/src/hooks/useCopyToClipboard.tsx
+++ b/mitosheet/src/hooks/useCopyToClipboard.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { writeTextToClipboard } from "../utils/copy";
 
 /* 
     A hook to allow you to copy code to the users clipboard, 
@@ -14,7 +15,7 @@ export const useCopyToClipboard = (text: string | undefined, resetTimeout = 2500
         if (text == undefined) {
             return
         }
-        navigator.clipboard.writeText(text).then(
+        writeTextToClipboard(text).then(
             () => {setCopyStatus(true)},
             () => {setCopyStatus(false)}
         )

--- a/mitosheet/src/utils/actions.tsx
+++ b/mitosheet/src/utils/actions.tsx
@@ -12,7 +12,7 @@ import { FunctionDocumentationObject, functionDocumentationObjects } from "../da
 import { Action, DFSource, EditorState, GridState, SheetData, UIState, ActionEnum } from "../types"
 import { getColumnHeaderParts, getDisplayColumnHeader, getNewColumnHeader } from "./columnHeaders";
 import { FORMAT_DISABLED_MESSAGE } from "./formatColumns";
-import { getCopyStringForClipboard } from "./copy";
+import { writeTextToClipboard, getCopyStringForClipboard } from "./copy";
 
 
 export const createActions = (
@@ -180,7 +180,7 @@ export const createActions = (
 
                 const [stringToCopy, copiedSelections] = copyStringAndSelections;
                 
-                void navigator.clipboard.writeText(stringToCopy);
+                void writeTextToClipboard(stringToCopy);
 
                 setGridState(prevGridState => {
                     return {

--- a/mitosheet/src/utils/copy.tsx
+++ b/mitosheet/src/utils/copy.tsx
@@ -148,7 +148,7 @@ export const writeTextToClipboard = (text: string): Promise<void> => {
         return navigator.clipboard.writeText(text);
     } else {
         // Text area method
-        let textArea = document.createElement("textarea");
+        const textArea = document.createElement("textarea");
         textArea.value = text;
         // make the textarea not visible
         textArea.style.position = "absolute"; 

--- a/mitosheet/src/utils/copy.tsx
+++ b/mitosheet/src/utils/copy.tsx
@@ -133,3 +133,25 @@ export const getCopyStringForClipboard = (sheetData: SheetData | undefined, sele
 
     return [getCopyStringForSelections(sheetData, selectionsToCopy), selectionsToCopy];
 }
+
+export const writeTextToClipboard = (text: string): Promise<void> => {
+    // navigator clipboard api needs a secure context (https)
+    if (navigator.clipboard && window.isSecureContext) {
+        // navigator clipboard api method'
+        return navigator.clipboard.writeText(text);
+    } else {
+        // text area method
+        let textArea = document.createElement("textarea");
+        textArea.value = text;
+        // make the textarea not visible
+        textArea.style.position = "absolute"; 
+        textArea.style.opacity = "0";
+        document.body.appendChild(textArea);
+        textArea.select();
+        return new Promise((res, rej) => {
+            // here the magic happens
+            document.execCommand('copy') ? res() : rej();
+            textArea.remove();
+        });
+    }
+}

--- a/mitosheet/src/utils/copy.tsx
+++ b/mitosheet/src/utils/copy.tsx
@@ -134,24 +134,43 @@ export const getCopyStringForClipboard = (sheetData: SheetData | undefined, sele
     return [getCopyStringForSelections(sheetData, selectionsToCopy), selectionsToCopy];
 }
 
+/**
+ * A wrapper that makes sure copying to the clipboard works in all contexts, including
+ * insecure contexts where the navigator.clipboard is not defined.
+ * Adapted from: https://stackoverflow.com/questions/51805395/navigator-clipboard-is-undefined
+ * 
+ * @param text - the text to copy to the clipboard
+ * @returns a promise that resolves or rejects depending on success
+ */
 export const writeTextToClipboard = (text: string): Promise<void> => {
-    // navigator clipboard api needs a secure context (https)
     if (navigator.clipboard && window.isSecureContext) {
-        // navigator clipboard api method'
+        // Navigator clipboard api needs a secure context (https)
         return navigator.clipboard.writeText(text);
     } else {
-        // text area method
+        // Text area method
         let textArea = document.createElement("textarea");
         textArea.value = text;
         // make the textarea not visible
         textArea.style.position = "absolute"; 
         textArea.style.opacity = "0";
         document.body.appendChild(textArea);
+        
+        // Save the previous selected element
+        const currentFocusedElement = document.activeElement;
+
+        // Select the text area
         textArea.select();
         return new Promise((res, rej) => {
-            // here the magic happens
+            // Actually do the copy
             document.execCommand('copy') ? res() : rej();
             textArea.remove();
+
+            // Try to refocus on the element, if it is focusable
+            try {
+                (currentFocusedElement as any)?.focus();
+            } catch (e) {
+                console.log("Error refocusing on element", e);
+            }
         });
     }
 }


### PR DESCRIPTION
# Description

If a user was:
1. One http
2. On a remote serve (aka not local host)

This is considered a non-secure context, and the navigator.clipboard api is disabled. In this case, we need to copy to the clipboard differently. 

# Testing

Add a `&& false` to the first condition. Make sure it still copies! Not sure how to test it better than this...

# Documentation

N/A.