### PR TITLE
mitosheet: bump ipywidgets and jupyterlab-widgets versions

### DIFF
--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -24,6 +24,10 @@ jobs:
             pandas-version: '1.3.5'
           - python-version: 3.8
             pandas-version: '0.24.2'
+          - python-version: 3.9
+            pandas-version: '0.24.2'
+          - python-version: "3.10"
+            pandas-version: '0.24.2'
 
     steps:
     - name: Cancel Previous Runs

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
         pandas-version: ['0.24.2', '1.1.5', '1.3.5']
         exclude:
           - python-version: 3.6

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         pandas-version: ['0.24.2', '1.1.5', '1.3.5']
         exclude:
           - python-version: 3.6

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
         pandas-version: ['0.24.2', '1.1.5', '1.3.5']
         exclude:
           - python-version: 3.6

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -209,10 +209,10 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
         packages                 = setuptools.find_packages(exclude=['deployment']),
         install_requires=[        
             "jupyterlab~=3.0",
-            'ipywidgets>=8,<9',
+            'ipywidgets~=8',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
-            'jupyterlab_widgets>=3',
+            'jupyterlab_widgets~=3',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -212,7 +212,7 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
             'ipywidgets>=7.0',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
-            'jupyterlab-widgets~=3.0',
+            'jupyterlab-widgets>=2.0',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -208,7 +208,7 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
         cmdclass                 = cmdclass,
         packages                 = setuptools.find_packages(exclude=['deployment']),
         install_requires=[        
-            "jupyterlab~=3.0",
+            "jupyterlab>=3.0",
             'ipywidgets>=7.0',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -209,7 +209,7 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
         packages                 = setuptools.find_packages(exclude=['deployment']),
         install_requires=[        
             "jupyterlab~=3.0",
-            'ipywidgets~=8.0',
+            'ipywidgets~=7.0,8.0',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
             'jupyterlab-widgets~=3.0',

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -209,10 +209,10 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
         packages                 = setuptools.find_packages(exclude=['deployment']),
         install_requires=[        
             "jupyterlab~=3.0",
-            'ipywidgets>=7,<9',
+            'ipywidgets>=8,<9',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
-            'jupyterlab-widgets>=1.0.0',
+            'jupyterlab-widgets>=3.0.0',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -209,7 +209,7 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
         packages                 = setuptools.find_packages(exclude=['deployment']),
         install_requires=[        
             "jupyterlab~=3.0",
-            'ipywidgets~=7.0,8.0',
+            'ipywidgets>=7.0',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
             'jupyterlab-widgets~=3.0',

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -209,10 +209,10 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
         packages                 = setuptools.find_packages(exclude=['deployment']),
         install_requires=[        
             "jupyterlab~=3.0",
-            'ipywidgets~=8',
+            'ipywidgets~=8.0',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
-            'jupyterlab_widgets~=3',
+            'jupyterlab_widgets~=3.0',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -249,10 +249,10 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
             "License :: OSI Approved :: GNU Affero General Public License v3",
             "Programming Language :: Python",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Framework :: Jupyter",
         ],
     )

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -212,7 +212,7 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
             'ipywidgets~=8.0',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
-            'jupyterlab_widgets~=3.0',
+            'jupyterlab-widgets~=3.0',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -212,7 +212,7 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
             'ipywidgets>=8,<9',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
-            'jupyterlab-widgets>=3.0.0',
+            'jupyterlab-widgets>=3',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -212,7 +212,7 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
             'ipywidgets>=8,<9',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
-            'jupyterlab-widgets>=3',
+            'jupyterlab_widgets>=3',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',


### PR DESCRIPTION
# Description

- Bumps ipywidgets on the mitosheet package to version 8
- Bumps jupyterlab-widgets on the mitosheet package to version 3, which is required by ipywidgets 8
