### PR TITLE
mitoinstaller: make sure experiment is in user.json

### DIFF
--- a/mitoinstaller/mitoinstaller/experiments/experiment_utils.py
+++ b/mitoinstaller/mitoinstaller/experiments/experiment_utils.py
@@ -6,7 +6,7 @@ def get_random_variant() -> str:
     """Returns "A" or "B" with 50% probability"""
     return "A" if random.random() < 0.5 else "B"
 
-def get_new_experiment() -> Optional[Dict[str, str]]:
+def get_new_experiment() -> Dict[str, str]:
     # NOTE: this needs to match the mitosheet package!
     return {
         'experiment_id': 'installer_communication_and_time_to_value',

--- a/mitoinstaller/mitoinstaller/install.py
+++ b/mitoinstaller/mitoinstaller/install.py
@@ -1,6 +1,7 @@
 from mitoinstaller.installer_steps import (ALL_INSTALLER_STEPS,
                                            run_installer_steps)
 from mitoinstaller.installer_steps.initial_installer_steps import initial_install_step_create_user
+from mitoinstaller.log_utils import log_error
 
 
 def do_install() -> None:
@@ -14,7 +15,12 @@ def do_install() -> None:
     # We need to create the user json file before we can run anything,
     # as this creates the experiment variant we use throughout the rest of the
     # installer.
-    initial_install_step_create_user()
+    try:
+        initial_install_step_create_user()
+    except:
+        log_error('install_failed', {'installer_step_name': 'create_user'})
+        log_error('create_user_failed')
+        exit(1)
 
     # Run the installer steps
     run_installer_steps(ALL_INSTALLER_STEPS)

--- a/mitoinstaller/mitoinstaller/user_install.py
+++ b/mitoinstaller/mitoinstaller/user_install.py
@@ -67,14 +67,10 @@ def try_create_user_json_file(is_pro: bool=False) -> None:
             updated_user_json['mitosheet_telemetry'] = not is_pro
             updated_user_json['mitosheet_pro'] = is_pro      
 
-        # Make sure that the user.json contains the experiment field
-        if 'experiment' not in updated_user_json.keys():
-            updated_user_json['experiment'] = dict()
-
         # And we also make sure that the experiment is updated, if it needs
         # to be updated
         new_experiment = get_new_experiment()
-        if new_experiment is not None and ('experiment_id' not in updated_user_json['experiment'] or updated_user_json['experiment']['experiment_id'] != new_experiment['experiment_id']):
+        if 'experiment' not in updated_user_json or 'experiment_id' not in updated_user_json['experiment'] or updated_user_json['experiment']['experiment_id'] != new_experiment['experiment_id']:
             updated_user_json['experiment'] = new_experiment
 
         with open(USER_JSON_PATH, 'w') as f:

--- a/mitoinstaller/mitoinstaller/user_install.py
+++ b/mitoinstaller/mitoinstaller/user_install.py
@@ -67,10 +67,14 @@ def try_create_user_json_file(is_pro: bool=False) -> None:
             updated_user_json['mitosheet_telemetry'] = not is_pro
             updated_user_json['mitosheet_pro'] = is_pro      
 
+        # Make sure that the user.json contains the experiment field
+        if 'experiment' not in updated_user_json.keys():
+            updated_user_json['experiment'] = dict()
+
         # And we also make sure that the experiment is updated, if it needs
         # to be updated
         new_experiment = get_new_experiment()
-        if new_experiment is not None and updated_user_json['experiment']['experiment_id'] != new_experiment['experiment_id']:
+        if new_experiment is not None and ('experiment_id' not in updated_user_json['experiment'] or updated_user_json['experiment']['experiment_id'] != new_experiment['experiment_id']):
             updated_user_json['experiment'] = new_experiment
 
         with open(USER_JSON_PATH, 'w') as f:

--- a/mitoinstaller/mitoinstaller/user_install.py
+++ b/mitoinstaller/mitoinstaller/user_install.py
@@ -70,7 +70,7 @@ def try_create_user_json_file(is_pro: bool=False) -> None:
         # And we also make sure that the experiment is updated, if it needs
         # to be updated
         new_experiment = get_new_experiment()
-        if 'experiment' not in updated_user_json or 'experiment_id' not in updated_user_json['experiment'] or updated_user_json['experiment']['experiment_id'] != new_experiment['experiment_id']:
+        if 'experiment' not in updated_user_json or updated_user_json['experiment']['experiment_id'] != new_experiment['experiment_id']:
             updated_user_json['experiment'] = new_experiment
 
         with open(USER_JSON_PATH, 'w') as f:

--- a/mitosheet/mitosheet/experiments/experiment_utils.py
+++ b/mitosheet/mitosheet/experiments/experiment_utils.py
@@ -27,7 +27,7 @@ def get_random_variant() -> str:
     """Returns "A" or "B" with 50% probability"""
     return "A" if random.random() < 0.5 else "B"
 
-def get_new_experiment() -> Optional[Dict[str, str]]:
+def get_new_experiment() -> Dict[str, str]:
     # NOTE: this needs to match the installer!
     return {
         'experiment_id': 'installer_communication_and_time_to_value',


### PR DESCRIPTION
# Description

In trying to understand this experiment. I upgraded an old mitosheet and the upgrade process failed with the error `File "/Users/aarondiamond-reivich/Desktop/mito-upgrade-test/venv/lib/python3.8/site-packages/mitoinstaller/user_install.py", line 73, in try_create_user_json_file
    if new_experiment is not None and updated_user_json['experiment']['experiment_id'] != new_experiment['experiment_id']:
KeyError: 'experiment'`

To recreate it:
1. Delete your user.jsoin
2. Run `pip install mitosheet=0.1.430 --no-cache-dir`
3. Go through the signup flow. 
4. Then kill the server and try to upgrade Mito by running: `python -m pip install mitoinstaller --upgrade` followed by `python -m mitoinstaller upgrade`

On the actual upgrade command the error appears. Also, importantly note that it doesn't show up in the logs at all.

@naterush is thoughts on how we could add logging so we see more upgrade issues? 

# Testing

1. Delete your user.jsoin
2. Run `pip install mitosheet=0.1.430 --no-cache-dir`
3. Go through the signup flow. 
4. Run the dev installer by following the instructions in the `mitoinstaller/readme.md`


# Documentation

None.