### PR TITLE
mitosheet: add back mitosheet-private package

### DIFF
--- a/.github/workflows/deploy-mitosheet-private.yml
+++ b/.github/workflows/deploy-mitosheet-private.yml
@@ -1,0 +1,56 @@
+name: Deploy mitosheet-private
+on: 
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Package version to deploy to. Go to pypi and add 1 to the previous version of mitosheet-private"
+        required: true
+
+jobs:
+  deploy-mitosheet-private:
+    name: Deploy mitosheet-private
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.extract_branch.outputs.branch }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup Auth for PyPi
+        run: |
+          echo -e "[distutils]" >> ~/.pypirc
+          echo -e "index-servers =" >> ~/.pypirc
+          echo -e "    pypi" >> ~/.pypirc
+          echo -e "    testpypi" >> ~/.pypirc
+          echo -e "[pypi]" >> ~/.pypirc
+          echo -e "repository = https://pypi.python.org/pypi" >> ~/.pypirc
+          echo -e "username = __token__" >> ~/.pypirc
+          echo -e "password = ${{ secrets.PYPI_API_TOKEN }}" >> ~/.pypirc
+          echo -e "" >> ~/.pypirc
+          echo -e "[testpypi]" >> ~/.pypirc
+          echo -e "repository = https://test.pypi.org/legacy/" >> ~/.pypirc
+          echo -e "username = __token__" >> ~/.pypirc
+          echo -e "password = ${{ secrets.TEST_PYPI_API_TOKEN }}" >> ~/.pypirc
+      - name: Setup mitosheet
+        run: |
+          cd mitosheet
+          rm -rf venv
+          python3 -m venv venv
+          source venv/bin/activate
+          python switch.py mitosheet-private
+          python ../deployment/bump_version.py mitosheet-private ${{ steps.extract_branch.outputs.branch }} ${{ github.event.inputs.version }}
+          python -m pip install -e ".[test, deploy]"          
+      - name: Deploy mitosheet
+        run: |
+          cd mitosheet
+          source venv/bin/activate
+          python ../deployment/deploy.py ${{ steps.extract_branch.outputs.branch }}

--- a/mitosheet/mitosheet/telemetry/telemetry_utils.py
+++ b/mitosheet/mitosheet/telemetry/telemetry_utils.py
@@ -56,6 +56,11 @@ def telemetry_turned_on() -> bool:
     if MITOSHEET_HELPER_PRIVATE:
         return False
 
+    # If the current package is mitosheet-private, then we don't log anything,
+     # ever, under any circumstances - this is a custom distribution for a client
+    if package_name == 'mitosheet-private':
+        return False
+
     # If Mito Pro is on, then don't log anything
     if is_pro():
         return False

--- a/mitosheet/mitosheet/user/utils.py
+++ b/mitosheet/mitosheet/user/utils.py
@@ -58,6 +58,10 @@ def is_pro() -> bool:
     if MITOSHEET_HELPER_PRO:
         return MITOSHEET_HELPER_PRO
 
+    # If the current package is mitosheet-private, we activate Pro
+    if package_name == 'mitosheet-private':
+        return True
+
     return is_pro if is_pro is not None else False
 
 
@@ -88,6 +92,10 @@ def should_upgrade_mitosheet() -> bool:
     
     from mitosheet.telemetry.telemetry_utils import MITOSHEET_HELPER_PRIVATE
     if MITOSHEET_HELPER_PRO or MITOSHEET_HELPER_PRIVATE:
+        return False
+
+    # If it's mitosheet-private, then we don't give them the upgrade prompts
+    if package_name == 'mitosheet-private':
         return False
     
     last_upgraded_date_stored = get_user_field(UJ_MITOSHEET_LAST_UPGRADED_DATE)

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -150,7 +150,7 @@ if name == 'mitosheet2':
             """,
         long_description_content_type='text/markdown'
     )
-elif name == 'mitosheet' or name == 'mitosheet3':
+elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
     # Representative files that should exist after a successful build
     jstargets = [
         str(lab_path / "package.json"),

--- a/mitosheet/src/components/checklists/Checklist.tsx
+++ b/mitosheet/src/components/checklists/Checklist.tsx
@@ -134,7 +134,7 @@ const Checklist = (props: {
         }
 
         if (remainingChecklistItems.includes('signup')) {
-            if (props.userProfile.userEmail !== '') {
+            if (props.userProfile.userEmail !== '' || props.userProfile.isPro) {
                 void props.mitoAPI.updateChecklist('onboarding_checklist', ['signup'], false);
             }
         } 

--- a/mitosheet/switch.py
+++ b/mitosheet/switch.py
@@ -165,7 +165,7 @@ MITOSHEET_PACKAGE_JSON = """{
   "scripts": {
     "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
     "clean:nbextension": "rimraf mitosheet/nbextension",
-    "clean:labextension": "rimraf mitosheet/labextension",
+    "clean:labextension": "rimrafelif mitosheet/labextension",
     "clean:all": "jlpm run clean:lib && jlpm run clean:nbextension && jlpm run clean:labextension",
     "clean": "npm run clean:all",
 
@@ -277,6 +277,8 @@ def switch(new_package):
       open('package.json', 'w').write(MITOSHEET_PACKAGE_JSON.replace('REPLACE_WITH_PACKAGE_NAME_WITH_REPLACE', 'mitosheet'))
     elif new_package == 'mitosheet3':    
       open('package.json', 'w').write(MITOSHEET_PACKAGE_JSON.replace('REPLACE_WITH_PACKAGE_NAME_WITH_REPLACE', 'mitosheet3'))
+    elif new_package == 'mitosheet-private':
+       open('package.json', 'w').write(MITOSHEET_PACKAGE_JSON.replace('REPLACE_WITH_PACKAGE_NAME_WITH_REPLACE', 'mitosheet-private'))
 
     
 if __name__ == '__main__':
@@ -291,6 +293,7 @@ if __name__ == '__main__':
       'mitosheet2',
       'mitosheet',
       'mitosheet3',
+      'mitosheet-private'
     ]
 
     # Sanity check!

--- a/mitosheet/switch.py
+++ b/mitosheet/switch.py
@@ -165,7 +165,7 @@ MITOSHEET_PACKAGE_JSON = """{
   "scripts": {
     "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
     "clean:nbextension": "rimraf mitosheet/nbextension",
-    "clean:labextension": "rimrafelif mitosheet/labextension",
+    "clean:labextension": "rimraf mitosheet/labextension",
     "clean:all": "jlpm run clean:lib && jlpm run clean:nbextension && jlpm run clean:labextension",
     "clean": "npm run clean:all",
 


### PR DESCRIPTION
# Description

Check that it undoes the changes here: https://github.com/mito-ds/monorepo/pull/407/files
And that it activates pro. 

Test this by running the switch, and actually setting up the `mitosheet-private` package. **I would reccomend editing the macsetup.sh script to switch to the mitosheet-private package, and then just running that. It makes life much easier.**
# Documentation

No.