### PR TITLE
Dogfood 8-25

### DIFF
--- a/mitosheet/mitosheet/code_chunks/postprocessing/set_dataframe_format_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/postprocessing/set_dataframe_format_code_chunk.py
@@ -116,9 +116,15 @@ def get_rows_format_code(state: State, sheet_index: int, even_or_odd: str) -> Op
     df_format = state.df_formats[sheet_index]
     rows = df_format['rows']
 
+    # By default, Pandas indexes rows starting with index 0. 
+    # However, when we apply the pandas styler, it defaults to calculating if rows
+    # are even or odd starting at index 1. Therefore, to keep them in sync, we reverse
+    # the even or odd substring of the css selector. 
+    even_or_odd_css_selector = 'even' if even_or_odd == 'odd' else 'odd'
+
     evenOrOdd = rows.get(even_or_odd, dict())
     return get_transpiled_table_style(
-        f'tbody tr:nth-child({even_or_odd})',
+        f'tbody tr:nth-child({even_or_odd_css_selector})',
         [
             ('color', evenOrOdd.get('color', None)),
             ('background-color', evenOrOdd.get('backgroundColor', None))

--- a/mitosheet/mitosheet/tests/step_performers/test_set_dataframe_format.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_set_dataframe_format.py
@@ -56,11 +56,11 @@ SET_DATAFRAME_FORMAT_TESTS = [
         get_dataframe_format(
             columns={'A': {'type': NUMBER_FORMAT_PLAIN_TEXT}},
             headers={'color': '#FFFFFF', 'backgroundColor': '#549D3A'},
-            rowsEven={'color': '#494650', 'backgroundColor': '#D0E3C9'}, 
-            rowsOdd={'color': '#494650', 'backgroundColor': '#FFFFFF'},
+            rowsOdd={'color': '#494650', 'backgroundColor': '#D0E3C9'}, 
+            rowsEven={'color': '#494650', 'backgroundColor': '#FFFFFF'},
             border={'borderStyle': 'solid', 'borderColor': '#000000'}
         ),
-        [".format(\"{:d}\", subset=[\'A\'])\\\n    .set_table_styles([\n        {'selector': 'thead', 'props': [('color', '#FFFFFF'), ('background-color', '#549D3A')]},\n        {'selector': 'tbody tr:nth-child(even)', 'props': [('color', '#494650'), ('background-color', '#D0E3C9')]},\n        {'selector': 'tbody tr:nth-child(odd)', 'props': [('color', '#494650'), ('background-color', '#FFFFFF')]},\n        {'selector': '', 'props': [('border', '1px solid #000000')]}"]
+        [".format(\"{:d}\", subset=[\'A\'])\\\n    .set_table_styles([\n        {'selector': 'thead', 'props': [('color', '#FFFFFF'), ('background-color', '#549D3A')]},\n        {'selector': 'tbody tr:nth-child(odd)', 'props': [('color', '#494650'), ('background-color', '#FFFFFF')]},\n        {'selector': 'tbody tr:nth-child(even)', 'props': [('color', '#494650'), ('background-color', '#D0E3C9')]},\n        {'selector': '', 'props': [('border', '1px solid #000000')]}"]
     ),
 ]
 @pytest.mark.parametrize("df_format, included_formatting_code", SET_DATAFRAME_FORMAT_TESTS)
@@ -89,8 +89,8 @@ def test_format_with_undo():
     mito.set_dataframe_format(0, get_dataframe_format(
             columns={'A': {'type': NUMBER_FORMAT_PLAIN_TEXT}},
             headers={'color': '#FFFFFF', 'backgroundColor': '#549D3A'},
-            rowsEven={'color': '#494650', 'backgroundColor': '#D0E3C9'}, 
-            rowsOdd={'color': '#494650', 'backgroundColor': '#FFFFFF'},
+            rowsOdd={'color': '#494650', 'backgroundColor': '#D0E3C9'}, 
+            rowsEven={'color': '#494650', 'backgroundColor': '#FFFFFF'},
             border={'borderStyle': 'solid', 'borderColor': '#000000'}
         )
     )

--- a/mitosheet/src/components/endo/GridData.tsx
+++ b/mitosheet/src/components/endo/GridData.tsx
@@ -42,7 +42,6 @@ const GridData = (props: {
                     'mito-grid-row-odd': rowIndex % 2 !== 0
                 }) 
 
-                // To keep the styles in sync with the pandas styler, we 1 index our rows 
                 const style = rowIndex % 2 === 0 
                     ? {backgroundColor: evenRowBackgroundColor, color: evenRowTextColor} 
                     : {backgroundColor: oddRowBackgroundColor, color: oddRowTextColor};

--- a/mitosheet/src/components/endo/GridData.tsx
+++ b/mitosheet/src/components/endo/GridData.tsx
@@ -42,6 +42,7 @@ const GridData = (props: {
                     'mito-grid-row-odd': rowIndex % 2 !== 0
                 }) 
 
+                // To keep the styles in sync with the pandas styler, we 1 index our rows 
                 const style = rowIndex % 2 === 0 
                     ? {backgroundColor: evenRowBackgroundColor, color: evenRowTextColor} 
                     : {backgroundColor: oddRowBackgroundColor, color: oddRowTextColor};


### PR DESCRIPTION
# Description

- Mito appears to be 0 indexed, but the css selector used in the styler is 1 indexed. To keep them consistent, we flip the even and odd strings in the selector. 

# Testing

Set the background color of the even and odd rows and make sure they match in the sheet & styler