### PR TITLE
mitosheet: make experiment always go to B

### DIFF
--- a/mitoinstaller/mitoinstaller/experiments/experiment_utils.py
+++ b/mitoinstaller/mitoinstaller/experiments/experiment_utils.py
@@ -3,8 +3,10 @@ from typing import Dict, Optional
 
 
 def get_random_variant() -> str:
-    """Returns "A" or "B" with 50% probability"""
-    return "A" if random.random() < 0.5 else "B"
+    """Returns "A" or "B" with 50% probability
+    
+    Currently, as we have no experiment, only returns B"""
+    return "B"
 
 def get_new_experiment() -> Dict[str, str]:
     # NOTE: this needs to match the mitosheet package!

--- a/mitosheet/mitosheet/experiments/experiment_utils.py
+++ b/mitosheet/mitosheet/experiments/experiment_utils.py
@@ -24,8 +24,11 @@ from typing import Dict, Optional
 from mitosheet.user.db import USER_JSON_PATH, get_user_field
 
 def get_random_variant() -> str:
-    """Returns "A" or "B" with 50% probability"""
-    return "A" if random.random() < 0.5 else "B"
+    """Returns "A" or "B" with 50% probability
+    
+    Currently, as we have no experiment, only returns option B!
+    """
+    return "B"
 
 def get_new_experiment() -> Dict[str, str]:
     # NOTE: this needs to match the installer!


### PR DESCRIPTION
# Description

This is a much better easier hack than the other hack we used to remove the experiment -- I'm super happy with this simplification!

We def need to iterate the AB test infrastructure, but given that we're using it, pretty low priority! I also noted that the experiment ended today in the tracker, so we don't get confused when it stops!

# Testing

Test you get B!

# Documentation

No.