### PR TITLE
Installer communication

### DIFF
--- a/mitoinstaller/mitoinstaller/commands.py
+++ b/mitoinstaller/mitoinstaller/commands.py
@@ -3,8 +3,10 @@ Contains useful commands for interacting
 with the command line directly
 """
 
+import os
 import sys
 import traceback
+import analytics
 from subprocess import CompletedProcess
 from typing import List, Tuple, Union
 
@@ -217,13 +219,16 @@ def get_jupyterlab_metadata() -> Tuple[Union[str, None], Union[List[str], None]]
 
 def exit_after_error() -> None:
 
+    # Flush the log messages
+    analytics.flush()
+
     # Print the full error so that the user can see it
-    print(traceback.format_exc())
+    print(traceback.format_exc(), flush=True)
 
     # Then, print a final error message
     full_error = '\n\nSorry, looks like we hit a problem.' + \
         '\nWe\'re happy to help you fix it ASAP. Just hop on our discord, and and post in the install-help channel. We\'ll get you sorted in a few minutes:\n\n\t https://discord.gg/AAeYm6YV7B\n'
 
-    print(colored(full_error, 'red'))
-    # TODO: we need to make this work from within a thread!
-    exit(1)
+    print(colored(full_error, 'red'), flush=True)
+    # We have to use this function as this may run within a thread
+    os._exit(1)

--- a/mitoinstaller/mitoinstaller/commands.py
+++ b/mitoinstaller/mitoinstaller/commands.py
@@ -225,4 +225,5 @@ def exit_after_error() -> None:
         '\nWe\'re happy to help you fix it ASAP. Just hop on our discord, and and post in the install-help channel. We\'ll get you sorted in a few minutes:\n\n\t https://discord.gg/AAeYm6YV7B\n'
 
     print(colored(full_error, 'red'))
+    # TODO: we need to make this work from within a thread!
     exit(1)

--- a/mitoinstaller/mitoinstaller/experiments/experiment_utils.py
+++ b/mitoinstaller/mitoinstaller/experiments/experiment_utils.py
@@ -16,8 +16,7 @@ def get_new_experiment() -> Optional[Dict[str, str]]:
 def is_variant_a() -> bool:
     from mitoinstaller.user_install import get_current_experiment
     current_experiment = get_current_experiment()
-    print("Current", current_experiment)
-    return current_experiment is None or ['variant'] == 'A'
+    return current_experiment is None or current_experiment['variant'] == 'A'
 
 def is_variant_b() -> bool:
     return not is_variant_a()

--- a/mitoinstaller/mitoinstaller/experiments/experiment_utils.py
+++ b/mitoinstaller/mitoinstaller/experiments/experiment_utils.py
@@ -1,0 +1,23 @@
+import random
+from typing import Dict, Optional
+
+
+def get_random_variant() -> str:
+    """Returns "A" or "B" with 50% probability"""
+    return "A" if random.random() < 0.5 else "B"
+
+def get_new_experiment() -> Optional[Dict[str, str]]:
+    # NOTE: this needs to match the mitosheet package!
+    return {
+        'experiment_id': 'title_name',
+        'variant': get_random_variant(),
+    }
+
+def is_variant_a() -> bool:
+    from mitoinstaller.user_install import get_current_experiment
+    current_experiment = get_current_experiment()
+    print("Current", current_experiment)
+    return current_experiment is None or ['variant'] == 'A'
+
+def is_variant_b() -> bool:
+    return not is_variant_a()

--- a/mitoinstaller/mitoinstaller/experiments/experiment_utils.py
+++ b/mitoinstaller/mitoinstaller/experiments/experiment_utils.py
@@ -9,7 +9,7 @@ def get_random_variant() -> str:
 def get_new_experiment() -> Optional[Dict[str, str]]:
     # NOTE: this needs to match the mitosheet package!
     return {
-        'experiment_id': 'title_name',
+        'experiment_id': 'installer_communication_and_time_to_value',
         'variant': get_random_variant(),
     }
 

--- a/mitoinstaller/mitoinstaller/install.py
+++ b/mitoinstaller/mitoinstaller/install.py
@@ -1,5 +1,6 @@
 from mitoinstaller.installer_steps import (ALL_INSTALLER_STEPS,
                                            run_installer_steps)
+from mitoinstaller.installer_steps.initial_installer_steps import initial_install_step_create_user
 
 
 def do_install() -> None:
@@ -10,5 +11,10 @@ def do_install() -> None:
     identical. As such, we reuse this function to upgrade, just with different
     error and logging messages.
     """
+    # We need to create the user json file before we can run anything,
+    # as this creates the experiment variant we use throughout the rest of the
+    # installer.
+    initial_install_step_create_user()
+
     # Run the installer steps
     run_installer_steps(ALL_INSTALLER_STEPS)

--- a/mitoinstaller/mitoinstaller/install.py
+++ b/mitoinstaller/mitoinstaller/install.py
@@ -1,6 +1,4 @@
-from mitoinstaller.installer_steps import (FINAL_INSTALLER_STEPS,
-                                           INITIAL_INSTALLER_STEPS,
-                                           MITOSHEET_INSTALLER_STEPS,
+from mitoinstaller.installer_steps import (ALL_INSTALLER_STEPS,
                                            run_installer_steps)
 
 
@@ -12,13 +10,5 @@ def do_install() -> None:
     identical. As such, we reuse this function to upgrade, just with different
     error and logging messages.
     """
-    print("Starting install...")
-
-    # Run the initiall installer steps
-    run_installer_steps(INITIAL_INSTALLER_STEPS)
-
-    # Then, we try to install mitosheet package
-    run_installer_steps(MITOSHEET_INSTALLER_STEPS)
-
-    # Then, we try and launch JLab
-    run_installer_steps(FINAL_INSTALLER_STEPS)
+    # Run the installer steps
+    run_installer_steps(ALL_INSTALLER_STEPS)

--- a/mitoinstaller/mitoinstaller/installer_steps/__init__.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/__init__.py
@@ -4,3 +4,6 @@ from mitoinstaller.installer_steps.installer_step_utils import run_installer_ste
 from mitoinstaller.installer_steps.initial_installer_steps import INITIAL_INSTALLER_STEPS
 from mitoinstaller.installer_steps.mitosheet_installer_steps import MITOSHEET_INSTALLER_STEPS
 from mitoinstaller.installer_steps.final_installer_steps import FINAL_INSTALLER_STEPS
+
+
+ALL_INSTALLER_STEPS = INITIAL_INSTALLER_STEPS + MITOSHEET_INSTALLER_STEPS + FINAL_INSTALLER_STEPS

--- a/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
@@ -7,9 +7,10 @@ import time
 
 import analytics
 from mitoinstaller.create_startup_file import create_startup_file
+from mitoinstaller.experiments.experiment_utils import is_variant_a
 from mitoinstaller.installer_steps.installer_step import InstallerStep
 from mitoinstaller.jupyter_utils import get_prefered_jupyter_env_variable
-from mitoinstaller.print_utils import clear_terminal
+from mitoinstaller.print_utils import clear_terminal, print_current_installer_message
 from mitoinstaller.starter_notebook import (MITO_STARTER_NOTEBOOK_PATH,
                                             try_create_starter_notebook)
 from mitoinstaller.user_install import is_running_test
@@ -31,8 +32,10 @@ def replace_process_with_jupyter():
     # Flush analytics before we terminate the process, as it's our last chance
     analytics.flush()
 
-    # Clear the terminal, as we're done installing
-    clear_terminal()
+    # If we're in variant A, we let the user know that we're done running all the installer steps
+    if is_variant_a():
+        from mitoinstaller.installer_steps import ALL_INSTALLER_STEPS
+        print_current_installer_message(ALL_INSTALLER_STEPS, len(ALL_INSTALLER_STEPS), time.perf_counter())
 
     os.execl(sys.executable, 'python', '-m', 'jupyter', prefered_jupyter, MITO_STARTER_NOTEBOOK_PATH)
 

--- a/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
@@ -9,6 +9,7 @@ import analytics
 from mitoinstaller.create_startup_file import create_startup_file
 from mitoinstaller.installer_steps.installer_step import InstallerStep
 from mitoinstaller.jupyter_utils import get_prefered_jupyter_env_variable
+from mitoinstaller.print_utils import clear_terminal
 from mitoinstaller.starter_notebook import (MITO_STARTER_NOTEBOOK_PATH,
                                             try_create_starter_notebook)
 from mitoinstaller.user_install import is_running_test
@@ -29,6 +30,9 @@ def replace_process_with_jupyter():
 
     # Flush analytics before we terminate the process, as it's our last chance
     analytics.flush()
+
+    # Clear the terminal, as we're done installing
+    clear_terminal()
 
     os.execl(sys.executable, 'python', '-m', 'jupyter', prefered_jupyter, MITO_STARTER_NOTEBOOK_PATH)
 

--- a/mitoinstaller/mitoinstaller/installer_steps/initial_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/initial_installer_steps.py
@@ -13,8 +13,7 @@ from mitoinstaller.user_install import (USER_JSON_PATH, go_pro,
 
 def initial_install_step_create_user() -> None:
 
-    if not os.path.exists(USER_JSON_PATH):
-        try_create_user_json_file(is_pro=('--pro' in sys.argv))
+    try_create_user_json_file(is_pro=('--pro' in sys.argv))
 
     if not ('--pro' in sys.argv):
         # Only try and log if we're not pro

--- a/mitoinstaller/mitoinstaller/installer_steps/initial_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/initial_installer_steps.py
@@ -11,7 +11,7 @@ from mitoinstaller.user_install import (USER_JSON_PATH, go_pro,
                                         try_create_user_json_file)
 
 
-def initial_install_step_create_user():
+def initial_install_step_create_user() -> None:
 
     if not os.path.exists(USER_JSON_PATH):
         try_create_user_json_file(is_pro=('--pro' in sys.argv))

--- a/mitoinstaller/mitoinstaller/installer_steps/initial_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/initial_installer_steps.py
@@ -40,10 +40,6 @@ def initial_install_step_add_env_for_which_jupyter():
 
 INITIAL_INSTALLER_STEPS = [
     InstallerStep(
-        'Create mito user',
-        initial_install_step_create_user
-    ),
-    InstallerStep(
         'Upgrade mitoinstaller',
         upgrade_mito_installer,
         optional=True

--- a/mitoinstaller/mitoinstaller/installer_steps/installer_step.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/installer_step.py
@@ -52,7 +52,6 @@ class InstallerStep:
             if not self.optional:
                 # Do one major log if we fail, so that we can easily tell what happened
                 log_error('install_failed', {'installer_step_name': self.installer_step_name})
-                # I think we should prompt users to do this, defaulting to Yes!
                 exit_after_error()
 
 

--- a/mitoinstaller/mitoinstaller/installer_steps/installer_step.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/installer_step.py
@@ -57,7 +57,6 @@ class InstallerStep:
 
 
     def log_success(self, start_time: float) -> None:
-        print("Logging success", flush=True)
         processing_time = perf_counter() - start_time
         log(self.event_name + '_success', {
             'processing_time': round(processing_time, 1),

--- a/mitoinstaller/mitoinstaller/installer_steps/installer_step.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/installer_step.py
@@ -22,12 +22,14 @@ class InstallerStep:
         installer_step_name: str, 
         execution_function: Callable,
         optional: bool=False,
-        should_log_success: bool=False
+        should_log_success: bool=False,
+        no_print_in_main_loop: bool=False, # Set to True if you don't want to print this step in the main loop
     ):
         self.installer_step_name = installer_step_name
         self.execution_function = execution_function
         self.optional = optional
         self.should_log_success = should_log_success
+        self.no_print_in_main_loop = no_print_in_main_loop
         
     @property
     def event_name(self):

--- a/mitoinstaller/mitoinstaller/installer_steps/installer_step.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/installer_step.py
@@ -57,6 +57,7 @@ class InstallerStep:
 
 
     def log_success(self, start_time: float) -> None:
+        print("Logging success", flush=True)
         processing_time = perf_counter() - start_time
         log(self.event_name + '_success', {
             'processing_time': round(processing_time, 1),

--- a/mitoinstaller/mitoinstaller/installer_steps/installer_step_utils.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/installer_step_utils.py
@@ -52,27 +52,30 @@ def run_installer_steps(installer_steps: List[InstallerStep]) -> None:
     if not is_variant_a():
         print('Starting install...')
 
-    for index, installer_step in enumerate(installer_steps):
+    try:
+        for index, installer_step in enumerate(installer_steps):
 
-        if not is_variant_a():
-            print(installer_step.installer_step_name)
+            if not is_variant_a():
+                print(installer_step.installer_step_name)
 
-        # Create a thread to execute the step in, and start it
-        th = threading.Thread(target=installer_step.execute)
-        th.start()
+            # Create a thread to execute the step in, and start it
+            th = threading.Thread(target=installer_step.execute)
+            th.start()
 
-        start_time = perf_counter()
+            start_time = perf_counter()
 
-        # Then, we wait for the execution to finish, checking every second if it has
-        while th.is_alive():
+            # Then, we wait for the execution to finish, checking every second if it has
+            while th.is_alive():
 
-            if is_variant_a():
-                print_current_installer_message(installer_steps, index - 1, start_time)
+                if is_variant_a():
+                    print_current_installer_message(installer_steps, index - 1, start_time)
 
-            # We want to print the progress every second, so we the user knows what is going on
-            time.sleep(1)
-        
-            # TODO: catch KeyboardInterrupt and exit gracefully
+                # We want to print the progress every second, so we the user knows what is going on
+                time.sleep(1)
+    except:
+        # Do one major log if we fail, so that we can easily tell what happened
+        log_error('install_failed')
+        exit_after_error()
 
 
         

--- a/mitoinstaller/mitoinstaller/installer_steps/installer_step_utils.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/installer_step_utils.py
@@ -70,8 +70,8 @@ def run_installer_steps(installer_steps: List[InstallerStep]) -> None:
                 if is_variant_a():
                     print_current_installer_message(installer_steps, index - 1, start_time)
 
-                # We want to print the progress every second, so we the user knows what is going on
-                time.sleep(1)
+                # We want to print the progress every 2 seconds, so we the user knows what is going on
+                time.sleep(2)
     except:
         # Do one major log if we fail, so that we can easily tell what happened
         log_error('install_failed')

--- a/mitoinstaller/mitoinstaller/installer_steps/installer_step_utils.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/installer_step_utils.py
@@ -2,11 +2,13 @@ import threading
 from time import perf_counter
 import time
 from mitoinstaller.commands import exit_after_error
+from mitoinstaller.experiments.experiment_utils import is_variant_a
 from mitoinstaller.log_utils import log_error
 import traceback
 from typing import List
 
 from mitoinstaller.installer_steps.installer_step import InstallerStep
+from mitoinstaller.print_utils import print_current_installer_message
 
 
 def run_installer_steps(installer_steps: List[InstallerStep]) -> None:
@@ -47,23 +49,30 @@ def run_installer_steps(installer_steps: List[InstallerStep]) -> None:
     installer issues easier!
     """
 
-    print("Starting install...")
+    if not is_variant_a():
+        print('Starting install...')
 
     for index, installer_step in enumerate(installer_steps):
+
+        if not is_variant_a():
+            print(installer_step.installer_step_name)
 
         # Create a thread to execute the step in, and start it
         th = threading.Thread(target=installer_step.execute)
         th.start()
 
+        start_time = perf_counter()
+
         # Then, we wait for the execution to finish, checking every second if it has
         while th.is_alive():
 
-            # TODO: catch KeyboardInterrupt and exit gracefully
-            print(f"Index:\nIndex, {index}", end="\r")
-            print('\r')
-        
+            if is_variant_a():
+                print_current_installer_message(installer_steps, index - 1, start_time)
+
             # We want to print the progress every second, so we the user knows what is going on
             time.sleep(1)
+        
+            # TODO: catch KeyboardInterrupt and exit gracefully
 
 
         

--- a/mitoinstaller/mitoinstaller/installer_steps/installer_step_utils.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/installer_step_utils.py
@@ -67,7 +67,7 @@ def run_installer_steps(installer_steps: List[InstallerStep]) -> None:
             # Then, we wait for the execution to finish, checking every second if it has
             while th.is_alive():
 
-                if is_variant_a():
+                if is_variant_a() and not installer_step.no_print_in_main_loop:
                     print_current_installer_message(installer_steps, index - 1, start_time)
 
                 # We want to print the progress every 2 seconds, so we the user knows what is going on

--- a/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
@@ -18,6 +18,7 @@ def install_step_mitosheet_check_dependencies():
     version of JLab they have installed, and if this version of JLab has
     any installed dependencies (that we cannot safely upgrade).
     """
+
     jupyterlab_version, extension_names = get_jupyterlab_metadata()
 
     # If no JupyterLab is installed, we can continue with install, as
@@ -56,8 +57,10 @@ def install_step_mitosheet_install_mitosheet():
     except:
         # If the user hits an install error because of permission issues, we ask them if 
         # they want to try a user install
+        # TODO: note this is off for now, as it conflicts with the constant print
+        # messages that we are getting from the install process.
         error_traceback_last_line = get_recent_traceback().strip().split('\n')[-1].strip()
-        if error_traceback_last_line == 'Consider using the `--user` option or check the permissions.':
+        if False or error_traceback_last_line == 'Consider using the `--user` option or check the permissions.':
             do_user_install = input("The installer hit a permission error while trying to install Mito. Would you like to do a user install? Note that this will not work inside a virtual enviornment. [y/n] ")
             if do_user_install.lower().startswith('y'):
                 # Log do user install

--- a/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
@@ -60,7 +60,7 @@ def install_step_mitosheet_install_mitosheet():
         # TODO: note this is off for now, as it conflicts with the constant print
         # messages that we are getting from the install process.
         error_traceback_last_line = get_recent_traceback().strip().split('\n')[-1].strip()
-        if False or error_traceback_last_line == 'Consider using the `--user` option or check the permissions.':
+        if False and error_traceback_last_line == 'Consider using the `--user` option or check the permissions.':
             do_user_install = input("The installer hit a permission error while trying to install Mito. Would you like to do a user install? Note that this will not work inside a virtual enviornment. [y/n] ")
             if do_user_install.lower().startswith('y'):
                 # Log do user install

--- a/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
@@ -1,3 +1,4 @@
+from multiprocessing.sharedctypes import Value
 import sys
 from time import perf_counter
 from mitoinstaller.commands import (get_jupyterlab_metadata,
@@ -17,6 +18,8 @@ def install_step_mitosheet_check_dependencies():
     version of JLab they have installed, and if this version of JLab has
     any installed dependencies (that we cannot safely upgrade).
     """
+
+    raise ValueError("This step is not implemented yet")
 
     jupyterlab_version, extension_names = get_jupyterlab_metadata()
 

--- a/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
@@ -18,9 +18,6 @@ def install_step_mitosheet_check_dependencies():
     version of JLab they have installed, and if this version of JLab has
     any installed dependencies (that we cannot safely upgrade).
     """
-
-    raise ValueError("This step is not implemented yet")
-
     jupyterlab_version, extension_names = get_jupyterlab_metadata()
 
     # If no JupyterLab is installed, we can continue with install, as
@@ -54,7 +51,6 @@ def remove_mitosheet_3_if_present():
     
 
 def install_step_mitosheet_install_mitosheet():
-    print("This might take a few moments...")
     try:
         install_pip_packages('mitosheet', test_pypi='--test-pypi' in sys.argv)
     except:
@@ -64,7 +60,6 @@ def install_step_mitosheet_install_mitosheet():
         if error_traceback_last_line == 'Consider using the `--user` option or check the permissions.':
             do_user_install = input("The installer hit a permission error while trying to install Mito. Would you like to do a user install? Note that this will not work inside a virtual enviornment. [y/n] ")
             if do_user_install.lower().startswith('y'):
-                print("Doing user install")
                 # Log do user install
                 log('install_mitosheet_user')
                 install_pip_packages('mitosheet', test_pypi='--test-pypi' in sys.argv, user_install=True)

--- a/mitoinstaller/mitoinstaller/log_utils.py
+++ b/mitoinstaller/mitoinstaller/log_utils.py
@@ -77,8 +77,6 @@ def log_error(event: str, params: Dict[str, Any]=None) -> None:
 
     recent_traceback = get_recent_traceback().strip().split('\n')
 
-    print(recent_traceback, flush=True)
-
     # Then, we log it
     log(
         event,
@@ -97,7 +95,7 @@ def _get_experiment_params() -> Dict[str, Any]:
     Get data relevant for tracking the experiment, so we can 
     see how the experiment is running
 
-    TODO: this must match the function in mitosheet
+    NOTE: this must match the function in mitosheet
     """
     global experiment
     if experiment is None:

--- a/mitoinstaller/mitoinstaller/log_utils.py
+++ b/mitoinstaller/mitoinstaller/log_utils.py
@@ -101,7 +101,6 @@ def _get_experiment_params() -> Dict[str, Any]:
     """
     global experiment
     if experiment is None:
-        from mitoinstaller.experiments import get_current_experiment
         experiment = get_current_experiment()
 
     if experiment is None:

--- a/mitoinstaller/mitoinstaller/log_utils.py
+++ b/mitoinstaller/mitoinstaller/log_utils.py
@@ -48,7 +48,6 @@ def identify() -> None:
     operating_system = platform.system()
 
     if user_json_is_installer_default() and not is_running_test():
-        return
         analytics.identify(
             static_user_id,
             {
@@ -128,7 +127,6 @@ def log(event: str, params: Dict[str, Any]=None) -> None:
 
     # Don't log if telemetry is turned off
     if not is_running_test() and get_mitosheet_telemetry():
-        return
         analytics.track(
             static_user_id, 
             event, 

--- a/mitoinstaller/mitoinstaller/log_utils.py
+++ b/mitoinstaller/mitoinstaller/log_utils.py
@@ -48,6 +48,7 @@ def identify() -> None:
     operating_system = platform.system()
 
     if user_json_is_installer_default() and not is_running_test():
+        return
         analytics.identify(
             static_user_id,
             {
@@ -127,6 +128,7 @@ def log(event: str, params: Dict[str, Any]=None) -> None:
 
     # Don't log if telemetry is turned off
     if not is_running_test() and get_mitosheet_telemetry():
+        return
         analytics.track(
             static_user_id, 
             event, 

--- a/mitoinstaller/mitoinstaller/log_utils.py
+++ b/mitoinstaller/mitoinstaller/log_utils.py
@@ -17,7 +17,7 @@ import analytics
 analytics.write_key = '6I7ptc5wcIGC4WZ0N1t0NXvvAbjRGUgX' 
 
 from mitoinstaller import __version__
-from mitoinstaller.user_install import (get_mitosheet_telemetry,
+from mitoinstaller.user_install import (get_current_experiment, get_mitosheet_telemetry,
                                         get_static_user_id, is_running_test,
                                         user_json_is_installer_default)
 
@@ -91,6 +91,30 @@ def log_error(event: str, params: Dict[str, Any]=None) -> None:
         }
     )
 
+experiment = None
+def _get_experiment_params() -> Dict[str, Any]:
+    """
+    Get data relevant for tracking the experiment, so we can 
+    see how the experiment is running
+
+    TODO: this must match the function in mitosheet
+    """
+    global experiment
+    if experiment is None:
+        from mitoinstaller.experiments import get_current_experiment
+        experiment = get_current_experiment()
+
+    if experiment is None:
+        experiment_params = {'experiment_id': 'No experiment'}
+    else:
+        experiment_params = {
+            'experiment_id': experiment["experiment_id"],
+            'experiment_variant': experiment["variant"],
+            f'experiment_{experiment["experiment_id"]}': experiment['variant']
+        }
+
+    return experiment_params
+
 
 def log(event: str, params: Dict[str, Any]=None) -> None:
     """
@@ -100,6 +124,9 @@ def log(event: str, params: Dict[str, Any]=None) -> None:
 
     if params is None:
         params = {}
+
+    # Add the experiment params to the installer
+    params = {**params, **_get_experiment_params()}
 
     # Don't log if telemetry is turned off
     if not is_running_test() and get_mitosheet_telemetry():

--- a/mitoinstaller/mitoinstaller/log_utils.py
+++ b/mitoinstaller/mitoinstaller/log_utils.py
@@ -76,6 +76,9 @@ def log_error(event: str, params: Dict[str, Any]=None) -> None:
         params = {}
 
     recent_traceback = get_recent_traceback().strip().split('\n')
+
+    print(recent_traceback, flush=True)
+
     # Then, we log it
     log(
         event,

--- a/mitoinstaller/mitoinstaller/print_utils.py
+++ b/mitoinstaller/mitoinstaller/print_utils.py
@@ -2,35 +2,21 @@
 
 
 import time
+import os
 
+def clear_terminal():
+    os.system('cls' if os.name == 'nt' else 'clear')
 
-def clear_line(n=1):
-    LINE_UP = '\033[1A'
-    LINE_CLEAR = '\x1b[2K'
-    for i in range(n):
-        print(LINE_UP, end=LINE_CLEAR)
-
-def print_and_overwrite(message: str, previous_message: str = None):
-    if previous_message is not None:
-        clear_line(n=previous_message.count('\n') + 1)
+def clear_and_print(message: str):
+    clear_terminal()
     print(message)
-
-class OverwritePrinter:
-    def __init__(self):
-        self.previous_message = None
-
-    def print(self, message: str):
-        print_and_overwrite(message, previous_message=self.previous_message)
-        self.previous_message = message
-
 
 first_message = 'This\nis\na\ntest'
 second_message = 'New\nis\na\ntest\nwith\nmultiple\nlines'
 
 
-printer = OverwritePrinter()
-printer.print(first_message)
+clear_and_print(first_message)
 time.sleep(5)
-printer.print(second_message)
+clear_and_print(second_message)
 time.sleep(5)
-printer.print(first_message)
+clear_and_print(first_message)

--- a/mitoinstaller/mitoinstaller/print_utils.py
+++ b/mitoinstaller/mitoinstaller/print_utils.py
@@ -21,13 +21,17 @@ STILL_RUNNING_MESSAGES = [
     'Still running...',
     'This can take a while...',
     'This is taking a while...',
-    'Still running...',
+    'This operation can take a few minutes. Still working...',
     'Working...',
+    'This operation can take a few minutes. Still working...',
     'Still working...',
+    'This operation can take a few minutes. Still working...',
     'Hoping to finish soon...',
+    'This operation can take a few minutes. Still working...',
     'Hopefully finishing soon...',
+    'This operation can take a few minutes. Still working...',
     'Still working...',
-    'Still running...',
+    'This operation can take a few minutes. Still working...',
 ]
 
 
@@ -35,7 +39,7 @@ def print_current_installer_message(installer_steps: List[InstallerStep], finish
 
     # First, build the checklist of the completed steps
 
-    final_string = 'Starting Mito install. This make take a few moments. In the meantime, check out a 2 minute intro to Mito: https://www.youtube.com/watch?v=LFfWfqzdKyE\n\n'
+    final_string = 'Starting Mito install. This make take a few moments.\n\nIn the meantime, check out a 2 minute intro to Mito: https://www.youtube.com/watch?v=LFfWfqzdKyE\n\n'
 
     running_for = time.perf_counter() - start_time
 

--- a/mitoinstaller/mitoinstaller/print_utils.py
+++ b/mitoinstaller/mitoinstaller/print_utils.py
@@ -35,7 +35,7 @@ def print_current_installer_message(installer_steps: List[InstallerStep], finish
 
     # First, build the checklist of the completed steps
 
-    final_string = 'Starting Mito install. This make take a few moments. In the meantime, check out a 2 minute intro to Mito: <VIDEO LINK HERE>\n\n'
+    final_string = 'Starting Mito install. This make take a few moments. In the meantime, check out a 2 minute intro to Mito: https://www.youtube.com/watch?v=LFfWfqzdKyE\n\n'
 
     running_for = time.perf_counter() - start_time
 

--- a/mitoinstaller/mitoinstaller/print_utils.py
+++ b/mitoinstaller/mitoinstaller/print_utils.py
@@ -7,10 +7,10 @@ from typing import List
 
 from mitoinstaller.installer_steps.installer_step import InstallerStep
 
-def clear_terminal():
+def clear_terminal() -> None:
     os.system('cls' if os.name == 'nt' else 'clear')
 
-def clear_and_print(message: str):
+def clear_and_print(message: str) -> None:
     clear_terminal()
     print(message)
 
@@ -31,7 +31,7 @@ STILL_RUNNING_MESSAGES = [
 ]
 
 
-def print_current_installer_message(installer_steps: List[InstallerStep], finished_index: int, start_time: float) -> str:
+def print_current_installer_message(installer_steps: List[InstallerStep], finished_index: int, start_time: float) -> None:
 
     # First, build the checklist of the completed steps
 

--- a/mitoinstaller/mitoinstaller/print_utils.py
+++ b/mitoinstaller/mitoinstaller/print_utils.py
@@ -1,0 +1,36 @@
+
+
+
+import time
+
+
+def clear_line(n=1):
+    LINE_UP = '\033[1A'
+    LINE_CLEAR = '\x1b[2K'
+    for i in range(n):
+        print(LINE_UP, end=LINE_CLEAR)
+
+def print_and_overwrite(message: str, previous_message: str = None):
+    if previous_message is not None:
+        clear_line(n=previous_message.count('\n') + 1)
+    print(message)
+
+class OverwritePrinter:
+    def __init__(self):
+        self.previous_message = None
+
+    def print(self, message: str):
+        print_and_overwrite(message, previous_message=self.previous_message)
+        self.previous_message = message
+
+
+first_message = 'This\nis\na\ntest'
+second_message = 'New\nis\na\ntest\nwith\nmultiple\nlines'
+
+
+printer = OverwritePrinter()
+printer.print(first_message)
+time.sleep(5)
+printer.print(second_message)
+time.sleep(5)
+printer.print(first_message)

--- a/mitoinstaller/mitoinstaller/print_utils.py
+++ b/mitoinstaller/mitoinstaller/print_utils.py
@@ -3,6 +3,9 @@
 
 import time
 import os
+from typing import List
+
+from mitoinstaller.installer_steps.installer_step import InstallerStep
 
 def clear_terminal():
     os.system('cls' if os.name == 'nt' else 'clear')
@@ -11,12 +14,40 @@ def clear_and_print(message: str):
     clear_terminal()
     print(message)
 
-first_message = 'This\nis\na\ntest'
-second_message = 'New\nis\na\ntest\nwith\nmultiple\nlines'
+# We change up the message we display to the user every 10 seconds, so that they are
+# are aware of the progress of the install and that it is not frozen.
+STILL_RUNNING_MESSAGES = [
+    'Running...',
+    'Still running...',
+    'This can take a while...',
+    'This is taking a while...',
+    'Still running...',
+    'Working...',
+    'Still working...',
+    'Hoping to finish soon...',
+    'Hopefully finishing soon...',
+    'Still working...',
+    'Still running...',
+]
 
 
-clear_and_print(first_message)
-time.sleep(5)
-clear_and_print(second_message)
-time.sleep(5)
-clear_and_print(first_message)
+def print_current_installer_message(installer_steps: List[InstallerStep], finished_index: int, start_time: float) -> str:
+
+    # First, build the checklist of the completed steps
+
+    final_string = 'Starting Mito install. This make take a few moments. In the meantime, check out a 2 minute intro to Mito: <VIDEO LINK HERE>\n\n'
+
+    running_for = time.perf_counter() - start_time
+
+    for index, installer_step in enumerate(installer_steps):
+        checked = index <= finished_index
+        running = index == finished_index + 1
+    
+        final_string += f' [{"X" if checked else " "}] ' + installer_step.installer_step_name
+        if running:
+            final_string += f' ({STILL_RUNNING_MESSAGES[int((running_for // 10)) % len(STILL_RUNNING_MESSAGES)]})'
+
+        final_string += '\n'
+
+
+    clear_and_print(final_string)

--- a/mitoinstaller/mitoinstaller/user_install.py
+++ b/mitoinstaller/mitoinstaller/user_install.py
@@ -1,10 +1,11 @@
 import json
 import os
-from typing import Optional
+from typing import Dict, Optional
 import uuid
 from copy import deepcopy
 
 from mitoinstaller import __version__
+from mitoinstaller.experiments.experiment_utils import get_new_experiment
 
 # Where all global .mito files are stored
 MITO_FOLDER = os.path.join(os.path.expanduser("~"), '.mito')
@@ -42,6 +43,7 @@ USER_JSON_DEFAULT = {
     'static_user_id': get_random_id() if not is_running_test() else 'github_action',
     'mitosheet_telemetry': True,
     'mitosheet_pro': False,
+    'experiment': get_new_experiment()
 }
 
 def try_create_user_json_file(is_pro: bool=False) -> None:
@@ -81,6 +83,17 @@ def get_mitosheet_telemetry() -> bool:
             return json.load(f)['mitosheet_telemetry']
     except: 
         return True
+
+
+def get_current_experiment() -> Optional[Dict[str, str]]:
+    """
+    Returns the current experiment object, or None if it does not exist
+    """
+    try:
+        with open(USER_JSON_PATH) as f:
+            return json.load(f)['experiment']
+    except: 
+        return None
 
 def user_json_is_installer_default() -> bool:
     """

--- a/mitoinstaller/mitoinstaller/user_install.py
+++ b/mitoinstaller/mitoinstaller/user_install.py
@@ -66,9 +66,15 @@ def try_create_user_json_file(is_pro: bool=False) -> None:
             updated_user_json = json.loads(f.read())
             updated_user_json['mitosheet_telemetry'] = not is_pro
             updated_user_json['mitosheet_pro'] = is_pro      
+
+        # And we also make sure that the experiment is updated, if it needs
+        # to be updated
+        new_experiment = get_new_experiment()
+        if new_experiment is not None and updated_user_json['experiment']['experiment_id'] != new_experiment['experiment_id']:
+            updated_user_json['experiment'] = new_experiment
+
         with open(USER_JSON_PATH, 'w') as f:
             f.write(json.dumps(updated_user_json))
-
 
 def get_static_user_id() -> Optional[str]:
     try:

--- a/mitoinstaller/tests/test_user_json.py
+++ b/mitoinstaller/tests/test_user_json.py
@@ -4,7 +4,7 @@ import os
 
 from tests.conftest import VirtualEnvironment, clear_user_json
 
-from mitoinstaller.user_install import get_static_user_id, try_create_user_json_file
+from mitoinstaller.user_install import get_current_experiment, get_static_user_id, try_create_user_json_file
 from mitoinstaller.user_install import USER_JSON_PATH
 
 
@@ -79,3 +79,19 @@ def test_running_installer_twice_does_not_overwrite_static_user_id(venv: Virtual
     static_user_id_two = get_static_user_id()
 
     assert static_user_id_one == static_user_id_two
+
+def test_generates_experiment(venv: VirtualEnvironment, clear_user_json):
+    venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])    
+    venv.run_python_module_command(['mitoinstaller', 'install'])
+    current_experiment = get_current_experiment()
+    assert current_experiment is not None
+
+def test_experiment_not_overwritten_by_mitosheet_import(venv: VirtualEnvironment, clear_user_json):
+    venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])    
+    venv.run_python_module_command(['mitoinstaller', 'install'])
+    current_experiment = get_current_experiment()
+
+    venv.run_python_script('import mitosheet')
+    current_experiment_new = get_current_experiment()
+    assert current_experiment['experiment_id'] == current_experiment_new['experiment_id']
+    assert current_experiment['variant'] == current_experiment_new['variant']

--- a/mitoinstaller/tests/test_user_json.py
+++ b/mitoinstaller/tests/test_user_json.py
@@ -1,10 +1,12 @@
+from copy import deepcopy
 import pytest
 import json
 import os
+from mitoinstaller.experiments.experiment_utils import get_new_experiment
 
 from tests.conftest import VirtualEnvironment, clear_user_json
 
-from mitoinstaller.user_install import get_current_experiment, get_static_user_id, try_create_user_json_file
+from mitoinstaller.user_install import USER_JSON_DEFAULT, get_current_experiment, get_static_user_id, try_create_user_json_file
 from mitoinstaller.user_install import USER_JSON_PATH
 
 
@@ -85,6 +87,17 @@ def test_generates_experiment(venv: VirtualEnvironment, clear_user_json):
     venv.run_python_module_command(['mitoinstaller', 'install'])
     current_experiment = get_current_experiment()
     assert current_experiment is not None
+
+def test_overwrites_old_experiment(venv: VirtualEnvironment, clear_user_json):
+    venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])    
+    user_json = deepcopy(USER_JSON_DEFAULT)
+    user_json['experiment'] = {'experiment_id': 'old_experiment_id', 'variant': 'A'}
+    with open(USER_JSON_PATH, 'w+') as f:
+        f.write(json.dumps(user_json))
+
+    venv.run_python_module_command(['mitoinstaller', 'install'])
+    current_experiment = get_current_experiment()
+    assert current_experiment['experiment_id'] != 'old_experiment_id' and current_experiment['experiment_id'] == get_new_experiment()['experiment_id']
 
 def test_experiment_not_overwritten_by_mitosheet_import(venv: VirtualEnvironment, clear_user_json):
     venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])    

--- a/mitosheet/mitosheet/experiments/experiment_utils.py
+++ b/mitosheet/mitosheet/experiments/experiment_utils.py
@@ -31,6 +31,7 @@ def get_random_variant() -> str:
     return "A" if random.random() < 0.5 else "B"
 
 def get_new_experiment() -> Optional[Dict[str, str]]:
+    # NOTE: this needs to match the installer!
     return {
         'experiment_id': 'title_name',
         'variant': get_random_variant(),

--- a/mitosheet/mitosheet/experiments/experiment_utils.py
+++ b/mitosheet/mitosheet/experiments/experiment_utils.py
@@ -9,16 +9,11 @@ Contains utilities for interacting with experiments. If you want to change the c
 experiment, do the following:
 
 1. Change the get_new_experiment() function to return the new experiment you want to run.
-2. Change the user.json version to increase by one.
-3. Write an upgrader function that changes the experiment in the user json to the new experiment.
-4. Add this to the experiment tracker in notion so we remember what the experiments are.
-5. Change the experiment in the installer to use the new experiment as well.
-6. Actually use the new experiment (and remove old experiment code).
+2. Change the get_new_experiment() in the mitoinstaller to use the new experiment id as well.
+3. Add this to the experiment tracker in notion so we remember what the experiments are.
+4. Actually use the new experiment (and remove old experiment code).
 
 That's it! We can continue to optimize this over time, but that is fine for now.
-
-TODO: we should come back to this once we get the installer involved in this process as 
-well, as this might be a complex interaction... not sure yet.
 """
 
 
@@ -35,7 +30,7 @@ def get_random_variant() -> str:
 def get_new_experiment() -> Optional[Dict[str, str]]:
     # NOTE: this needs to match the installer!
     return {
-        'experiment_id': 'title_name',
+        'experiment_id': 'installer_communication_and_time_to_value',
         'variant': get_random_variant(),
     }
 

--- a/mitosheet/mitosheet/experiments/experiment_utils.py
+++ b/mitosheet/mitosheet/experiments/experiment_utils.py
@@ -12,6 +12,8 @@ experiment, do the following:
 2. Change the user.json version to increase by one.
 3. Write an upgrader function that changes the experiment in the user json to the new experiment.
 4. Add this to the experiment tracker in notion so we remember what the experiments are.
+5. Change the experiment in the installer to use the new experiment as well.
+6. Actually use the new experiment (and remove old experiment code).
 
 That's it! We can continue to optimize this over time, but that is fine for now.
 

--- a/mitosheet/mitosheet/telemetry/telemetry_utils.py
+++ b/mitosheet/mitosheet/telemetry/telemetry_utils.py
@@ -205,6 +205,8 @@ def _get_experiment_params() -> Dict[str, Any]:
     """
     Get data relevant for tracking the experiment, so we can 
     see how the experiment is running
+
+    TODO: This must match the function in the installer
     """
     global experiment
     if experiment is None:

--- a/mitosheet/mitosheet/telemetry/telemetry_utils.py
+++ b/mitosheet/mitosheet/telemetry/telemetry_utils.py
@@ -206,7 +206,7 @@ def _get_experiment_params() -> Dict[str, Any]:
     Get data relevant for tracking the experiment, so we can 
     see how the experiment is running
 
-    TODO: This must match the function in the installer
+    NOTE: This must match the function in the installer
     """
     global experiment
     if experiment is None:

--- a/mitosheet/mitosheet/tests/user/conftest.py
+++ b/mitosheet/mitosheet/tests/user/conftest.py
@@ -77,7 +77,7 @@ def check_user_json(
         mitosheet_last_fifty_usages=[today_str],
         mitosheet_telemetry=True,
         mitosheet_is_pro=False,
-        mitosheet_experiment=True,
+        mitosheet_experiment_id=None,
     ):
     """
     This is the main helper function that does sanity checks about the 
@@ -100,4 +100,7 @@ def check_user_json(
     assert get_user_field(UJ_MITOSHEET_TELEMETRY) == mitosheet_telemetry
     assert get_user_field(UJ_MITOSHEET_PRO) == mitosheet_is_pro
     assert get_user_field(UJ_EXPERIMENT) is not None
+    if mitosheet_experiment_id:
+        assert get_user_field(UJ_EXPERIMENT)['experiment_id'] == mitosheet_experiment_id
+
 

--- a/mitosheet/mitosheet/tests/user/test_user.py
+++ b/mitosheet/mitosheet/tests/user/test_user.py
@@ -10,10 +10,11 @@ and that it can handle the various undefined versions of user.json that exist.
 import os
 from copy import deepcopy
 import subprocess
+from mitosheet.experiments.experiment_utils import get_new_experiment
 
 from mitosheet.utils import get_random_id
 from mitosheet._version import __version__
-from mitosheet.user.schemas import UJ_MITOSHEET_PRO, UJ_MITOSHEET_TELEMETRY, USER_JSON_VERSION_1, USER_JSON_VERSION_2, USER_JSON_VERSION_3
+from mitosheet.user.schemas import UJ_EXPERIMENT, UJ_MITOSHEET_PRO, UJ_MITOSHEET_TELEMETRY, USER_JSON_VERSION_1, USER_JSON_VERSION_2, USER_JSON_VERSION_3
 from mitosheet.user.db import USER_JSON_PATH, get_user_field
 from mitosheet.user import initialize_user
 from mitosheet.tests.user.conftest import check_user_json, write_fake_user_json, today_str
@@ -278,3 +279,19 @@ def test_main_cli_turn_off_logging():
     initialize_user()
     subprocess.run(['python', '-m', 'mitosheet', 'turnofflogging'])
     assert get_user_field(UJ_MITOSHEET_TELEMETRY) == False
+
+def test_upgrades_to_new_experiment():
+    write_fake_user_json({
+        UJ_STATIC_USER_ID: 'github_action',
+        UJ_MITOSHEET_TELEMETRY: True,
+        UJ_MITOSHEET_PRO: False,
+        UJ_EXPERIMENT: {
+            'experiment_id': 'an_old_experiment',
+            'variant': 'A',
+        }
+    })
+
+    initialize_user()
+    check_user_json(user_email='', mitosheet_experiment_id=get_new_experiment()['experiment_id'])
+
+    os.remove(USER_JSON_PATH)

--- a/mitosheet/mitosheet/tests/user/test_user.py
+++ b/mitosheet/mitosheet/tests/user/test_user.py
@@ -293,5 +293,10 @@ def test_upgrades_to_new_experiment():
 
     initialize_user()
     check_user_json(user_email='', mitosheet_experiment_id=get_new_experiment()['experiment_id'])
-
     os.remove(USER_JSON_PATH)
+
+def test_experiments_in_sync():
+    import sys
+    sys.path.insert(0, '../mitoinstaller')
+    from mitoinstaller.experiments import get_new_experiment as get_new_experiment_from_mitoinstaller
+    assert get_new_experiment_from_mitoinstaller()['experiment_id'] == get_new_experiment()['experiment_id']

--- a/mitosheet/mitosheet/tests/user/test_user.py
+++ b/mitosheet/mitosheet/tests/user/test_user.py
@@ -298,5 +298,5 @@ def test_upgrades_to_new_experiment():
 def test_experiments_in_sync():
     import sys
     sys.path.insert(0, '../mitoinstaller')
-    from mitoinstaller.experiments import get_new_experiment as get_new_experiment_from_mitoinstaller
+    from mitoinstaller.experiments.experiment_utils import get_new_experiment as get_new_experiment_from_mitoinstaller
     assert get_new_experiment_from_mitoinstaller()['experiment_id'] == get_new_experiment()['experiment_id']

--- a/mitosheet/mitosheet/user/upgrade.py
+++ b/mitosheet/mitosheet/user/upgrade.py
@@ -181,6 +181,12 @@ def try_upgrade_user_json_to_current_version() -> None:
     if user_json_object[UJ_USER_JSON_VERSION] == 5:
         user_json_object = upgrade_user_json_version_5_to_6(user_json_object)
 
+    # We always make sure that the experiment is the most up to date
+    # version of the experiment
+    new_experiment = get_new_experiment()
+    if user_json_object[UJ_EXPERIMENT]['experiment_id'] != new_experiment['experiment_id']:
+        user_json_object[UJ_EXPERIMENT] = new_experiment
+
     set_user_json_object(user_json_object)
 
 

--- a/mitosheet/mitosheet/user/upgrade.py
+++ b/mitosheet/mitosheet/user/upgrade.py
@@ -184,8 +184,8 @@ def try_upgrade_user_json_to_current_version() -> None:
     # We always make sure that the experiment is the most up to date
     # version of the experiment
     new_experiment = get_new_experiment()
-    if user_json_object[UJ_EXPERIMENT]['experiment_id'] != new_experiment['experiment_id']:
-        user_json_object[UJ_EXPERIMENT] = new_experiment
+    if new_experiment is not None and user_json_object[UJ_EXPERIMENT]['experiment_id'] != new_experiment['experiment_id']:
+            user_json_object[UJ_EXPERIMENT] = new_experiment
 
     set_user_json_object(user_json_object)
 


### PR DESCRIPTION
# Description

Implements: https://www.notion.so/trymito/Faster-Installer-Investigation-adc3de7829f14db9b75d145d60fcea42

Also implements all the AB test infrastructure for the installer, which is sweet!

# Testing

```
rm ~/.mito/user.json; deactivate; rm -rf venv; python3 -m venv venv; source venv/bin/activate; pip install -r requirements.txt; python -m mitoinstaller install
```

Things to test:
1. Logs generate correctly in both versions.
2. Logs generate correct when there are errors in steps (insert random Throws in steps)
3. You can keyboard cancel.
4. Both Mac and windows.

# Documentation

Nothing different!