### PR TITLE
Button

### DIFF
--- a/mitosheet/css/mito.css
+++ b/mitosheet/css/mito.css
@@ -2,6 +2,19 @@
     --taskpane-width: 430px;
 }
 
+:root .toolbar-mito-button-class {
+    background-color: var(--mito-purple);
+    border-radius: 3px;
+}
+
+:root .toolbar-mito-button-class:hover {
+    background-color: var(--mito-medium-purple);
+}
+
+:root .toolbar-mito-button-class .jp-ToolbarButtonComponent-label {
+    color: white !important;
+}
+
 /* 
     We override the the overflow behavior on the jupyter-widgets class, which 
     seems to only be applied to the container of the widgets themselves (e.g.

--- a/mitosheet/css/mito.css
+++ b/mitosheet/css/mito.css
@@ -3,16 +3,12 @@
 }
 
 :root .toolbar-mito-button-class {
-    background-color: var(--mito-purple);
+    background-color: var(--mito-very-light-purple);
     border-radius: 3px;
 }
 
-:root .toolbar-mito-button-class:hover {
-    background-color: var(--mito-medium-purple);
-}
-
 :root .toolbar-mito-button-class .jp-ToolbarButtonComponent-label {
-    color: white !important;
+    color: var(--mito-purple);
 }
 
 /* 

--- a/mitosheet/css/mito.css
+++ b/mitosheet/css/mito.css
@@ -2,14 +2,20 @@
     --taskpane-width: 430px;
 }
 
-:root .toolbar-mito-button-class {
+/* 
+    The following two css rules are used to style the Create new Mitosheet button in the notebook toolbar. 
+    The pure css selectors are used for the JLab button, and the id selection is used for the notebook 
+    button, since we're not able to set the class name of our button in notebooks. 
+*/
+:root .toolbar-mito-button-class, #create_mitosheet {
     background-color: var(--mito-very-light-purple);
     border-radius: 3px;
 }
 
-:root .toolbar-mito-button-class .jp-ToolbarButtonComponent-label {
+:root .toolbar-mito-button-class .jp-ToolbarButtonComponent-label, #create_mitosheet {
     color: var(--mito-purple);
 }
+
 
 /* 
     We override the the overflow behavior on the jupyter-widgets class, which 

--- a/mitosheet/css/mito.css
+++ b/mitosheet/css/mito.css
@@ -10,6 +10,7 @@
 :root .toolbar-mito-button-class, #create_mitosheet {
     background-color: var(--mito-very-light-purple);
     border-radius: 3px;
+    border: .5px solid var(--mito-light-gray);
 }
 
 :root .toolbar-mito-button-class .jp-ToolbarButtonComponent-label, #create_mitosheet {

--- a/mitosheet/css/mito.css
+++ b/mitosheet/css/mito.css
@@ -7,13 +7,13 @@
     The pure css selectors are used for the JLab button, and the id selection is used for the notebook 
     button, since we're not able to set the class name of our button in notebooks. 
 */
-:root .toolbar-mito-button-class, #create_mitosheet {
+:root .toolbar-mito-button-class, #mito-toolbar-button-id {
     background-color: var(--mito-very-light-purple);
     border-radius: 3px;
     border: .5px solid var(--mito-light-gray);
 }
 
-:root .toolbar-mito-button-class .jp-ToolbarButtonComponent-label, #create_mitosheet {
+:root .toolbar-mito-button-class .jp-ToolbarButtonComponent-label, #mito-toolbar-button-id {
     color: var(--mito-purple);
 }
 

--- a/mitosheet/src/components/icons/JLabIcon/MitoIcon.ts
+++ b/mitosheet/src/components/icons/JLabIcon/MitoIcon.ts
@@ -3,8 +3,16 @@ import { LabIcon } from '@jupyterlab/ui-components';
 
 export const mitoJLabIcon = new LabIcon({
     name: 'mitosheet:mitosheet-jlab-icon',
-    svgstr: '<svg width="7" height="11" viewBox="0 0 7 11" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="0.871094" y="2.87109" width="5.52567" height="5.3994" fill="#D0B9FE"/><ellipse cx="3.63393" cy="2.80053" rx="2.76283" ry="2.0603" fill="#D0B9FE"/><ellipse cx="3.63393" cy="8.20092" rx="2.76283" ry="2.0603" fill="#D0B9FE"/></svg>'
-
+    svgstr: '<svg width="7" height="11" viewBox="0 0 7 11" fill="none" xmlns="http://www.w3.org/2000/svg">\
+    <rect x="0.871094" y="2.87109" width="5.52567" height="5.3994" fill="#D0B9FE"/>\
+    <ellipse cx="3.63393" cy="2.80053" rx="2.76283" ry="2.0603" fill="#D0B9FE"/>\
+    <ellipse cx="3.63393" cy="8.20092" rx="2.76283" ry="2.0603" fill="#D0B9FE"/>\
+    <path d="M0.871094 2.94922H3.2966C3.57827 2.94922 3.80661 3.17755 3.80661 3.45922V3.45922C3.80661 3.74088 3.57827 3.96922 3.29661 3.96922H0.871094V2.94922Z" fill="#9D6CFF"/>\
+    <path d="M0.871094 7.03125H3.2966C3.57827 7.03125 3.80661 7.25958 3.80661 7.54125V7.54125C3.80661 7.82292 3.57827 8.05125 3.29661 8.05125H0.871094V7.03125Z" fill="#9D6CFF"/>\
+    <path d="M6.39673 4.99023H3.97122C3.68955 4.99023 3.46122 5.21857 3.46122 5.50023V5.50023C3.46122 5.7819 3.68955 6.01023 3.97122 6.01023H6.39673V4.99023Z" fill="#9D6CFF"/>\
+    </svg>'
 });
+
+
 
 

--- a/mitosheet/src/components/icons/JLabIcon/MitoIcon.ts
+++ b/mitosheet/src/components/icons/JLabIcon/MitoIcon.ts
@@ -1,0 +1,10 @@
+import { LabIcon } from '@jupyterlab/ui-components';
+
+
+export const mitoJLabIcon = new LabIcon({
+    name: 'mitosheet:mitosheet-jlab-icon',
+    svgstr: '<svg width="7" height="11" viewBox="0 0 7 11" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="0.871094" y="2.87109" width="5.52567" height="5.3994" fill="#D0B9FE"/><ellipse cx="3.63393" cy="2.80053" rx="2.76283" ry="2.0603" fill="#D0B9FE"/><ellipse cx="3.63393" cy="8.20092" rx="2.76283" ry="2.0603" fill="#D0B9FE"/></svg>'
+
+});
+
+

--- a/mitosheet/src/jupyter/notebook/extension.tsx
+++ b/mitosheet/src/jupyter/notebook/extension.tsx
@@ -28,13 +28,12 @@ if (window.require) {
 // Try to add a button
 (window as any).Jupyter?.toolbar.add_buttons_group([{
     id : 'create_mitosheet',
-    label : 'Mito',
+    label : 'Create new Mitosheet',
     icon: 'test',
     callback : () => {
-        // TODO: make this work here
-        console.log("Create a mitosheet")
         writeEmptyMitosheetCell()
     },
+    className: 'toolbar-mito-button-class'
 }]);
 
 // Export the required load_ipython_extension

--- a/mitosheet/src/jupyter/notebook/extension.tsx
+++ b/mitosheet/src/jupyter/notebook/extension.tsx
@@ -27,8 +27,8 @@ if (window.require) {
 
 // Try to add a button
 (window as any).Jupyter?.toolbar.add_buttons_group([{
-    id : 'create_mitosheet', // Since we're unable to set the className, we use the id for styling
-    label : 'Create new Mitosheet',
+    id : 'mito-toolbar-button-id', // Since we're unable to set the className, we use the id for styling
+    label : 'Create New Mitosheet',
     title: 'Create a blank Mitosheet below the active code cell',
     icon: 'fa-regular fa-table', // For now we use a font awesome icon, since we can't load our icon -- this is what Jupyter suggests
     callback : () => {

--- a/mitosheet/src/jupyter/notebook/extension.tsx
+++ b/mitosheet/src/jupyter/notebook/extension.tsx
@@ -30,7 +30,7 @@ if (window.require) {
     id : 'create_mitosheet', // Since we're unable to set the className, we use the id for styling
     label : 'Create new Mitosheet',
     title: 'Create a blank Mitosheet below the active code cell',
-    icon: 'mito-noteboook-toolbar',
+    icon: 'fa-regular fa-table', // For now we use a font awesome icon, since we can't load our icon -- this is what Jupyter suggests
     callback : () => {
         writeEmptyMitosheetCell()
     },

--- a/mitosheet/src/jupyter/notebook/extension.tsx
+++ b/mitosheet/src/jupyter/notebook/extension.tsx
@@ -28,13 +28,13 @@ if (window.require) {
 // Try to add a button
 (window as any).Jupyter?.toolbar.add_buttons_group([{
     id : 'create_mitosheet',
-    label : 'Changed',
+    label : 'Mito',
     icon: 'test',
     callback : () => {
         // TODO: make this work here
         console.log("Create a mitosheet")
         writeEmptyMitosheetCell()
-    }
+    },
 }]);
 
 // Export the required load_ipython_extension

--- a/mitosheet/src/jupyter/notebook/extension.tsx
+++ b/mitosheet/src/jupyter/notebook/extension.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 
-import { writeEmptyMitosheetCell } from "./pluginUtils";
+import { writeEmptyMitosheetCell } from "./pluginUtils"; 
 
 // This file contains the javascript that is run when the notebook is loaded.
 // It contains some requirejs configuration and the `load_ipython_extension`
@@ -28,8 +28,8 @@ if (window.require) {
 // Try to add a button
 (window as any).Jupyter?.toolbar.add_buttons_group([{
     id : 'create_mitosheet',
-    label : 'Mito',
-    icon : 'Test',
+    label : 'Changed',
+    icon: 'test',
     callback : () => {
         // TODO: make this work here
         console.log("Create a mitosheet")

--- a/mitosheet/src/jupyter/notebook/extension.tsx
+++ b/mitosheet/src/jupyter/notebook/extension.tsx
@@ -27,13 +27,13 @@ if (window.require) {
 
 // Try to add a button
 (window as any).Jupyter?.toolbar.add_buttons_group([{
-    id : 'create_mitosheet',
+    id : 'create_mitosheet', // Since we're unable to set the className, we use the id for styling
     label : 'Create new Mitosheet',
-    icon: 'test',
+    title: 'Create a blank Mitosheet below the active code cell',
+    icon: 'mito-noteboook-toolbar',
     callback : () => {
         writeEmptyMitosheetCell()
     },
-    className: 'toolbar-mito-button-class'
 }]);
 
 // Export the required load_ipython_extension

--- a/mitosheet/src/jupyter/notebook/extension.tsx
+++ b/mitosheet/src/jupyter/notebook/extension.tsx
@@ -1,5 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 
+import { writeEmptyMitosheetCell } from "./pluginUtils";
+
 // This file contains the javascript that is run when the notebook is loaded.
 // It contains some requirejs configuration and the `load_ipython_extension`
 // which is required for any notebook extension.
@@ -22,6 +24,18 @@ if (window.require) {
         }
     });
 }
+
+// Try to add a button
+(window as any).Jupyter?.toolbar.add_buttons_group([{
+    id : 'create_mitosheet',
+    label : 'Mito',
+    icon : 'Test',
+    callback : () => {
+        // TODO: make this work here
+        console.log("Create a mitosheet")
+        writeEmptyMitosheetCell()
+    }
+}]);
 
 // Export the required load_ipython_extension
 module.exports = {

--- a/mitosheet/src/jupyter/notebook/pluginUtils.tsx
+++ b/mitosheet/src/jupyter/notebook/pluginUtils.tsx
@@ -254,6 +254,9 @@ export const notebookWriteGeneratedCodeToCell = (analysisName: string, codeLines
 }
 
 
+
+
+
 export const writeEmptyMitosheetCell = () => {
     // Create a new cell below the active code cell
     (window as any).Jupyter?.notebook?.insert_cell_below();
@@ -265,5 +268,4 @@ export const writeEmptyMitosheetCell = () => {
         writeToCell(activeCell, 'import mitosheet\nmitosheet.sheet()');
         (window as any).Jupyter?.notebook?.execute_cell();
     }
-
 }

--- a/mitosheet/src/jupyter/notebook/pluginUtils.tsx
+++ b/mitosheet/src/jupyter/notebook/pluginUtils.tsx
@@ -253,3 +253,13 @@ export const notebookWriteGeneratedCodeToCell = (analysisName: string, codeLines
     }
 }
 
+
+export const writeEmptyMitosheetCell = () => {
+    const activeCell = (window as any).Jupyter?.notebook?.get_cell((window as any).Jupyter?.notebook?.get_anchor_index());
+    if (isEmptyCell(activeCell)) {
+        console.log("IS empty, writing", activeCell)
+        writeToCell(activeCell, 'import mitosheet\nmitosheet.sheet()');
+        (window as any).Jupyter?.notebook?.execute_cell();
+    }
+
+}

--- a/mitosheet/src/jupyter/notebook/pluginUtils.tsx
+++ b/mitosheet/src/jupyter/notebook/pluginUtils.tsx
@@ -255,9 +255,13 @@ export const notebookWriteGeneratedCodeToCell = (analysisName: string, codeLines
 
 
 export const writeEmptyMitosheetCell = () => {
+    // Create a new cell below the active code cell
+    (window as any).Jupyter?.notebook?.insert_cell_below();
+    (window as any).Jupyter?.notebook?.select_next();
     const activeCell = (window as any).Jupyter?.notebook?.get_cell((window as any).Jupyter?.notebook?.get_anchor_index());
+
+    // Add mitosheet.sheet call to new code cell
     if (isEmptyCell(activeCell)) {
-        console.log("IS empty, writing", activeCell)
         writeToCell(activeCell, 'import mitosheet\nmitosheet.sheet()');
         (window as any).Jupyter?.notebook?.execute_cell();
     }

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -14,13 +14,11 @@ import { getCellAtIndex, getCellCallingMitoshetWithAnalysis, getCellText, getMos
 import { containsGeneratedCodeOfAnalysis, containsMitosheetCallWithAnyAnalysisToReplay, getAnalysisNameFromOldGeneratedCode, getArgsFromMitosheetCallCode, getCodeString, getLastNonEmptyLine, isMitosheetCallCode } from './utils/code';
 import { MODULE_NAME, MODULE_VERSION } from './version';
 import * as widgetExports from './jupyter/widget';
+import { mitoJLabIcon } from './components/icons/JLabIcon/MitoIcon';
 
 import {
     ToolbarButton,
-    showDialog
 } from '@jupyterlab/apputils';
-import { mitoJLabIcon } from './components/icons/JLabIcon/MitoIcon';
-import React from 'react';
 
 
 const EXTENSION_ID = 'mitosheet:plugin';
@@ -35,30 +33,19 @@ const addButton = (tracker: INotebookTracker) => {
         onClick: (): void => {
             window.commands?.execute('create-empty-mitosheet');
         },
-        tooltip: 'New Mito button',
-        label: 'Mito',
+        tooltip: 'Create a blank Mitosheet below the active code cell',
+        label: 'Create new Mitosheet',
     });
 
     const panel = tracker.currentWidget;
 
     if (panel) {
         console.log("Adding button!")
-        const added = panel.toolbar.addItem('Test', button);
+        const added = panel.toolbar.insertAfter('cellType', 'Create Mito Button', button, );
         console.log("Added", added)
     } else {
         console.log("No panel")
     }
-
-}
-
-const addDialog = (tracker: INotebookTracker) => {
-
-    console.log("Adding dialog to ", tracker)
-
-    void showDialog({
-        title: 'hello nate',
-        body: <input placeholder='testing'></input>,
-    });
 
 }
 
@@ -91,7 +78,6 @@ function activateWidgetExtension(
 
     setTimeout(() => {
         addButton(tracker);
-        addDialog(tracker);
     }, 10000)
 
 

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -78,7 +78,7 @@ function activateWidgetExtension(
 
     setTimeout(() => {
         addButton(tracker);
-    }, 500)
+    }, 1000)
 
 
     app.commands.addCommand('write-analysis-to-replay-to-mitosheet-call', {

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -25,8 +25,6 @@ const EXTENSION_ID = 'mitosheet:plugin';
 
 const addButton = (tracker: INotebookTracker) => {
 
-    console.log("Adding button to ", tracker)
-
     const button = new ToolbarButton({
         className: 'toolbar-mito-button-class',
         icon: mitoJLabIcon,
@@ -40,11 +38,9 @@ const addButton = (tracker: INotebookTracker) => {
     const panel = tracker.currentWidget;
 
     if (panel) {
-        console.log("Adding button!")
-        const added = panel.toolbar.insertAfter('cellType', 'Create Mito Button', button, );
-        console.log("Added", added)
+        panel.toolbar.insertAfter('cellType', 'Create Mito Button', button);
     } else {
-        console.log("No panel")
+        console.log("Unable to insert Create Mito Button because the Notebook Panel was undefined")
     }
 
 }
@@ -74,9 +70,9 @@ function activateWidgetExtension(
     registry: IJupyterWidgetRegistry,
     tracker: INotebookTracker
 ): void {
-    console.log("Running activate!");
 
     setTimeout(() => {
+        // Add the Create new Mitosheet button after a short delay so everything is defined
         addButton(tracker);
     }, 1000)
 

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -20,6 +20,7 @@ import {
     showDialog
 } from '@jupyterlab/apputils';
 import { mitoJLabIcon } from './components/icons/JLabIcon/MitoIcon';
+import React from 'react';
 
 
 const EXTENSION_ID = 'mitosheet:plugin';
@@ -54,11 +55,9 @@ const addDialog = (tracker: INotebookTracker) => {
 
     console.log("Adding dialog to ", tracker)
 
-    const body = 'this is a dialog box';
-
     void showDialog({
         title: 'hello nate',
-        body,
+        body: <input placeholder='testing'></input>,
     });
 
 }

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -32,7 +32,7 @@ const addButton = (tracker: INotebookTracker) => {
             window.commands?.execute('create-empty-mitosheet');
         },
         tooltip: 'Create a blank Mitosheet below the active code cell',
-        label: 'Create new Mitosheet',
+        label: 'Create New Mitosheet',
     });
 
     const panel = tracker.currentWidget;
@@ -72,7 +72,7 @@ function activateWidgetExtension(
 ): void {
 
     setTimeout(() => {
-        // Add the Create new Mitosheet button after a short delay so everything is defined
+        // Add the Create New Mitosheet button after a short delay so everything is defined
         addButton(tracker);
     }, 1000)
 

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -17,6 +17,7 @@ import * as widgetExports from './jupyter/widget';
 
 import {
     ToolbarButton,
+    showDialog
 } from '@jupyterlab/apputils';
 import { mitoJLabIcon } from './components/icons/JLabIcon/MitoIcon';
 
@@ -49,6 +50,19 @@ const addButton = (tracker: INotebookTracker) => {
 
 }
 
+const addDialog = (tracker: INotebookTracker) => {
+
+    console.log("Adding dialog to ", tracker)
+
+    const body = 'this is a dialog box';
+
+    void showDialog({
+        title: 'hello nate',
+        body,
+    });
+
+}
+
 /**
  * The example plugin.
  */
@@ -78,6 +92,7 @@ function activateWidgetExtension(
 
     setTimeout(() => {
         addButton(tracker);
+        addDialog(tracker);
     }, 10000)
 
 

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -18,6 +18,7 @@ import * as widgetExports from './jupyter/widget';
 import {
     ToolbarButton,
 } from '@jupyterlab/apputils';
+import { mitoJLabIcon } from './components/icons/JLabIcon/MitoIcon';
 
 
 const EXTENSION_ID = 'mitosheet:plugin';
@@ -28,7 +29,7 @@ const addButton = (tracker: INotebookTracker) => {
 
     const button = new ToolbarButton({
         className: 'toolbar-mito-button-class',
-        iconClass: 'test',
+        icon: mitoJLabIcon,
         onClick: (): void => {
             window.commands?.execute('create-empty-mitosheet');
         },

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -78,7 +78,7 @@ function activateWidgetExtension(
 
     setTimeout(() => {
         addButton(tracker);
-    }, 10000)
+    }, 500)
 
 
     app.commands.addCommand('write-analysis-to-replay-to-mitosheet-call', {

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -309,9 +309,6 @@ function activateWidgetExtension(
             const context = tracker.currentWidget?.context;
             if (!notebook || !context) return;
 
-            // Clear the output of the active cell
-            NotebookActions.clearOutputs(notebook)
-
             // Create a new code cell that creates a blank mitosheet
             NotebookActions.insertBelow(notebook);
             const newActiveCell = notebook.activeCell;

--- a/mitosheet/src/plugin.tsx
+++ b/mitosheet/src/plugin.tsx
@@ -27,7 +27,7 @@ const addButton = (tracker: INotebookTracker) => {
     console.log("Adding button to ", tracker)
 
     const button = new ToolbarButton({
-        className: 'test',
+        className: 'toolbar-mito-button-class',
         iconClass: 'test',
         onClick: (): void => {
             window.commands?.execute('create-empty-mitosheet');


### PR DESCRIPTION
# Description

Adds a `Create new Mitosheet` button to the Jupyter toolbar, following the spec [here](https://www.notion.so/trymito/Roadmap-10671f3f6d53416ab6efeabcce7daf62?p=42a065dd923f4bd9a6ab2d6975fe9534&pm=s)

Tested on:
- Mac, JLab
- Mac, Notebook <- the styling of the button isn't applied until the first mitosheet is rendered.
- Windows, JLab
- Windows, Notebook <- the styling of the button isn't applied until the first mitosheet is rendered.

Note: In notebooks, we also don't display the `View full df in Mito` button. So my guess is that this has something to do with the mito widget not being activated. 

# Testing

Test in Windows/Mac, Notebook/Lab. 

# Documentation

To be added in release process. 