### PR TITLE
Make Plotly work offline

### DIFF
--- a/mitosheet/mitosheet/api/get_column_summary_graph.py
+++ b/mitosheet/mitosheet/api/get_column_summary_graph.py
@@ -33,6 +33,7 @@ def get_column_summary_graph(params: Dict[str, Any], steps_manager: StepsManager
     column_id: ColumnID = params['column_id']
     height = params['height']
     width = params['width']
+    include_plotlyjs = params['include_plotlyjs']
 
 
     # Create a copy of the dataframe, just for safety.
@@ -51,7 +52,7 @@ def get_column_summary_graph(params: Dict[str, Any], steps_manager: StepsManager
         )
     )
 
-    return_object = get_html_and_script_from_figure(fig, height, width)
+    return_object = get_html_and_script_from_figure(fig, height, width, include_plotlyjs)
 
     return json.dumps(return_object)
 

--- a/mitosheet/mitosheet/step_performers/graph_steps/graph.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/graph.py
@@ -177,7 +177,6 @@ class GraphStepPerformer(StepPerformer):
                 )
             )
 
-            print("include_plotlyjs:", include_plotlyjs)
             html_and_script = get_html_and_script_from_figure(fig, height, width, include_plotlyjs)
 
             graph_generation_code = get_plotly_express_graph_code(

--- a/mitosheet/mitosheet/step_performers/graph_steps/graph.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/graph.py
@@ -86,6 +86,7 @@ class GraphStepPerformer(StepPerformer):
         graph_creation: Dict[str, Any] = get_param(params, 'graph_creation')
         graph_styling: Dict[str, Any] = get_param(params, 'graph_styling')
         graph_rendering: Dict[str, Any] = get_param(params, 'graph_rendering')
+        include_plotlyjs: bool = get_param(params, 'include_plotlyjs')
 
         # We make a new state to modify it
         post_state = prev_state.copy()
@@ -176,7 +177,8 @@ class GraphStepPerformer(StepPerformer):
                 )
             )
 
-            html_and_script = get_html_and_script_from_figure(fig, height, width)
+            print("include_plotlyjs:", include_plotlyjs)
+            html_and_script = get_html_and_script_from_figure(fig, height, width, include_plotlyjs)
 
             graph_generation_code = get_plotly_express_graph_code(
                 graph_type,

--- a/mitosheet/mitosheet/step_performers/graph_steps/graph_utils.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/graph_utils.py
@@ -174,9 +174,11 @@ def get_html_and_script_from_figure(
     # Everything in a script tag we want to treat as one big script
 
     # The get the graph div, which looks like: <div id="9c21d143-3fcd-4958-9295-ac7ada668186" class="plotly-graph-div" style="height:425px; width:970px;"></div>
+    # This is the only div we need to put on the frontend.
     div = original_html[original_html.find('<div id='):original_html.find('</div>', original_html.find('<div id='))]
 
-    # Get all the scripts that are between the <script> tags, and join them together
+    # Get all the scripts that are between the <script> tags, and join them together. If include_plotlyjs is true, this includes
+    # the plotly js script, and otherwise, it's just the data and the script that uses Plotly to build the graph on the div above
     script = ''
     index = 0
     while index < len(original_html):

--- a/mitosheet/mitosheet/step_performers/graph_steps/graph_utils.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/graph_utils.py
@@ -145,7 +145,8 @@ def get_new_graph_tab_name(graph_data_dict: Dict[str, Dict[str, Any]]) -> str:
 
 
 def get_html_and_script_from_figure(
-    fig: go.Figure, height: int, width: int
+    fig: go.Figure, height: int, width: int,
+    include_plotlyjs: boolean,
 ) -> Dict[str, str]:
     """
     Given a plotly figure, generates HTML from it, and returns
@@ -163,12 +164,13 @@ def get_html_and_script_from_figure(
     fig.write_html(
         buffer,
         full_html=False,
-        include_plotlyjs=False,
+        include_plotlyjs=include_plotlyjs,
         default_height=height,
         default_width=width,
     )
 
     original_html = buffer.getvalue()
+    open ("original_html.txt", "w").write(original_html)
     # First, we remove the main div, and the resulting whitespace, to just have the children
     original_html = original_html[5:]
     original_html = original_html[:-6]

--- a/mitosheet/mitosheet/step_performers/graph_steps/graph_utils.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/graph_utils.py
@@ -170,19 +170,26 @@ def get_html_and_script_from_figure(
     )
 
     original_html = buffer.getvalue()
-    open ("original_html.txt", "w").write(original_html)
-    # First, we remove the main div, and the resulting whitespace, to just have the children
-    original_html = original_html[5:]
-    original_html = original_html[:-6]
-    original_html = original_html.strip()
 
-    # Then, we split the children into the div, and the script
-    # making sure to remove the script tag (so we can execute it)
-    script_start = '<script type="text/javascript">'
-    script_end = "</script>"
-    split_html = original_html.split(script_start)
-    div = split_html[0]
-    script = split_html[1][: -len(script_end)]
+    # Everything in a script tag we want to treat as one big script
+
+    # The get the graph div, which looks like: <div id="9c21d143-3fcd-4958-9295-ac7ada668186" class="plotly-graph-div" style="height:425px; width:970px;"></div>
+    div = original_html[original_html.find('<div id='):original_html.find('</div>', original_html.find('<div id='))]
+
+    # Get all the scripts that are between the <script> tags, and join them together
+    script = ''
+    index = 0
+    while index < len(original_html):
+        script_start = original_html.find('<script type="text/javascript">', index)
+        script_end = original_html.find('</script>', script_start)
+
+        if script_start == -1 or script_end == -1:
+            break
+
+        # Get rid of the initial script
+        script_start += len('<script type="text/javascript">')
+        script = script + original_html[script_start:script_end] + ';\n'
+        index = script_end + 9
 
     return {"html": div, "script": script}
 

--- a/mitosheet/src/jupyter/api.tsx
+++ b/mitosheet/src/jupyter/api.tsx
@@ -358,7 +358,8 @@ export default class MitoAPI {
                 'sheet_index': sheetIndex,
                 'column_id': column_id,
                 'height': height,
-                'width': width
+                'width': width,
+                'include_plotlyjs': (window as any).Plotly === undefined,
             },
         }, { maxRetries: 250 })
 
@@ -589,7 +590,8 @@ export default class MitoAPI {
                 'graph_rendering': {
                     'height': height, 
                     'width': width
-                }
+                },
+                'include_plotlyjs': (window as any).Plotly === undefined
             }
         }, { maxRetries: 250 })
 


### PR DESCRIPTION
# Description

1. Detects if Plotly is not loaded, and loads from the backend. This makes Plotly work when it is offline.
2. Parses the Plotly generated code better.

# Testing

1. Test graphing normally.
2. Open console and `delete window.Plotly`, and make sure graphing still works (and that window.Plotly gets redefined after 1 new graph is made)

# Documentation

N/A.