### PR TITLE
mitosheet: fix dependency issues with new ipywidgets

### DIFF
--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -213,7 +213,7 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
         packages                 = setuptools.find_packages(exclude=['deployment']),
         install_requires=[        
             "jupyterlab~=3.0",
-            'ipywidgets~=7.0.0',
+            'ipywidgets>=7.0.0',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
             'jupyterlab-widgets>=1.0.0',

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -104,7 +104,7 @@ if name == 'mitosheet2':
         install_requires = [
             # We require jupyterlab 2.0
             'jupyterlab>=2.0,<3.0,!=2.3.0,!=2.3.1', # there are css incompatabilities on version 2.3.1 and 2.3.0
-            'ipywidgets~=8.0.0',
+            'ipywidgets>=7.0.0',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',
@@ -213,10 +213,10 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
         packages                 = setuptools.find_packages(exclude=['deployment']),
         install_requires=[        
             "jupyterlab~=3.0",
-            'ipywidgets~=8.0.0',
+            'ipywidgets~=7.0.0',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
-            'jupyterlab-widgets~=3.0.0',
+            'jupyterlab-widgets>=1.0.0',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -104,7 +104,7 @@ if name == 'mitosheet2':
         install_requires = [
             # We require jupyterlab 2.0
             'jupyterlab>=2.0,<3.0,!=2.3.0,!=2.3.1', # there are css incompatabilities on version 2.3.1 and 2.3.0
-            'ipywidgets>=7.0.0',
+            'ipywidgets~=8.0.0',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',
@@ -213,10 +213,10 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
         packages                 = setuptools.find_packages(exclude=['deployment']),
         install_requires=[        
             "jupyterlab~=3.0",
-            'ipywidgets>=7.0.0',
+            'ipywidgets~=8.0.0',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
-            'jupyterlab-widgets~=1.0.0',
+            'jupyterlab-widgets~=3.0.0',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',


### PR DESCRIPTION
# Description

There is a newly released version of ipywidgets (8.0.1) on 8/18, which is incompatible with our pinned version of jupyterlab-widgets~=1.0.0. So the installation finishes, but then Mito won't load. Updating our setup.py file to allow for the new version of jupyterlab-widgets (3.0.2) created a big ugly javascript error, but it might work if I redeploy to test-pypi so the mitosheet package has new dependencies. I'm not sure why we pinned the jupyterlab-widgets to version 1.

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.