### PR TITLE
Support Ipywidgets 8.0 to support Python 3.10

### DIFF
--- a/mitosheet/package.json
+++ b/mitosheet/package.json
@@ -25,7 +25,7 @@
   },
   "version": "0.3.131",
   "dependencies": {
-    "@jupyter-widgets/base": "^4",
+    "@jupyter-widgets/base": "^4 || ^5 || ^6",
     "@jupyterlab/notebook": "^3.0.6",
     "@types/fscreen": "^1.0.1",
     "@types/react-dom": "^17.0.2",

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -100,7 +100,7 @@ if name == 'mitosheet2':
         install_requires = [
             # We require jupyterlab 2.0
             'jupyterlab>=2.0,<3.0,!=2.3.0,!=2.3.1', # there are css incompatabilities on version 2.3.1 and 2.3.0
-            'ipywidgets>=7,<9',
+            'ipywidgets~=7.0.0',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',
@@ -212,7 +212,7 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
             'ipywidgets>=7,<9',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
-            'jupyterlab-widgets~=1.0.0',
+            'jupyterlab-widgets>=1.0.0',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -104,7 +104,7 @@ if name == 'mitosheet2':
         install_requires = [
             # We require jupyterlab 2.0
             'jupyterlab>=2.0,<3.0,!=2.3.0,!=2.3.1', # there are css incompatabilities on version 2.3.1 and 2.3.0
-            'ipywidgets~=7.0.0',
+            'ipywidgets>=7,<9',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',
@@ -213,7 +213,7 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
         packages                 = setuptools.find_packages(exclude=['deployment']),
         install_requires=[        
             "jupyterlab~=3.0",
-            'ipywidgets~=7.0.0',
+            'ipywidgets>=7,<9',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
             'jupyterlab-widgets~=1.0.0',

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -37,6 +37,7 @@ package_json = json.loads(open('package.json').read())
 lab_path = Path(pjoin(HERE, 'mitosheet', 'labextension'))
 notebook_path = Path(pjoin(HERE, 'mitosheet', 'nbextension'))
 
+python_requires='>=3.4'
 
 # The name of the project
 name = package_json['name']

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -27,7 +27,6 @@ from jupyter_packaging import (
     ensure_targets,
     combine_commands,
     skip_if_exists,
-    ensure_python,
 )
 
 from setuptools import setup
@@ -41,10 +40,6 @@ notebook_path = Path(pjoin(HERE, 'mitosheet', 'nbextension'))
 
 # The name of the project
 name = package_json['name']
-
-# Ensure a valid python version
-ensure_python('>=3.4')
-
 
 if name == 'mitosheet2':
     # Get our version, which we just read 

--- a/mitosheet/src/jupyter/widget.tsx
+++ b/mitosheet/src/jupyter/widget.tsx
@@ -61,12 +61,21 @@ import { AnalysisData, GraphDataBackend, GraphDataDict, GraphParamsBackend, Mito
 import { ModalEnum } from '../components/modals/modals';
 import { convertBackendtoFrontendGraphParams } from '../components/taskpanes/Graph/graphUtils';
 
+
+/**
+ * In IPyWidgets 8.0, the type of parameters we need moved from InitializeParameters
+ * to IInitializeParameters. So we create this fancy conditional types to support
+ * both earlier versions as well, as they are necessary on JupyterLab 2.0. 
+ */
+type InitializeParametersOf<T> = T extends { IInitializeParameters: unknown } ? T["IInitializeParameters"] : (T extends { InitializeParameters: unknown } ? T["InitializeParameters"] : never);
+
+
 export class ExampleView extends DOMWidgetView {
     // Used to make code in the notebook not flash when read in for replaying.
     // See write-code-to-cell below.
     creationSeconds: undefined | number;
 
-    initialize(parameters: WidgetView.IInitializeParameters): void {
+    initialize(parameters: InitializeParametersOf<WidgetView>): void {
         super.initialize(parameters);
 
         // Bind the functions we pass down to other classes

--- a/mitosheet/src/jupyter/widget.tsx
+++ b/mitosheet/src/jupyter/widget.tsx
@@ -66,7 +66,7 @@ export class ExampleView extends DOMWidgetView {
     // See write-code-to-cell below.
     creationSeconds: undefined | number;
 
-    initialize(parameters: WidgetView.InitializeParameters): void {
+    initialize(parameters: WidgetView.IInitializeParameters): void {
         super.initialize(parameters);
 
         // Bind the functions we pass down to other classes

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -8,7 +8,7 @@
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 import { INotebookTracker, NotebookActions } from '@jupyterlab/notebook';
 import { Application, IPlugin } from 'application';
-import { Widget } from 'widgets';
+import { Widget } from "../node_modules/@lumino/widgets/types/widget"
 import MitoAPI from './jupyter/api';
 import { getCellAtIndex, getCellCallingMitoshetWithAnalysis, getCellText, getMostLikelyMitosheetCallingCell, getParentMitoContainer, isEmptyCell, tryOverwriteAnalysisToReplayParameter, tryWriteAnalysisToReplayParameter, writeToCell } from './jupyter/lab/pluginUtils';
 import { containsGeneratedCodeOfAnalysis, containsMitosheetCallWithAnyAnalysisToReplay, getAnalysisNameFromOldGeneratedCode, getArgsFromMitosheetCallCode, getCodeString, getLastNonEmptyLine, isMitosheetCallCode } from './utils/code';

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -8,7 +8,7 @@
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 import { INotebookTracker, NotebookActions } from '@jupyterlab/notebook';
 import { Application, IPlugin } from 'application';
-import { Widget } from "../node_modules/@lumino/widgets/types/widget"
+import { Widget } from "widgetsalias";
 import MitoAPI from './jupyter/api';
 import { getCellAtIndex, getCellCallingMitoshetWithAnalysis, getCellText, getMostLikelyMitosheetCallingCell, getParentMitoContainer, isEmptyCell, tryOverwriteAnalysisToReplayParameter, tryWriteAnalysisToReplayParameter, writeToCell } from './jupyter/lab/pluginUtils';
 import { containsGeneratedCodeOfAnalysis, containsMitosheetCallWithAnyAnalysisToReplay, getAnalysisNameFromOldGeneratedCode, getArgsFromMitosheetCallCode, getCodeString, getLastNonEmptyLine, isMitosheetCallCode } from './utils/code';

--- a/mitosheet/switch.py
+++ b/mitosheet/switch.py
@@ -154,7 +154,7 @@ MITOSHEET_PACKAGE_JSON = """{
   },
   "version": "0.3.131",
   "dependencies": {
-    "@jupyter-widgets/base": "^4",
+    "@jupyter-widgets/base": "^4 || ^5 || ^6",
     "@jupyterlab/notebook": "^3.0.6",
     "@types/fscreen": "^1.0.1",
     "@types/react-dom": "^17.0.2",

--- a/mitosheet/switch.py
+++ b/mitosheet/switch.py
@@ -104,7 +104,7 @@ MITOSHEET_TWO_PACKAGE_JSON = """{
     "@typescript-eslint/eslint-plugin": "^4.4.0",
     "@typescript-eslint/parser": "^4.4.0",
     "acorn": "^8.5.0",
-    "application": "npm:@phospor/application@^1.13.1",
+    "application": "npm:@phosphor/application@^1.7.3",
     "buffer": "^6.0.3",
     "eslint": "^7.19.0",
     "eslint-config-prettier": "^8.3.0",
@@ -119,7 +119,7 @@ MITOSHEET_TWO_PACKAGE_JSON = """{
     "prettier": "^2.0.5",
     "rimraf": "^3.0.2",
     "typescript": "^4.4.3",
-    "widgetsalias": "npm:@phospor/widgets@^1.16.1"
+    "widgetsalias": "npm:@phospor/widgets@^1.9.3"
   },
   "main": "lib/index.js",
   "homepage": "https://github.com/mito-ds/monorepo",

--- a/mitosheet/switch.py
+++ b/mitosheet/switch.py
@@ -104,7 +104,7 @@ MITOSHEET_TWO_PACKAGE_JSON = """{
     "@typescript-eslint/eslint-plugin": "^4.4.0",
     "@typescript-eslint/parser": "^4.4.0",
     "acorn": "^8.5.0",
-    "application": "npm:@phosphor/application@^1.7.3",
+    "application": "npm:@lumino/application@^1.13.1",
     "buffer": "^6.0.3",
     "eslint": "^7.19.0",
     "eslint-config-prettier": "^8.3.0",
@@ -119,7 +119,7 @@ MITOSHEET_TWO_PACKAGE_JSON = """{
     "prettier": "^2.0.5",
     "rimraf": "^3.0.2",
     "typescript": "^4.4.3",
-    "widgets": "npm:@phosphor/widgets@^1.9.3"
+    "widgets": "npm:@lumino/widgets@^1.16.1"
   },
   "main": "lib/index.js",
   "homepage": "https://github.com/mito-ds/monorepo",

--- a/mitosheet/switch.py
+++ b/mitosheet/switch.py
@@ -119,7 +119,7 @@ MITOSHEET_TWO_PACKAGE_JSON = """{
     "prettier": "^2.0.5",
     "rimraf": "^3.0.2",
     "typescript": "^4.4.3",
-    "widgetsalias": "npm:@phospor/widgets@^1.9.3"
+    "widgetsalias": "npm:@phosphor/widgets@^1.9.3"
   },
   "main": "lib/index.js",
   "homepage": "https://github.com/mito-ds/monorepo",

--- a/mitosheet/switch.py
+++ b/mitosheet/switch.py
@@ -104,7 +104,7 @@ MITOSHEET_TWO_PACKAGE_JSON = """{
     "@typescript-eslint/eslint-plugin": "^4.4.0",
     "@typescript-eslint/parser": "^4.4.0",
     "acorn": "^8.5.0",
-    "application": "npm:@lumino/application@^1.13.1",
+    "application": "npm:@phospor/application@^1.13.1",
     "buffer": "^6.0.3",
     "eslint": "^7.19.0",
     "eslint-config-prettier": "^8.3.0",
@@ -119,7 +119,7 @@ MITOSHEET_TWO_PACKAGE_JSON = """{
     "prettier": "^2.0.5",
     "rimraf": "^3.0.2",
     "typescript": "^4.4.3",
-    "widgets": "npm:@lumino/widgets@^1.16.1"
+    "widgetsalias": "npm:@phospor/widgets@^1.16.1"
   },
   "main": "lib/index.js",
   "homepage": "https://github.com/mito-ds/monorepo",
@@ -222,7 +222,7 @@ MITOSHEET_PACKAGE_JSON = """{
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
     "typescript": "^4.4.3",
-    "widgets": "npm:@lumino/widgets@^1.16.1"
+    "widgetsalias": "npm:@lumino/widgets@^1.16.1"
   },
   "main": "lib/index.js",
   "homepage": "https://trymito.io",


### PR DESCRIPTION
# Description

We've observed users installing Mito on Python 3.10+ run into the same issues over and over. 

```
$ python -m mitoinstaller install --no-cache-dir
Starting install...
Upgrade mitoinstaller
Setting up environment
Check dependencies
Remove mitosheet3 if present
Install mitosheet
Activate extension
Traceback (most recent call last):
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/mitoinstaller/installer_steps/installer_step.py", line 44, in execute
    self.execution_function()
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/mitoinstaller/installer_steps/mitosheet_installer_steps.py", line 77, in install_step_mitosheet_activate_notebook_extension
    run_command([sys.executable, "-m", 'jupyter', 'nbextension', 'install', '--py', '--user', 'mitosheet'])
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/mitoinstaller/commands.py", line 50, in run_command
    raise Exception(get_output(completed_process))
Exception: Traceback (most recent call last):
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/bin/jupyter-nbextension", line 8, in <module>
    sys.exit(main())
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/jupyter_core/application.py", line 269, in launch_instance
    return super().launch_instance(argv=argv, **kwargs)
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/traitlets/config/application.py", line 976, in launch_instance
    app.start()
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/nbclassic/nbextensions.py", line 972, in start
    super().start()
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/jupyter_core/application.py", line 258, in start
    self.subapp.start()
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/nbclassic/nbextensions.py", line 702, in start
    self.install_extensions()
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/nbclassic/nbextensions.py", line 675, in install_extensions
    full_dests = install(self.extra_args[0],
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/nbclassic/nbextensions.py", line 203, in install_nbextension_python
    m, nbexts = _get_nbextension_metadata(module)
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/nbclassic/nbextensions.py", line 1107, in _get_nbextension_metadata
    m = import_item(module)
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/traitlets/utils/importstring.py", line 38, in import_item
    return __import__(parts[0])
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/mitosheet/__init__.py", line 31, in <module>
    from mitosheet.mito_widget import MitoWidget, sheet
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/mitosheet/mito_widget.py", line 17, in <module>
    from ipywidgets import DOMWidget
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/ipywidgets/__init__.py", line 25, in <module>
    from .widgets import *
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/ipywidgets/widgets/__init__.py", line 20, in <module>
    from .widget_selection import RadioButtons, ToggleButtons, ToggleButtonsStyle, Dropdown, Select, SelectionSlider, SelectMultiple, SelectionRangeSlider
  File "/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/site-packages/ipywidgets/widgets/widget_selection.py", line 9, in <module>
    from collections import Mapping, Iterable
ImportError: cannot import name 'Mapping' from 'collections' (/Users/aarondiamond-reivich/opt/anaconda3/envs/mitoenv/lib/python3.10/collections/__init__.py)

```
This error is thrown in the ipywidgets codebase. The error is caused because in Python 3.10, instead of importing `from collections import Mapping`, you must import as `from collections.abc import Mapping`.

Ipywdigets 8.0 resolves this import issue. See [here](https://github.com/jupyter-widgets/ipywidgets/blob/3dbd281a7488da6d2e2fc10d14df58041963eaa6/python/ipywidgets/ipywidgets/widgets/widget_selection.py).

This PR updates Mito to work with ipywidgets 8.0

See investigation and documentation about this upgrade process [here](https://www.notion.so/trymito/Python-3-10-Error-cbec7bf27bae42e58083ece3bc052082)

In upgrading my Python version to 3.10, I also ran into issues with the development environmnent. Specifically:
1. `ensure_python` is deprecated on 3.10, so I switched to `python_requires`
2. removing `ensure_python` caused GitHub tests to not pass. I was able to resolve this by following the error message and updating `InitializeParameters` to `IInitializeParameters` in `src/jupyter/widget.tsx`

Fixing 2 above, caused Mito on JupyterLab 2 to not work, however. It says:
```
"src/jupyter/widget.tsx(69,39): error TS2724: '"/Users/aarondiamond-reivich/Documents/saga/monorepo/mitosheet/node_modules/@jupyter-widgets/base/lib/widget".WidgetView' has no exported member named 'IInitializeParameters'. Did you mean 'InitializeParameters'?"
```

# Testing

To test:
1. Install python 3.10
2. Checkout the main branch
4. Remove the ensure_python import and use in the setup.py file
5. Create a new virtual evironment and run the commands to start Mito (note you might need to install a xcode upgrade, just read the error message)
6. Notice that that you receive the error ` ImportError("cannot import name 'Mapping' from 'collections' `
7. Checkout this branch
8. Create a new virtual evironment and run the commands to start Mito
9. See that Mito works 

# Documentation

Note if any new documentation needs to addressed or reviewed.