### PR TITLE
mitosheet: fix up some unrealized race conditions

### DIFF
--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -391,6 +391,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
                         currOpenModal: {type: ModalEnum.None},
                         currOpenTaskpane: {
                             type: TaskpaneType.PIVOT,
+                            sourceSheetIndex: existingPivotParams.sheet_index,
                             destinationSheetIndex: uiState.selectedSheetIndex,
                             existingPivotParams: existingPivotParams
                         },
@@ -631,7 +632,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
                     sheetDataArray={sheetDataArray}
                     columnIDsMapArray={columnIDsMapArray}
                     mitoAPI={props.mitoAPI}
-                    selectedSheetIndex={uiState.selectedSheetIndex}
+                    sourceSheetIndex={uiState.currOpenTaskpane.sourceSheetIndex}
                     analysisData={analysisData}
                     setUIState={setUIState}
                     destinationSheetIndex={uiState.currOpenTaskpane.destinationSheetIndex}

--- a/mitosheet/src/components/taskpanes/PivotTable/PivotTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/PivotTable/PivotTaskpane.tsx
@@ -18,7 +18,7 @@ export type PivotTaskpaneProps = {
     dfNames: string[],
     sheetDataArray: SheetData[],
     columnIDsMapArray: ColumnIDsMap[],
-    selectedSheetIndex: number,
+    sourceSheetIndex: number,
 
     /* 
         These props are only defined if we are editing a pivot table
@@ -36,7 +36,7 @@ export type PivotTaskpaneProps = {
 const PivotTaskpane = (props: PivotTaskpaneProps): JSX.Element => {
 
     const {params, setParams} = useLiveUpdatingParams(
-        () => getDefaultPivotParams(props.sheetDataArray, props.selectedSheetIndex, props.existingPivotParams),
+        () => getDefaultPivotParams(props.sheetDataArray, props.sourceSheetIndex, props.existingPivotParams),
         StepType.Pivot,
         props.mitoAPI, props.analysisData, 0, 
         {
@@ -133,8 +133,8 @@ const PivotTaskpane = (props: PivotTaskpaneProps): JSX.Element => {
         })
     }
 
-    const sheetData: SheetData | undefined = props.sheetDataArray[params.selectedSheetIndex];
-    const columnIDsMap = props.columnIDsMapArray[params.selectedSheetIndex] || {}; // Make sure it's not undefined
+    const sheetData: SheetData | undefined = props.sheetDataArray[params.sourceSheetIndex];
+    const columnIDsMap = props.columnIDsMapArray[params.sourceSheetIndex] || {}; // Make sure it's not undefined
     
     return (
         <DefaultTaskpane>
@@ -149,7 +149,7 @@ const PivotTaskpane = (props: PivotTaskpaneProps): JSX.Element => {
                 <DataframeSelect
                     title='Dataframe to pivot'
                     sheetDataArray={props.sheetDataArray}
-                    sheetIndex={props.selectedSheetIndex}
+                    sheetIndex={params.sourceSheetIndex}
                     onChange={(newSheetIndex) => {
                         // Set the selected index, and reset to the default params (taking no existing params)
                         const newParams = getDefaultPivotParams(props.sheetDataArray, newSheetIndex, undefined);

--- a/mitosheet/src/components/taskpanes/PivotTable/pivotUtils.tsx
+++ b/mitosheet/src/components/taskpanes/PivotTable/pivotUtils.tsx
@@ -2,14 +2,14 @@ import { AggregationType, BackendPivotParams, FrontendPivotParams, SheetData } f
 import { getDeduplicatedArray } from "../../../utils/arrays";
 
 
-export const getDefaultPivotParams = (sheetDataArray: SheetData[], selectedSheetIndex: number, existingPivotParams: BackendPivotParams | undefined): FrontendPivotParams | undefined => {
+export const getDefaultPivotParams = (sheetDataArray: SheetData[], sourceSheetIndex: number, existingPivotParams: BackendPivotParams | undefined): FrontendPivotParams | undefined => {
     if (sheetDataArray.length === 0) {
         return undefined;
     }
     
     if (existingPivotParams === undefined) {
         return {
-            selectedSheetIndex: selectedSheetIndex,
+            sourceSheetIndex: sourceSheetIndex,
             pivotRowColumnIDs: [],
             pivotColumnsColumnIDs: [],
             pivotValuesColumnIDsArray: [],
@@ -23,7 +23,7 @@ export const getDefaultPivotParams = (sheetDataArray: SheetData[], selectedSheet
 
 export const getPivotFrontendParamsFromBackendParams = (pivotParams: BackendPivotParams): FrontendPivotParams => {
     return {
-        selectedSheetIndex: pivotParams.sheet_index,
+        sourceSheetIndex: pivotParams.sheet_index,
         pivotRowColumnIDs: pivotParams.pivot_rows_column_ids,
         pivotColumnsColumnIDs: pivotParams.pivot_columns_column_ids,
         pivotValuesColumnIDsArray: valuesRecordToArray(pivotParams.values_column_ids_map),
@@ -34,7 +34,7 @@ export const getPivotFrontendParamsFromBackendParams = (pivotParams: BackendPivo
 
 export const getPivotBackendParamsFromFrontendParams = (params: FrontendPivotParams): BackendPivotParams => {
     return {
-        sheet_index: params.selectedSheetIndex,
+        sheet_index: params.sourceSheetIndex,
         // Deduplicate the rows and columns before sending them to the backend
         // as otherwise this generates errors if you have duplicated key
         pivot_rows_column_ids: getDeduplicatedArray(params.pivotRowColumnIDs),

--- a/mitosheet/src/components/taskpanes/taskpanes.tsx
+++ b/mitosheet/src/components/taskpanes/taskpanes.tsx
@@ -57,6 +57,7 @@ export type TaskpaneInfo =
     | {type: TaskpaneType.NONE}
     | {
         type: TaskpaneType.PIVOT,
+        sourceSheetIndex: number,
         // Optional params only defined if this is a pivot
         // editing a specific existing pivot table
         destinationSheetIndex?: number;

--- a/mitosheet/src/jupyter/api.tsx
+++ b/mitosheet/src/jupyter/api.tsx
@@ -765,7 +765,7 @@ export default class MitoAPI {
             type: 'pivot_edit',
             'step_id': stepID,
             'params': {
-                sheet_index: pivotParams.selectedSheetIndex,
+                sheet_index: pivotParams.sourceSheetIndex,
                 // Deduplicate the rows and columns before sending them to the backend
                 // as otherwise this generates errors if you have duplicated key
                 pivot_rows_column_ids: getDeduplicatedArray(pivotParams.pivotRowColumnIDs),

--- a/mitosheet/src/types.tsx
+++ b/mitosheet/src/types.tsx
@@ -322,7 +322,7 @@ export interface BackendPivotParams {
 // backend and the frontend, due to it being easier to manipulate as an array on the 
 // frontend while keeping the ordering for values
 export interface FrontendPivotParams {
-    selectedSheetIndex: number,
+    sourceSheetIndex: number,
     pivotRowColumnIDs: ColumnID[],
     pivotColumnsColumnIDs: ColumnID[],
     // NOTE: storing these values as an array makes keeping an order of them

--- a/mitosheet/src/utils/actions.tsx
+++ b/mitosheet/src/utils/actions.tsx
@@ -651,6 +651,7 @@ export const createActions = (
                                 currOpenModal: {type: ModalEnum.None},
                                 currOpenTaskpane: {
                                     type: TaskpaneType.PIVOT,
+                                    sourceSheetIndex: existingPivotParams.sheet_index,
                                     destinationSheetIndex: sheetIndex,
                                     existingPivotParams: existingPivotParams
                                 },
@@ -681,6 +682,7 @@ export const createActions = (
                         currOpenModal: {type: ModalEnum.None},
                         currOpenTaskpane: {
                             type: TaskpaneType.PIVOT,
+                            sourceSheetIndex: sheetIndex,
                             destinationSheetIndex: undefined,
                             existingPivotParams: undefined
                         },


### PR DESCRIPTION
# Description

This PR fixes a bug I discovered while working on the new TTV checklist. Namely, if you switched to a sheet b/c of an open pivot table, you can get a race condition that leads to the wrong param being used as the sheet index.

This bug isn't manifesting in deployed code, but based on the fact adding a checklist made it happen means it might, so let's get this fixed ASAP!

# Testing

Use the pivot table!

# Documentation

N/A.