### PR TITLE
Bulk change dtype

### DIFF
--- a/mitosheet/mitosheet/code_chunks/step_performers/column_steps/change_column_dtype_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/column_steps/change_column_dtype_code_chunk.py
@@ -4,8 +4,10 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 
-from typing import List
+from typing import Any, List, Optional
 from mitosheet.code_chunks.code_chunk import CodeChunk
+from mitosheet.types import ColumnID
+from mitosheet.state import State
 
 from mitosheet.errors import make_invalid_column_type_change_error
 from mitosheet.sheet_functions.types.utils import (get_datetime_format,
@@ -16,6 +18,117 @@ from mitosheet.sheet_functions.types.utils import (get_datetime_format,
                                                    is_string_dtype,
                                                    is_timedelta_dtype)
 from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_code
+
+
+def get_conversion_code(state: State, sheet_index: int, column_id: ColumnID, old_dtype: str, new_dtype: str) -> Optional[str]:
+    
+    column_header = state.column_ids.get_column_header_by_id(sheet_index, column_id)
+    transpiled_column_header = column_header_to_transpiled_code(column_header)
+    df_name = state.df_names[sheet_index]
+    column = state.dfs[sheet_index][column_header]
+
+    if is_bool_dtype(old_dtype):
+        if is_bool_dtype(new_dtype):
+            return None
+        elif is_int_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].astype(\'int\')'
+        elif is_float_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].astype(\'float\')'
+        elif is_string_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].astype(\'str\')'
+        elif is_datetime_dtype(new_dtype):
+            raise make_invalid_column_type_change_error(
+                column_header,
+                old_dtype,
+                new_dtype
+            )
+        elif is_timedelta_dtype(new_dtype):
+            raise make_invalid_column_type_change_error(
+                column_header,
+                old_dtype,
+                new_dtype
+            )
+    elif is_int_dtype(old_dtype):
+        if is_bool_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].fillna(False).astype(\'bool\')'
+        elif is_int_dtype(new_dtype):
+            return None
+        elif is_float_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].astype(\'float\')'
+        elif is_string_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].astype(\'str\')'
+        elif is_datetime_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = pd.to_datetime({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
+        elif is_timedelta_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = pd.to_timedelta({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
+    elif is_float_dtype(old_dtype):
+        if is_bool_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].fillna(False).astype(\'bool\')'
+        elif is_int_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].fillna(0).astype(\'int\')'
+        elif is_float_dtype(new_dtype):
+            return None
+        elif is_string_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].astype(\'str\')'
+        elif is_datetime_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = pd.to_datetime({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
+        elif is_timedelta_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = pd.to_timedelta({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
+    elif is_string_dtype(old_dtype):
+        if is_bool_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = to_boolean_series({df_name}[{transpiled_column_header}])'
+        elif is_int_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = to_int_series({df_name}[{transpiled_column_header}])'
+        elif is_float_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = to_float_series({df_name}[{transpiled_column_header}])'
+        elif is_string_dtype(new_dtype):
+            return None
+        elif is_datetime_dtype(new_dtype):
+            # Guess the datetime format to the best of Pandas abilities
+            datetime_format = get_datetime_format(column)
+            if datetime_format is not None:
+                return f'{df_name}[{transpiled_column_header}] = pd.to_datetime({df_name}[{transpiled_column_header}], format=\'{datetime_format}\', errors=\'coerce\')'
+            else:
+                return f'{df_name}[{transpiled_column_header}] = pd.to_datetime({df_name}[{transpiled_column_header}], infer_datetime_format=True, errors=\'coerce\')'
+        elif is_timedelta_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = pd.to_timedelta({df_name}[{transpiled_column_header}], errors=\'coerce\')'
+    elif is_datetime_dtype(old_dtype):
+        if is_bool_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = ~{df_name}[{transpiled_column_header}].isnull()'
+        elif is_int_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].astype(\'int\') / 10**9'
+        elif is_float_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].astype(\'int\').astype(\'float\') / 10**9'
+        elif is_string_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].dt.strftime(\'%Y-%m-%d %X\')'
+        elif is_datetime_dtype(new_dtype):
+            return None
+        elif is_timedelta_dtype(new_dtype):
+            raise make_invalid_column_type_change_error(
+                column_header,
+                old_dtype,
+                new_dtype
+            )
+    elif is_timedelta_dtype(old_dtype):
+        if is_bool_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = ~{df_name}[{transpiled_column_header}].isnull()'
+        elif is_int_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].dt.total_seconds().astype(\'int\')'
+        elif is_float_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].dt.total_seconds()'
+        elif is_string_dtype(new_dtype):
+            return f'{df_name}[{transpiled_column_header}] = {df_name}[{transpiled_column_header}].astype(\'str\')'
+        elif is_datetime_dtype(new_dtype):
+            raise make_invalid_column_type_change_error(
+                column_header,
+                old_dtype,
+                new_dtype
+            )
+        elif is_timedelta_dtype(new_dtype):
+            return None
+
+    return None
+    
 
 
 
@@ -37,126 +150,22 @@ class ChangeColumnDtypeCodeChunk(CodeChunk):
         old_dtypes = self.get_param('old_dtypes')
         new_dtype = self.get_param('new_dtype')
 
-        df_name = self.post_state.df_names[sheet_index]
-
-        code = []
 
         # Note: we can't actually group all the headers together in one conversion, and not every dtype can be converted
         # to the target dtype in the same way. Even if they have the same old_dtype, this still might not work in the case
-        # of converting to datetimes. We wait on doing this for now, depending on if we think the complexity is worth it!
+        # of converting to datetimes. It ends up being really hard to actually group these together (>50+ lines of relatively
+        # dense and complex code), so we avoid it for now.
 
+        code = []
         for column_id in column_ids:
             old_dtype = old_dtypes[column_id]
-            column_header = self.post_state.column_ids.get_column_header_by_id(sheet_index, column_id)
-            transpiled_column_header = column_header_to_transpiled_code(column_header)
 
-            column = self.prev_state.dfs[sheet_index][column_header]
-
-            conversion_code = f'{df_name}[{transpiled_column_header}]'
-            if is_bool_dtype(old_dtype):
-                if is_bool_dtype(new_dtype):
-                    pass
-                elif is_int_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'int\')'
-                elif is_float_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'float\')'
-                elif is_string_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'str\')'
-                elif is_datetime_dtype(new_dtype):
-                    raise make_invalid_column_type_change_error(
-                        column_header,
-                        old_dtype,
-                        new_dtype
-                    )
-                elif is_timedelta_dtype(new_dtype):
-                    raise make_invalid_column_type_change_error(
-                        column_header,
-                        old_dtype,
-                        new_dtype
-                    )
-            elif is_int_dtype(old_dtype):
-                if is_bool_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].fillna(False).astype(\'bool\')'
-                elif is_int_dtype(new_dtype):
-                    pass
-                elif is_float_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'float\')'
-                elif is_string_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'str\')'
-                elif is_datetime_dtype(new_dtype):
-                    conversion_code = f'pd.to_datetime({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
-                elif is_timedelta_dtype(new_dtype):
-                    conversion_code = f'pd.to_timedelta({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
-            elif is_float_dtype(old_dtype):
-                if is_bool_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].fillna(False).astype(\'bool\')'
-                elif is_int_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].fillna(0).astype(\'int\')'
-                elif is_float_dtype(new_dtype):
-                    pass
-                elif is_string_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'str\')'
-                elif is_datetime_dtype(new_dtype):
-                    conversion_code = f'pd.to_datetime({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
-                elif is_timedelta_dtype(new_dtype):
-                    conversion_code = f'pd.to_timedelta({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
-            elif is_string_dtype(old_dtype):
-                if is_bool_dtype(new_dtype):
-                    conversion_code = f'to_boolean_series({df_name}[{transpiled_column_header}])'
-                elif is_int_dtype(new_dtype):
-                    conversion_code = f'to_int_series({df_name}[{transpiled_column_header}])'
-                elif is_float_dtype(new_dtype):
-                    conversion_code = f'to_float_series({df_name}[{transpiled_column_header}])'
-                elif is_string_dtype(new_dtype):
-                    pass
-                elif is_datetime_dtype(new_dtype):
-                    # Guess the datetime format to the best of Pandas abilities
-                    datetime_format = get_datetime_format(column)
-                    if datetime_format is not None:
-                        conversion_code = f'pd.to_datetime({df_name}[{transpiled_column_header}], format=\'{datetime_format}\', errors=\'coerce\')'
-                    else:
-                        conversion_code = f'pd.to_datetime({df_name}[{transpiled_column_header}], infer_datetime_format=True, errors=\'coerce\')'
-                elif is_timedelta_dtype(new_dtype):
-                    conversion_code = f'pd.to_timedelta({df_name}[{transpiled_column_header}], errors=\'coerce\')'
-            elif is_datetime_dtype(old_dtype):
-                if is_bool_dtype(new_dtype):
-                    conversion_code = f'~{df_name}[{transpiled_column_header}].isnull()'
-                elif is_int_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'int\') / 10**9'
-                elif is_float_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'int\').astype(\'float\') / 10**9'
-                elif is_string_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].dt.strftime(\'%Y-%m-%d %X\')'
-                elif is_datetime_dtype(new_dtype):
-                    pass
-                elif is_timedelta_dtype(new_dtype):
-                    raise make_invalid_column_type_change_error(
-                        column_header,
-                        old_dtype,
-                        new_dtype
-                    )
-            elif is_timedelta_dtype(old_dtype):
-                if is_bool_dtype(new_dtype):
-                    conversion_code = f'~{df_name}[{transpiled_column_header}].isnull()'
-                elif is_int_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].dt.total_seconds().astype(\'int\')'
-                elif is_float_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].dt.total_seconds()'
-                elif is_string_dtype(new_dtype):
-                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'str\')'
-                elif is_datetime_dtype(new_dtype):
-                    raise make_invalid_column_type_change_error(
-                        column_header,
-                        old_dtype,
-                        new_dtype
-                    )
-                elif is_timedelta_dtype(new_dtype):
-                    pass
-
-            code.append(f'{df_name}[{transpiled_column_header}] = {conversion_code}')
+            conversion_code = get_conversion_code(self.post_state, sheet_index, column_id, old_dtype, new_dtype)
+            if conversion_code is not None:
+                code.append(conversion_code)
         
         # If we have pandas included, then add pandas to the transpiled code
-        if 'pd.to_datetime' in conversion_code:
+        if any('pd.to_datetime' in line for line in code):
             code.insert(0, 'import pandas as pd')
 
         return code

--- a/mitosheet/mitosheet/code_chunks/step_performers/column_steps/change_column_dtype_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/column_steps/change_column_dtype_code_chunk.py
@@ -26,125 +26,135 @@ class ChangeColumnDtypeCodeChunk(CodeChunk):
     
     def get_description_comment(self) -> str:
         sheet_index = self.get_param('sheet_index')
-        column_id = self.get_param('column_id')
+        column_ids = self.get_param('column_ids')
         new_dtype = self.get_param('new_dtype')
-        column_header = self.post_state.column_ids.get_column_header_by_id(sheet_index, column_id)
-        return f'Changed {column_header} to dtype {new_dtype}'
+        column_headers = self.post_state.column_ids.get_column_headers_by_ids(sheet_index, column_ids)
+        return f'Changed {", ".join([str(ch) for ch in column_headers])} to dtype {new_dtype}'
 
     def get_code(self) -> List[str]:
         sheet_index = self.get_param('sheet_index')
-        column_id = self.get_param('column_id')
-        old_dtype = self.get_param('old_dtype')
+        column_ids = self.get_param('column_ids')
+        old_dtypes = self.get_param('old_dtypes')
         new_dtype = self.get_param('new_dtype')
 
         df_name = self.post_state.df_names[sheet_index]
-        column_header = self.post_state.column_ids.get_column_header_by_id(sheet_index, column_id)
-        transpiled_column_header = column_header_to_transpiled_code(column_header)
 
-        column = self.prev_state.dfs[sheet_index][column_header]
+        code = []
 
-        conversion_code = f'{df_name}[{transpiled_column_header}]'
-        if is_bool_dtype(old_dtype):
-            if is_bool_dtype(new_dtype):
-                pass
-            elif is_int_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'int\')'
-            elif is_float_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'float\')'
-            elif is_string_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'str\')'
-            elif is_datetime_dtype(new_dtype):
-                raise make_invalid_column_type_change_error(
-                    column_header,
-                    old_dtype,
-                    new_dtype
-                )
-            elif is_timedelta_dtype(new_dtype):
-                raise make_invalid_column_type_change_error(
-                    column_header,
-                    old_dtype,
-                    new_dtype
-                )
-        elif is_int_dtype(old_dtype):
-            if is_bool_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].fillna(False).astype(\'bool\')'
-            elif is_int_dtype(new_dtype):
-                pass
-            elif is_float_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'float\')'
-            elif is_string_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'str\')'
-            elif is_datetime_dtype(new_dtype):
-                conversion_code = f'pd.to_datetime({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
-            elif is_timedelta_dtype(new_dtype):
-                conversion_code = f'pd.to_timedelta({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
-        elif is_float_dtype(old_dtype):
-            if is_bool_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].fillna(False).astype(\'bool\')'
-            elif is_int_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].fillna(0).astype(\'int\')'
-            elif is_float_dtype(new_dtype):
-                pass
-            elif is_string_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'str\')'
-            elif is_datetime_dtype(new_dtype):
-                conversion_code = f'pd.to_datetime({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
-            elif is_timedelta_dtype(new_dtype):
-                conversion_code = f'pd.to_timedelta({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
-        elif is_string_dtype(old_dtype):
-            if is_bool_dtype(new_dtype):
-                conversion_code = f'to_boolean_series({df_name}[{transpiled_column_header}])'
-            elif is_int_dtype(new_dtype):
-                conversion_code = f'to_int_series({df_name}[{transpiled_column_header}])'
-            elif is_float_dtype(new_dtype):
-                conversion_code = f'to_float_series({df_name}[{transpiled_column_header}])'
-            elif is_string_dtype(new_dtype):
-                pass
-            elif is_datetime_dtype(new_dtype):
-                # Guess the datetime format to the best of Pandas abilities
-                datetime_format = get_datetime_format(column)
-                if datetime_format is not None:
-                    conversion_code = f'pd.to_datetime({df_name}[{transpiled_column_header}], format=\'{datetime_format}\', errors=\'coerce\')'
-                else:
-                    conversion_code = f'pd.to_datetime({df_name}[{transpiled_column_header}], infer_datetime_format=True, errors=\'coerce\')'
-            elif is_timedelta_dtype(new_dtype):
-                conversion_code = f'pd.to_timedelta({df_name}[{transpiled_column_header}], errors=\'coerce\')'
-        elif is_datetime_dtype(old_dtype):
-            if is_bool_dtype(new_dtype):
-                conversion_code = f'~{df_name}[{transpiled_column_header}].isnull()'
-            elif is_int_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'int\') / 10**9'
-            elif is_float_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'int\').astype(\'float\') / 10**9'
-            elif is_string_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].dt.strftime(\'%Y-%m-%d %X\')'
-            elif is_datetime_dtype(new_dtype):
-                pass
-            elif is_timedelta_dtype(new_dtype):
-                raise make_invalid_column_type_change_error(
-                    column_header,
-                    old_dtype,
-                    new_dtype
-                )
-        elif is_timedelta_dtype(old_dtype):
-            if is_bool_dtype(new_dtype):
-                conversion_code = f'~{df_name}[{transpiled_column_header}].isnull()'
-            elif is_int_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].dt.total_seconds().astype(\'int\')'
-            elif is_float_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].dt.total_seconds()'
-            elif is_string_dtype(new_dtype):
-                conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'str\')'
-            elif is_datetime_dtype(new_dtype):
-                raise make_invalid_column_type_change_error(
-                    column_header,
-                    old_dtype,
-                    new_dtype
-                )
-            elif is_timedelta_dtype(new_dtype):
-                pass
+        # Note: we can't actually group all the headers together in one conversion, and not every dtype can be converted
+        # to the target dtype in the same way. Even if they have the same old_dtype, this still might not work in the case
+        # of converting to datetimes. We wait on doing this for now, depending on if we think the complexity is worth it!
 
-        code = [f'{df_name}[{transpiled_column_header}] = {conversion_code}']
+        for column_id in column_ids:
+            old_dtype = old_dtypes[column_id]
+            column_header = self.post_state.column_ids.get_column_header_by_id(sheet_index, column_id)
+            transpiled_column_header = column_header_to_transpiled_code(column_header)
+
+            column = self.prev_state.dfs[sheet_index][column_header]
+
+            conversion_code = f'{df_name}[{transpiled_column_header}]'
+            if is_bool_dtype(old_dtype):
+                if is_bool_dtype(new_dtype):
+                    pass
+                elif is_int_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'int\')'
+                elif is_float_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'float\')'
+                elif is_string_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'str\')'
+                elif is_datetime_dtype(new_dtype):
+                    raise make_invalid_column_type_change_error(
+                        column_header,
+                        old_dtype,
+                        new_dtype
+                    )
+                elif is_timedelta_dtype(new_dtype):
+                    raise make_invalid_column_type_change_error(
+                        column_header,
+                        old_dtype,
+                        new_dtype
+                    )
+            elif is_int_dtype(old_dtype):
+                if is_bool_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].fillna(False).astype(\'bool\')'
+                elif is_int_dtype(new_dtype):
+                    pass
+                elif is_float_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'float\')'
+                elif is_string_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'str\')'
+                elif is_datetime_dtype(new_dtype):
+                    conversion_code = f'pd.to_datetime({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
+                elif is_timedelta_dtype(new_dtype):
+                    conversion_code = f'pd.to_timedelta({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
+            elif is_float_dtype(old_dtype):
+                if is_bool_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].fillna(False).astype(\'bool\')'
+                elif is_int_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].fillna(0).astype(\'int\')'
+                elif is_float_dtype(new_dtype):
+                    pass
+                elif is_string_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'str\')'
+                elif is_datetime_dtype(new_dtype):
+                    conversion_code = f'pd.to_datetime({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
+                elif is_timedelta_dtype(new_dtype):
+                    conversion_code = f'pd.to_timedelta({df_name}[{transpiled_column_header}], unit=\'s\', errors=\'coerce\')'
+            elif is_string_dtype(old_dtype):
+                if is_bool_dtype(new_dtype):
+                    conversion_code = f'to_boolean_series({df_name}[{transpiled_column_header}])'
+                elif is_int_dtype(new_dtype):
+                    conversion_code = f'to_int_series({df_name}[{transpiled_column_header}])'
+                elif is_float_dtype(new_dtype):
+                    conversion_code = f'to_float_series({df_name}[{transpiled_column_header}])'
+                elif is_string_dtype(new_dtype):
+                    pass
+                elif is_datetime_dtype(new_dtype):
+                    # Guess the datetime format to the best of Pandas abilities
+                    datetime_format = get_datetime_format(column)
+                    if datetime_format is not None:
+                        conversion_code = f'pd.to_datetime({df_name}[{transpiled_column_header}], format=\'{datetime_format}\', errors=\'coerce\')'
+                    else:
+                        conversion_code = f'pd.to_datetime({df_name}[{transpiled_column_header}], infer_datetime_format=True, errors=\'coerce\')'
+                elif is_timedelta_dtype(new_dtype):
+                    conversion_code = f'pd.to_timedelta({df_name}[{transpiled_column_header}], errors=\'coerce\')'
+            elif is_datetime_dtype(old_dtype):
+                if is_bool_dtype(new_dtype):
+                    conversion_code = f'~{df_name}[{transpiled_column_header}].isnull()'
+                elif is_int_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'int\') / 10**9'
+                elif is_float_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'int\').astype(\'float\') / 10**9'
+                elif is_string_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].dt.strftime(\'%Y-%m-%d %X\')'
+                elif is_datetime_dtype(new_dtype):
+                    pass
+                elif is_timedelta_dtype(new_dtype):
+                    raise make_invalid_column_type_change_error(
+                        column_header,
+                        old_dtype,
+                        new_dtype
+                    )
+            elif is_timedelta_dtype(old_dtype):
+                if is_bool_dtype(new_dtype):
+                    conversion_code = f'~{df_name}[{transpiled_column_header}].isnull()'
+                elif is_int_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].dt.total_seconds().astype(\'int\')'
+                elif is_float_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].dt.total_seconds()'
+                elif is_string_dtype(new_dtype):
+                    conversion_code = f'{df_name}[{transpiled_column_header}].astype(\'str\')'
+                elif is_datetime_dtype(new_dtype):
+                    raise make_invalid_column_type_change_error(
+                        column_header,
+                        old_dtype,
+                        new_dtype
+                    )
+                elif is_timedelta_dtype(new_dtype):
+                    pass
+
+            code.append(f'{df_name}[{transpiled_column_header}] = {conversion_code}')
+        
         # If we have pandas included, then add pandas to the transpiled code
         if 'pd.to_datetime' in conversion_code:
             code.insert(0, 'import pandas as pd')

--- a/mitosheet/mitosheet/code_chunks/step_performers/column_steps/change_column_dtype_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/column_steps/change_column_dtype_code_chunk.py
@@ -138,10 +138,10 @@ class ChangeColumnDtypeCodeChunk(CodeChunk):
         return 'Changed dtype'
     
     def get_description_comment(self) -> str:
-        sheet_index = self.get_param('sheet_index')
-        column_ids = self.get_param('column_ids')
-        new_dtype = self.get_param('new_dtype')
-        column_headers = self.post_state.column_ids.get_column_headers_by_ids(sheet_index, column_ids)
+        sheet_index: int = self.get_param('sheet_index')
+        new_dtype: str = self.get_param('new_dtype')
+        changed_column_ids: List[ColumnID] = self.get_execution_data('changed_column_ids')
+        column_headers = self.post_state.column_ids.get_column_headers_by_ids(sheet_index, changed_column_ids)
         return f'Changed {", ".join([str(ch) for ch in column_headers])} to dtype {new_dtype}'
 
     def get_code(self) -> List[str]:

--- a/mitosheet/mitosheet/column_headers.py
+++ b/mitosheet/mitosheet/column_headers.py
@@ -227,6 +227,12 @@ class ColumnIDMap():
     def get_column_id_by_header(self, sheet_index: int, column_header: ColumnHeader) -> str:
         return self.column_header_to_column_id[sheet_index][column_header]
 
+    def get_column_ids_by_headers(self, sheet_index: int, column_headers: List[ColumnHeader]) -> List[ColumnID]:
+        return [
+            self.column_header_to_column_id[sheet_index][column_header] 
+            for column_header in column_headers
+        ]
+
     def get_column_header_by_id(self, sheet_index: int, column_id: ColumnID) -> ColumnHeader:
         return self.column_id_to_column_header[sheet_index][column_id]
 

--- a/mitosheet/mitosheet/saved_analyses/step_upgraders/change_column_dtype.py
+++ b/mitosheet/mitosheet/saved_analyses/step_upgraders/change_column_dtype.py
@@ -43,3 +43,43 @@ def upgrade_change_column_dtype_1_to_2(step: Dict[str, Any], later_steps: List[D
         "step_type": "change_column_dtype", 
         "params": params
     }] + later_steps
+
+def upgrade_change_column_dtype_2_to_3(step: Dict[str, Any], later_steps: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Supports changing the types of multiple columns at once
+
+    OLD: {
+        'step_version': 2, 
+        'step_type': "change_column_dtype",
+        'params': {
+            sheet_index: 0,
+            column_id: ColumnID,
+            old_dtype: str,
+            new_dtype: str,
+        }
+    }
+
+    NEW: {
+        'step_version': 2, 
+        'step_type': "change_column_dtype",
+        'params': {
+            sheet_index: 0,
+            column_ids: List[ColumnID],
+            old_dtypes: Dict[ColumnID, str],
+            new_dtype: str,
+        }
+    }
+    """
+    params = step['params']
+
+    params['column_ids'] = [params['column_id']]
+    params['old_dtypes'] = {params['column_id']: params['old_dtype']}
+    
+    del params['column_id']
+    del params['old_dtype']
+
+    return [{
+        "step_version": 3, 
+        "step_type": "change_column_dtype", 
+        "params": params
+    }] + later_steps

--- a/mitosheet/mitosheet/saved_analyses/step_upgraders/change_column_dtype.py
+++ b/mitosheet/mitosheet/saved_analyses/step_upgraders/change_column_dtype.py
@@ -60,7 +60,7 @@ def upgrade_change_column_dtype_2_to_3(step: Dict[str, Any], later_steps: List[D
     }
 
     NEW: {
-        'step_version': 2, 
+        'step_version': 3, 
         'step_type': "change_column_dtype",
         'params': {
             sheet_index: 0,

--- a/mitosheet/mitosheet/saved_analyses/upgrade.py
+++ b/mitosheet/mitosheet/saved_analyses/upgrade.py
@@ -22,7 +22,7 @@ from mitosheet.saved_analyses.schema_utils import (
 from mitosheet.saved_analyses.step_upgraders.add_column import \
     upgrade_add_column_1_to_add_column_2
 from mitosheet.saved_analyses.step_upgraders.change_column_dtype import \
-    upgrade_change_column_dtype_1_to_2
+    upgrade_change_column_dtype_1_to_2, upgrade_change_column_dtype_2_to_3
 from mitosheet.saved_analyses.step_upgraders.change_column_format import upgrade_change_column_format_1_to_remove
 from mitosheet.saved_analyses.step_upgraders.delete_column import (
     upgrade_delete_column_1_to_2, upgrade_delete_column_2_to_3)
@@ -85,7 +85,8 @@ STEP_UPGRADES_FUNCTION_MAPPING_NEW_FORMAT = {
         3: upgrade_merge_3_to_4,
     },
     'change_column_dtype': {
-        1: upgrade_change_column_dtype_1_to_2
+        1: upgrade_change_column_dtype_1_to_2,
+        2: upgrade_change_column_dtype_2_to_3
     },
     'delete_column': {
         1: upgrade_delete_column_1_to_2,

--- a/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
@@ -68,7 +68,7 @@ class ChangeColumnDtypeStepPerformer(StepPerformer):
         new_dtype: str = get_param(params, 'new_dtype')
 
         post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])
-        pandas_processing_time = 0
+        pandas_processing_time: float = 0
 
 
         # Store the changed columns till the end, so we can change them in a single

--- a/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
+++ b/mitosheet/mitosheet/step_performers/column_steps/change_column_dtype.py
@@ -39,7 +39,7 @@ class ChangeColumnDtypeStepPerformer(StepPerformer):
 
     @classmethod
     def step_version(cls) -> int:
-        return 2
+        return 3
 
     @classmethod
     def step_type(cls) -> str:
@@ -47,166 +47,180 @@ class ChangeColumnDtypeStepPerformer(StepPerformer):
 
     @classmethod
     def saturate(cls, prev_state: State, params: Dict[str, Any]) -> Dict[str, Any]:
-        sheet_index = params['sheet_index']
-        column_id = params['column_id']
-        column_header = prev_state.column_ids.get_column_header_by_id(sheet_index, column_id)
-        params['old_dtype'] = str(prev_state.dfs[sheet_index][column_header].dtype)
+        sheet_index: int = params['sheet_index']
+        column_ids: List[ColumnID] = params['column_ids']
+
+        # Save all the old dtypes
+        old_dtypes = dict()
+        for column_id in column_ids:
+            column_header = prev_state.column_ids.get_column_header_by_id(sheet_index, column_id)
+            old_dtypes[column_id] = str(prev_state.dfs[sheet_index][column_header].dtype)
+
+        params['old_dtypes'] = old_dtypes
+        
         return params
 
     @classmethod
     def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
         sheet_index: int = get_param(params, 'sheet_index')
-        column_id: ColumnID = get_param(params, 'column_id')
-        old_dtype: str = get_param(params, 'old_dtype')
+        column_ids: List[ColumnID] = get_param(params, 'column_ids')
+        old_dtypes: Dict[ColumnID, str] = get_param(params, 'old_dtypes')
         new_dtype: str = get_param(params, 'new_dtype')
 
         post_state = prev_state.copy(deep_sheet_indexes=[sheet_index])
+        pandas_processing_time = 0
 
-        column_header = prev_state.column_ids.get_column_header_by_id(sheet_index, column_id)
-        
-        column: pd.Series = prev_state.dfs[sheet_index][column_header]
-        new_column = column
-        
-        # How we handle the type conversion depends on what type it is
-        try:
-            pandas_start_time = perf_counter()
-            if is_bool_dtype(old_dtype):
-                if is_bool_dtype(new_dtype):
-                    pass
-                elif is_int_dtype(new_dtype):
-                    new_column = new_column.astype('int')
-                elif is_float_dtype(new_dtype):
-                    new_column = column.astype('float')
-                elif is_string_dtype(new_dtype):
-                    new_column = column.astype('str')
-                elif is_datetime_dtype(new_dtype):
-                    raise make_invalid_column_type_change_error(
-                        column_header,
-                        old_dtype,
-                        new_dtype
-                    )
-                elif is_timedelta_dtype(new_dtype):
-                    raise make_invalid_column_type_change_error(
-                        column_header,
-                        old_dtype,
-                        new_dtype
-                    )
-            if is_int_dtype(old_dtype):
-                if is_bool_dtype(new_dtype):
-                    new_column = column.fillna(False).astype('bool')
-                elif is_int_dtype(new_dtype):
-                    pass
-                elif is_float_dtype(new_dtype):
-                    new_column = column.astype('float')
-                elif is_string_dtype(new_dtype):
-                    new_column = column.astype('str')
-                elif is_datetime_dtype(new_dtype):
-                    new_column = pd.to_datetime(
-                        column, 
-                        unit='s',
-                        errors='coerce'
-                    )
-                elif is_timedelta_dtype(new_dtype):
-                    new_column = to_timedelta_series(column)
-            elif is_float_dtype(old_dtype):
-                if is_bool_dtype(new_dtype):
-                    new_column = column.fillna(False).astype('bool')
-                elif is_int_dtype(new_dtype):
-                    new_column = column.fillna(0).astype('int')
-                elif is_float_dtype(new_dtype):
-                    pass
-                elif is_string_dtype(new_dtype):
-                    new_column = column.astype('str')
-                elif is_datetime_dtype(new_dtype):
-                    new_column = pd.to_datetime(
-                        column, 
-                        unit='s',
-                        errors='coerce'
-                    )
-                elif is_timedelta_dtype(new_dtype):
-                    new_column = to_timedelta_series(column)
-            elif is_string_dtype(old_dtype):
-                if is_bool_dtype(new_dtype):
-                    new_column = to_boolean_series(new_column)
-                elif is_int_dtype(new_dtype):
-                    new_column = to_int_series(column)
-                elif is_float_dtype(new_dtype):
-                    new_column = to_float_series(column)
-                elif is_string_dtype(new_dtype):
-                    pass
-                elif is_datetime_dtype(new_dtype):
-                    # Guess the datetime format to the best of Pandas abilities
-                    datetime_format = get_datetime_format(column)
-                    # If it's None, then infer_datetime_format is enough to figure it out
-                    if datetime_format is not None:
+
+        # Change each column id
+        for column_id in column_ids:
+
+            old_dtype = old_dtypes[column_id]
+            column_header = prev_state.column_ids.get_column_header_by_id(sheet_index, column_id)
+
+            column: pd.Series = prev_state.dfs[sheet_index][column_header]
+            new_column = column
+            
+            # How we handle the type conversion depends on what type it is
+            try:
+                pandas_start_time = perf_counter()
+                if is_bool_dtype(old_dtype):
+                    if is_bool_dtype(new_dtype):
+                        pass
+                    elif is_int_dtype(new_dtype):
+                        new_column = new_column.astype('int')
+                    elif is_float_dtype(new_dtype):
+                        new_column = column.astype('float')
+                    elif is_string_dtype(new_dtype):
+                        new_column = column.astype('str')
+                    elif is_datetime_dtype(new_dtype):
+                        raise make_invalid_column_type_change_error(
+                            column_header,
+                            old_dtype,
+                            new_dtype
+                        )
+                    elif is_timedelta_dtype(new_dtype):
+                        raise make_invalid_column_type_change_error(
+                            column_header,
+                            old_dtype,
+                            new_dtype
+                        )
+                if is_int_dtype(old_dtype):
+                    if is_bool_dtype(new_dtype):
+                        new_column = column.fillna(False).astype('bool')
+                    elif is_int_dtype(new_dtype):
+                        pass
+                    elif is_float_dtype(new_dtype):
+                        new_column = column.astype('float')
+                    elif is_string_dtype(new_dtype):
+                        new_column = column.astype('str')
+                    elif is_datetime_dtype(new_dtype):
                         new_column = pd.to_datetime(
-                            column,
-                            format=datetime_format,
+                            column, 
+                            unit='s',
                             errors='coerce'
                         )
-                    else:
+                    elif is_timedelta_dtype(new_dtype):
+                        new_column = to_timedelta_series(column)
+                elif is_float_dtype(old_dtype):
+                    if is_bool_dtype(new_dtype):
+                        new_column = column.fillna(False).astype('bool')
+                    elif is_int_dtype(new_dtype):
+                        new_column = column.fillna(0).astype('int')
+                    elif is_float_dtype(new_dtype):
+                        pass
+                    elif is_string_dtype(new_dtype):
+                        new_column = column.astype('str')
+                    elif is_datetime_dtype(new_dtype):
                         new_column = pd.to_datetime(
-                            column,
-                            infer_datetime_format=True,
+                            column, 
+                            unit='s',
                             errors='coerce'
                         )
-                elif is_timedelta_dtype(new_dtype):
-                    new_column = to_timedelta_series(column)
-            elif is_datetime_dtype(old_dtype):
-                if is_bool_dtype(new_dtype):
-                    new_column = ~column.isnull()
-                elif is_int_dtype(new_dtype):
-                    new_column = column.astype('int') / 10**9
-                elif is_float_dtype(new_dtype):
-                    # For some reason, we have to do all the conversions at once
-                    new_column = column.astype('int').astype('float') / 10**9
-                elif is_string_dtype(new_dtype):
-                    # NOTE: this is the same conversion that we send to the frontend
-                    new_column = column.dt.strftime('%Y-%m-%d %X')
-                elif is_datetime_dtype(new_dtype):
-                    pass
-                elif is_timedelta_dtype(new_dtype):
-                    raise make_invalid_column_type_change_error(
-                        column_header,
-                        old_dtype,
-                        new_dtype
-                    )
-            elif is_timedelta_dtype(old_dtype):
-                if is_bool_dtype(new_dtype):
-                    new_column = ~column.isnull()
-                elif is_int_dtype(new_dtype):
-                    new_column = column.dt.total_seconds().astype('int')
-                elif is_float_dtype(new_dtype):
-                    new_column = column.dt.total_seconds()
-                elif is_string_dtype(new_dtype):
-                    new_column = column.astype('str')
-                elif is_datetime_dtype(new_dtype):
-                    raise make_invalid_column_type_change_error(
-                        column_header,
-                        old_dtype,
-                        new_dtype
-                    )
-                elif is_timedelta_dtype(new_dtype):
-                    pass
+                    elif is_timedelta_dtype(new_dtype):
+                        new_column = to_timedelta_series(column)
+                elif is_string_dtype(old_dtype):
+                    if is_bool_dtype(new_dtype):
+                        new_column = to_boolean_series(new_column)
+                    elif is_int_dtype(new_dtype):
+                        new_column = to_int_series(column)
+                    elif is_float_dtype(new_dtype):
+                        new_column = to_float_series(column)
+                    elif is_string_dtype(new_dtype):
+                        pass
+                    elif is_datetime_dtype(new_dtype):
+                        # Guess the datetime format to the best of Pandas abilities
+                        datetime_format = get_datetime_format(column)
+                        # If it's None, then infer_datetime_format is enough to figure it out
+                        if datetime_format is not None:
+                            new_column = pd.to_datetime(
+                                column,
+                                format=datetime_format,
+                                errors='coerce'
+                            )
+                        else:
+                            new_column = pd.to_datetime(
+                                column,
+                                infer_datetime_format=True,
+                                errors='coerce'
+                            )
+                    elif is_timedelta_dtype(new_dtype):
+                        new_column = to_timedelta_series(column)
+                elif is_datetime_dtype(old_dtype):
+                    if is_bool_dtype(new_dtype):
+                        new_column = ~column.isnull()
+                    elif is_int_dtype(new_dtype):
+                        new_column = column.astype('int') / 10**9
+                    elif is_float_dtype(new_dtype):
+                        # For some reason, we have to do all the conversions at once
+                        new_column = column.astype('int').astype('float') / 10**9
+                    elif is_string_dtype(new_dtype):
+                        # NOTE: this is the same conversion that we send to the frontend
+                        new_column = column.dt.strftime('%Y-%m-%d %X')
+                    elif is_datetime_dtype(new_dtype):
+                        pass
+                    elif is_timedelta_dtype(new_dtype):
+                        raise make_invalid_column_type_change_error(
+                            column_header,
+                            old_dtype,
+                            new_dtype
+                        )
+                elif is_timedelta_dtype(old_dtype):
+                    if is_bool_dtype(new_dtype):
+                        new_column = ~column.isnull()
+                    elif is_int_dtype(new_dtype):
+                        new_column = column.dt.total_seconds().astype('int')
+                    elif is_float_dtype(new_dtype):
+                        new_column = column.dt.total_seconds()
+                    elif is_string_dtype(new_dtype):
+                        new_column = column.astype('str')
+                    elif is_datetime_dtype(new_dtype):
+                        raise make_invalid_column_type_change_error(
+                            column_header,
+                            old_dtype,
+                            new_dtype
+                        )
+                    elif is_timedelta_dtype(new_dtype):
+                        pass
 
-            # We update the column, as well as the type of the column
-            post_state.dfs[sheet_index][column_header] = new_column
-            pandas_processing_time = perf_counter() - pandas_start_time
+                # We update the column, as well as the type of the column
+                post_state.dfs[sheet_index][column_header] = new_column
+                pandas_processing_time += (perf_counter() - pandas_start_time)
 
-            # If we're changing away from a number column, then we remove the formatting on the column if it exists
-            if not is_number_dtype(new_dtype) and column_id in post_state.df_formats[sheet_index]['columns']:
-                del post_state.df_formats[sheet_index]['columns'][column_id]
-                
-            return post_state, {
-                'pandas_processing_time': pandas_processing_time
-            }
-        except:
-            print(get_recent_traceback())
-            raise make_invalid_column_type_change_error(
-                column_header,
-                old_dtype,
-                new_dtype
-            )
+                # If we're changing away from a number column, then we remove the formatting on the column if it exists
+                if not is_number_dtype(new_dtype) and column_id in post_state.df_formats[sheet_index]['columns']:
+                    del post_state.df_formats[sheet_index]['columns'][column_id]
+                    
+            except:
+                print(get_recent_traceback())
+                raise make_invalid_column_type_change_error(
+                    column_header,
+                    old_dtype,
+                    new_dtype
+                )
+
+        return post_state, {
+            'pandas_processing_time': pandas_processing_time
+        }
         
 
     @classmethod

--- a/mitosheet/mitosheet/tests/saved_analyses/test_upgrade.py
+++ b/mitosheet/mitosheet/tests/saved_analyses/test_upgrade.py
@@ -52,7 +52,7 @@ UPGRADE_TESTS = [
         },
         {
             "version": __version__, 
-            "steps_data": [{'params': {"move_to_deprecated_id_algorithm": True}, 'step_type': 'bulk_old_rename', 'step_version': 1}, {"step_version": 2, "step_type": "change_column_dtype", "params": {"sheet_index": 0, "column_id": get_column_header_id("Median_Income"), "new_dtype": "int", "old_dtype": "float64"}}]
+            "steps_data": [{'params': {"move_to_deprecated_id_algorithm": True}, 'step_type': 'bulk_old_rename', 'step_version': 1}, {"step_version": 3, "step_type": "change_column_dtype", "params": {"sheet_index": 0, "column_ids": [get_column_header_id("Median_Income")], "new_dtype": "int", "old_dtypes": {get_column_header_id("Median_Income"): "float64"}}}]
         }
     ),
     # Rename a column 
@@ -295,7 +295,7 @@ UPGRADE_TESTS = [
             "version": __version__, 
             "steps_data": [ 
                 {"step_version": 2, "step_type": "simple_import", "params": {"file_names": ["Tesla.csv"]}}, 
-                {"step_version": 2, "step_type": "change_column_dtype", "params": {"sheet_index": 0, "column_id": "Date", "new_dtype": "datetime", "old_dtype": "object"}}, {"step_version": 2, "step_type": "add_column", "params": {"sheet_index": 0, "column_header": "new-column-9rkm", "column_header_index": 1}}, 
+                {"step_version": 3, "step_type": "change_column_dtype", "params": {"sheet_index": 0, "column_ids": ["Date"], "new_dtype": "datetime", "old_dtypes": {"Date": "object"}}}, {"step_version": 2, "step_type": "add_column", "params": {"sheet_index": 0, "column_header": "new-column-9rkm", "column_header_index": 1}}, 
                 {"step_version": 2, "step_type": "set_column_formula", "params": {"sheet_index": 0, "column_id": "new-column-9rkm", "new_formula": "weekday(Date)", "old_formula": "=0"}}, 
                 {"step_version": 4, "step_type": "graph", "params": {"graph_id": "_iv911muyd", "graph_preprocessing": {"safety_filter_turned_on_by_user": True}, "graph_creation": {"graph_type": "bar", "sheet_index": 0, "x_axis_column_ids": ["Low"], "y_axis_column_ids": ["Open"], "color": "new-column-9rkm"}, "graph_styling": {"title": {"visible": True, "title_font_color": DO_NOT_CHANGE_TITLE_FONT_COLOR_DEFAULT}, "xaxis": {"visible": True, "title_font_color": DO_NOT_CHANGE_TITLE_FONT_COLOR_DEFAULT, "showgrid": True, "rangeslider": {"visible": True}}, "yaxis": {"visible": True, "title_font_color": DO_NOT_CHANGE_TITLE_FONT_COLOR_DEFAULT, "showgrid": True}, "showlegend": True, 'legend': {'orientation': 'v'}, 'paper_bgcolor': DO_NOT_CHANGE_PAPER_BGCOLOR_DEFAULT, 'plot_bgcolor': DO_NOT_CHANGE_PLOT_BGCOLOR_DEFAULT}, "graph_rendering": {"height": "426px", "width": "1141.800048828125px"}}}
             ]

--- a/mitosheet/mitosheet/tests/step_performers/column_steps/test_change_column_dtype.py
+++ b/mitosheet/mitosheet/tests/step_performers/column_steps/test_change_column_dtype.py
@@ -263,5 +263,4 @@ def test_change_multiple_dtype_works_if_no_op():
 def test_change_multiple_dtype_fails_is_atomic():
     mito = create_mito_wrapper_dfs(pd.DataFrame({'A': [1, 2, 3], 'B': pd.to_datetime(['12-22-1997', '12-22-1997', '12-22-1997'])}))
     mito.change_column_dtype(0, ['A', 'B'], 'timedelta')
-    print(mito.dfs[0])
     assert mito.dfs[0].equals(pd.DataFrame({'A': [1, 2, 3], 'B': pd.to_datetime(['12-22-1997', '12-22-1997', '12-22-1997'])}))

--- a/mitosheet/mitosheet/tests/step_performers/column_steps/test_change_column_dtype.py
+++ b/mitosheet/mitosheet/tests/step_performers/column_steps/test_change_column_dtype.py
@@ -248,3 +248,20 @@ def test_change_type_deletes_diff_dataframe_no_optimizes():
     mito.change_column_dtype(0, ['A'], 'int')
     mito.delete_dataframe(1)
     assert len(mito.optimized_code_chunks) >= 3
+
+
+def test_change_multiple_dtype_works():
+    mito = create_mito_wrapper_dfs(pd.DataFrame({'A': [1, 2, 3], 'B': ['1.0', '2.0', '3.0']}))
+    mito.change_column_dtype(0, ['A', 'B'], 'float')
+    assert mito.dfs[0].equals(pd.DataFrame({'A': [1.0, 2.0, 3.0], 'B': [1.0, 2.0, 3.0]}))
+
+def test_change_multiple_dtype_works_if_no_op():
+    mito = create_mito_wrapper_dfs(pd.DataFrame({'A': [1, 2, 3], 'B': ['1.0', '2.0', '3.0']}))
+    mito.change_column_dtype(0, ['A', 'B'], 'int')
+    assert mito.dfs[0].equals(pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3]}))
+
+def test_change_multiple_dtype_fails_is_atomic():
+    mito = create_mito_wrapper_dfs(pd.DataFrame({'A': [1, 2, 3], 'B': pd.to_datetime(['12-22-1997', '12-22-1997', '12-22-1997'])}))
+    mito.change_column_dtype(0, ['A', 'B'], 'timedelta')
+    print(mito.dfs[0])
+    assert mito.dfs[0].equals(pd.DataFrame({'A': [1, 2, 3], 'B': pd.to_datetime(['12-22-1997', '12-22-1997', '12-22-1997'])}))

--- a/mitosheet/mitosheet/tests/step_performers/column_steps/test_change_column_dtype.py
+++ b/mitosheet/mitosheet/tests/step_performers/column_steps/test_change_column_dtype.py
@@ -27,7 +27,7 @@ DATETIME_ARRAY = [pd.to_datetime(x, unit='s') for x in [100, 200, 300]]
 TIMEDELTA_ARRAY = [pd.to_timedelta(x, unit='s') for x in [100, 200, 300]]
 
 BOOL_TESTS = [
-    ('bool', BOOL_ARRAY, 'df1[\'A\'] = df1[\'A\']'), 
+    ('bool', BOOL_ARRAY, None), 
     ('int', [1, 0, 1], 'df1[\'A\'] = df1[\'A\'].astype(\'int\')'), 
     ('int64', [1, 0, 1], 'df1[\'A\'] = df1[\'A\'].astype(\'int\')'), 
     ('float', [1.0, 0.0, 1.0], 'df1[\'A\'] = df1[\'A\'].astype(\'float\')'), 
@@ -54,8 +54,8 @@ def test_bool_to_other_types(new_dtype, result, code):
 
 INT_TESTS = [
     ('bool', [True, True, True], 'df1[\'A\'] = df1[\'A\'].fillna(False).astype(\'bool\')'), 
-    ('int', [1, 2, 3], 'df1[\'A\'] = df1[\'A\']'), 
-    ('int64', [1, 2, 3], 'df1[\'A\'] = df1[\'A\']'), 
+    ('int', [1, 2, 3], None), 
+    ('int64', [1, 2, 3], None), 
     ('float', [1.0, 2.0, 3.0], 'df1[\'A\'] = df1[\'A\'].astype(\'float\')'), 
     ('float64', [1.0, 2.0, 3.0], 'df1[\'A\'] = df1[\'A\'].astype(\'float\')'), 
     ('str', ['1', '2', '3'], 'df1[\'A\'] = df1[\'A\'].astype(\'str\')'), 
@@ -80,8 +80,8 @@ FLOAT_TESTS = [
     ('bool', [True, True, True], 'df1[\'A\'] = df1[\'A\'].fillna(False).astype(\'bool\')'), 
     ('int', [4, 5, 6], 'df1[\'A\'] = df1[\'A\'].astype(\'int\')'), 
     ('int64', [4, 5, 6], 'df1[\'A\'] = df1[\'A\'].astype(\'int\')'), 
-    ('float', [4.0, 5.1, 6.2], 'df1[\'A\'] = df1[\'A\']'), 
-    ('float64', [4.0, 5.1, 6.2], 'df1[\'A\'] = df1[\'A\']'), 
+    ('float', [4.0, 5.1, 6.2], None), 
+    ('float64', [4.0, 5.1, 6.2], None), 
     ('str', ['4.0', '5.1', '6.2'], 'df1[\'A\'] = df1[\'A\'].astype(\'str\')'), 
     ('object', ['4.0', '5.1', '6.2'], 'df1[\'A\'] = df1[\'A\'].astype(\'str\')'), 
     ('string', ['4.0', '5.1', '6.2'], 'df1[\'A\'] = df1[\'A\'].astype(\'str\')'), 
@@ -106,9 +106,9 @@ STRING_TESTS = [
     ('int64', [1, 2, -3], 'df1[\'A\'] = to_int_series(df1[\'A\'])'), 
     ('float', [1.0, 2.1, -3.2], 'df1[\'A\'] = to_float_series(df1[\'A\'])'), 
     ('float64', [1.0, 2.1, -3.2], 'df1[\'A\'] = to_float_series(df1[\'A\'])'),  
-    ('str', ["$1", "2.1", "(3.2)"], 'df1[\'A\'] = df1[\'A\']'), 
-    ('object', ["$1", "2.1", "(3.2)"], 'df1[\'A\'] = df1[\'A\']'), 
-    ('string', ["$1", "2.1", "(3.2)"], 'df1[\'A\'] = df1[\'A\']'),
+    ('str', ["$1", "2.1", "(3.2)"], None), 
+    ('object', ["$1", "2.1", "(3.2)"], None), 
+    ('string', ["$1", "2.1", "(3.2)"], None),
     ('datetime', [pd.to_datetime('A', errors='coerce') for x in [None, None, None]], 'df1[\'A\'] = pd.to_datetime(df1[\'A\'], format=\'%m-%d-%Y\', errors=\'coerce\')'), 
     ('datetime64[ns]', [pd.to_datetime('A', errors='coerce') for x in [None, None, None]], 'df1[\'A\'] = pd.to_datetime(df1[\'A\'], format=\'%m-%d-%Y\', errors=\'coerce\')'), 
     ('timedelta', [pd.to_timedelta('A', errors='coerce') for x in [None, None, None]], 'df1[\'A\'] = pd.to_timedelta(df1[\'A\'], errors=\'coerce\')'), 
@@ -168,8 +168,8 @@ DATETIME_TESTS = [
     ('str', ['1970-01-01 00:01:40', '1970-01-01 00:03:20', '1970-01-01 00:05:00'], 'df1[\'A\'] = df1[\'A\'].dt.strftime(\'%Y-%m-%d %X\')'), 
     ('object', ['1970-01-01 00:01:40', '1970-01-01 00:03:20', '1970-01-01 00:05:00'], 'df1[\'A\'] = df1[\'A\'].dt.strftime(\'%Y-%m-%d %X\')'), 
     ('string', ['1970-01-01 00:01:40', '1970-01-01 00:03:20', '1970-01-01 00:05:00'], 'df1[\'A\'] = df1[\'A\'].dt.strftime(\'%Y-%m-%d %X\')'),
-    ('datetime', DATETIME_ARRAY, 'df1[\'A\'] = df1[\'A\']'), 
-    ('datetime64[ns]', DATETIME_ARRAY, 'df1[\'A\'] = df1[\'A\']'), 
+    ('datetime', DATETIME_ARRAY, None), 
+    ('datetime64[ns]', DATETIME_ARRAY, None), 
     ('timedelta', DATETIME_ARRAY, None), 
 ]
 @pytest.mark.parametrize("new_dtype, result, code", DATETIME_TESTS)
@@ -190,7 +190,7 @@ TIMEDELTA_TESTS = [
     ('float64', [100.0, 200.0, 300.0], 'df1[\'A\'] = df1[\'A\'].dt.total_seconds()'),  
     ('datetime', TIMEDELTA_ARRAY, None), 
     ('datetime64[ns]', TIMEDELTA_ARRAY, None), 
-    ('timedelta', TIMEDELTA_ARRAY, 'df1[\'A\'] = df1[\'A\']'), 
+    ('timedelta', TIMEDELTA_ARRAY, None), 
 ]
 @pytest.mark.parametrize("new_dtype, result, code", TIMEDELTA_TESTS)
 def test_timedelta_to_other_types(new_dtype, result, code):

--- a/mitosheet/mitosheet/tests/step_performers/column_steps/test_change_column_dtype.py
+++ b/mitosheet/mitosheet/tests/step_performers/column_steps/test_change_column_dtype.py
@@ -42,7 +42,7 @@ BOOL_TESTS = [
 @pytest.mark.parametrize("new_dtype, result, code", BOOL_TESTS)
 def test_bool_to_other_types(new_dtype, result, code):
     mito = create_mito_wrapper(BOOL_ARRAY)
-    mito.change_column_dtype(0, 'A', new_dtype)
+    mito.change_column_dtype(0, ['A'], new_dtype)
     assert mito.get_column(0, 'A', as_list=True) == result
     if code is not None:
         assert mito.transpiled_code == [
@@ -68,7 +68,7 @@ INT_TESTS = [
 @pytest.mark.parametrize("new_dtype, result, code", INT_TESTS)
 def test_int_to_other_types(new_dtype, result, code):
     mito = create_mito_wrapper(INT_ARRAY)
-    mito.change_column_dtype(0, 'A', new_dtype)
+    mito.change_column_dtype(0, ['A'], new_dtype)
     assert mito.get_column(0, 'A', as_list=True) == result
     if code is not None:            
         assert len(mito.transpiled_code) > 0
@@ -92,7 +92,7 @@ FLOAT_TESTS = [
 @pytest.mark.parametrize("new_dtype, result, code", FLOAT_TESTS)
 def test_float_to_other_types(new_dtype, result, code):
     mito = create_mito_wrapper(FLOAT_ARRAY)
-    mito.change_column_dtype(0, 'A', new_dtype)
+    mito.change_column_dtype(0, ['A'], new_dtype)
     assert mito.get_column(0, 'A', as_list=True) == result
     if code is not None:            
         assert len(mito.transpiled_code) > 0
@@ -116,7 +116,7 @@ STRING_TESTS = [
 @pytest.mark.parametrize("new_dtype, result, code", STRING_TESTS)
 def test_string_to_other_types(new_dtype, result, code):
     mito = create_mito_wrapper(STRING_ARRAY)
-    mito.change_column_dtype(0, 'A', new_dtype)
+    mito.change_column_dtype(0, ['A'], new_dtype)
     assert mito.get_column(0, 'A', as_list=True) == result
     if code is not None:            
         assert len(mito.transpiled_code) > 0
@@ -151,7 +151,7 @@ COMPLEX_DATE_STRINGS = [
 @pytest.mark.parametrize("strings, result, code", COMPLEX_DATE_STRINGS)
 def test_complex_date_strings(strings, result, code):
     mito = create_mito_wrapper(strings)
-    mito.change_column_dtype(0, 'A', 'datetime')
+    mito.change_column_dtype(0, ['A'], 'datetime')
     assert mito.get_column(0, 'A', as_list=True) == result
     if code is not None:            
         assert len(mito.transpiled_code) > 0
@@ -175,7 +175,7 @@ DATETIME_TESTS = [
 @pytest.mark.parametrize("new_dtype, result, code", DATETIME_TESTS)
 def test_datetime_to_other_types(new_dtype, result, code):
     mito = create_mito_wrapper(DATETIME_ARRAY)
-    mito.change_column_dtype(0, 'A', new_dtype)
+    mito.change_column_dtype(0, ['A'], new_dtype)
     assert mito.get_column(0, 'A', as_list=True) == result
     if code is not None:            
         assert len(mito.transpiled_code) > 0
@@ -195,7 +195,7 @@ TIMEDELTA_TESTS = [
 @pytest.mark.parametrize("new_dtype, result, code", TIMEDELTA_TESTS)
 def test_timedelta_to_other_types(new_dtype, result, code):
     mito = create_mito_wrapper(TIMEDELTA_ARRAY)
-    mito.change_column_dtype(0, 'A', new_dtype)
+    mito.change_column_dtype(0, ['A'], new_dtype)
     assert mito.get_column(0, 'A', as_list=True) == result
     if code is not None:            
         assert len(mito.transpiled_code) > 0
@@ -212,7 +212,7 @@ TIMEDELTA_TESTS_STRING = [
 @pytest.mark.parametrize("new_dtype, result, code", TIMEDELTA_TESTS)
 def test_timedelta_to_other_types_post_1_post_3_6(new_dtype, result, code):
     mito = create_mito_wrapper(TIMEDELTA_ARRAY)
-    mito.change_column_dtype(0, 'A', new_dtype)
+    mito.change_column_dtype(0, ['A'], new_dtype)
     assert mito.get_column(0, 'A', as_list=True) == result
     if code is not None:            
         assert len(mito.transpiled_code) > 0
@@ -221,7 +221,7 @@ def test_timedelta_to_other_types_post_1_post_3_6(new_dtype, result, code):
     
 def test_convert_none_to_bool():
     mito = create_mito_wrapper_dfs(pd.DataFrame({'A': ['none', 'None']}))
-    mito.change_column_dtype(0, 'A', 'bool')
+    mito.change_column_dtype(0, ['A'], 'bool')
     assert mito.get_column(0, 'A', as_list=True) == [False, False]
 
 def test_change_type_on_renamed_column():
@@ -233,18 +233,18 @@ def test_change_type_on_renamed_column():
 
 def test_change_type_float_to_int_nan():
     mito = create_mito_wrapper_dfs(pd.DataFrame({'A': [1.2, 2.0, None]}))
-    mito.change_column_dtype(0, 'A', 'int')
+    mito.change_column_dtype(0, ['A'], 'int')
     assert mito.get_column(0, 'A', as_list=True) == [1, 2, 0]
 
 def test_change_type_deletes_dataframe_optimizes():
     mito = create_mito_wrapper_dfs(pd.DataFrame({'A': [1.2, 2.0, None]}))
-    mito.change_column_dtype(0, 'A', 'int')
+    mito.change_column_dtype(0, ['A'], 'int')
     mito.delete_dataframe(0)
     assert mito.transpiled_code == []
 
 def test_change_type_deletes_diff_dataframe_no_optimizes():
     mito = create_mito_wrapper_dfs(pd.DataFrame({'A': [1.2, 2.0, None]}))
     mito.duplicate_dataframe(0)
-    mito.change_column_dtype(0, 'A', 'int')
+    mito.change_column_dtype(0, ['A'], 'int')
     mito.delete_dataframe(1)
     assert len(mito.optimized_code_chunks) >= 3

--- a/mitosheet/mitosheet/tests/step_performers/test_pivot.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_pivot.py
@@ -231,7 +231,7 @@ def test_all_other_steps_after_pivot():
 
     # Run all the other steps
     mito.set_cell_value(1, 'Name', 0, 'Dork')
-    mito.change_column_dtype(1, 'Height min', 'string')
+    mito.change_column_dtype(1, ['Height min'], 'string')
     mito.add_column(1, 'A')
     mito.add_column(1, 'B')
     mito.delete_columns(1, ['B'])

--- a/mitosheet/mitosheet/tests/test_format.py
+++ b/mitosheet/mitosheet/tests/test_format.py
@@ -43,7 +43,7 @@ def test_sheet_json_displays_dates_correctly():
 
 def test_sheet_displays_dates_with_non_standard_dtype():
     mito = create_mito_wrapper(['2016-01-31T19:29:50.000+0000', '2016-01-31T19:29:50.000+0000'])
-    mito.change_column_dtype(0, 'A', 'datetime')
+    mito.change_column_dtype(0, ['A'], 'datetime')
 
     sheet_data = json.loads(mito.mito_widget.sheet_data_json)[0]
     assert get_value_helper(sheet_data, 0, 0) == '2016-01-31 19:29:50'

--- a/mitosheet/mitosheet/tests/test_step_format.py
+++ b/mitosheet/mitosheet/tests/test_step_format.py
@@ -135,7 +135,7 @@ def test_params_static():
 
     check_step(
         ChangeColumnDtypeStepPerformer,
-        2,
+        3,
         'change_column_dtype'
     )
 

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -746,11 +746,11 @@ class MitoWidgetTestWrapper:
         )
 
     @check_transpiled_code_after_call
-    def change_column_dtype(self, sheet_index: int, column_header: ColumnHeader, new_dtype: str) -> bool:
+    def change_column_dtype(self, sheet_index: int, column_headers: List[ColumnHeader], new_dtype: str) -> bool:
 
-        column_id = self.mito_widget.steps_manager.curr_step.column_ids.get_column_id_by_header(
+        column_ids = self.mito_widget.steps_manager.curr_step.column_ids.get_column_ids_by_headers(
             sheet_index,
-            column_header
+            column_headers
         )
 
         return self.mito_widget.receive_message(
@@ -762,7 +762,7 @@ class MitoWidgetTestWrapper:
                 'step_id': get_new_id(),
                 'params': {
                     'sheet_index': sheet_index,
-                    'column_id': column_id,
+                    'column_ids': column_ids,
                     'new_dtype': new_dtype
                 }
             }

--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -113,8 +113,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
         selectedGraphID: Object.keys(props.analysisData.graphDataDict || {}).length === 0 ? undefined : Object.keys(props.analysisData.graphDataDict)[0],
         selectedTabType: 'data',
         currOpenToolbarDropdown: undefined,
-        displayImportToolbarDropdown: false,
-        displayFormatToolbarDropdown: false,
+        toolbarDropdown: undefined,
         exportConfiguration: {exportType: 'csv'}
     })
     const [editorState, setEditorState] = useState<EditorState | undefined>(undefined);
@@ -838,6 +837,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
                     userProfile={userProfile}
                     setEditorState={setEditorState}
                     analysisData={analysisData}
+                    sheetIndex={uiState.selectedSheetIndex}
                 />
                 <div className="mito-main-sheet-div" id="mito-main-sheet-div"> 
                     <div className={formulaBarAndSheetClassNames}>

--- a/mitosheet/src/components/icons/DtypeIcon.tsx
+++ b/mitosheet/src/components/icons/DtypeIcon.tsx
@@ -1,17 +1,14 @@
+
 // Copyright (c) Mito
 
 import React from 'react';
 
-
 const DtypeIcon = (): JSX.Element => {
     return (
-        <svg width="15" height="13" viewBox="0 0 15 13" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M7.5 1.03611V6.51294V12.0129M1 1.01294H14" strokeWidth="1" stroke="#494650" strokeMiterlimit="10" strokeLinecap="round"/>
+        <svg width="33" height="15" viewBox="0 0 14 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M2.83203 1.3125V7H2.08984V1.3125H2.83203ZM4.66016 1.3125V1.92969H0.265625V1.3125H4.66016ZM10.3039 7L13.5199 1.424H7.07988L10.3039 7Z" fill="#494650"/>
         </svg>
-        
-
     )
 }
 
 export default DtypeIcon;
-

--- a/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/DtypeCard.tsx
+++ b/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/DtypeCard.tsx
@@ -24,7 +24,7 @@ type DtypeCardProps = {
 }
 
 // The dtypes accepted by the change column dtype change
-enum ColumnDtypes {
+export enum ColumnDtypes {
     BOOL = 'bool',
     INT = 'int',
     FLOAT = 'float',
@@ -60,6 +60,43 @@ export function getDtypeValue(dtype: string | undefined): ColumnDtypes {
     return ColumnDtypes.STRING;
 }
 
+export function getDtypeSelectOptions(onChange?: (newDtype: string) => void): JSX.Element[] {
+
+    // If you want to define an onClick directly, pass this onChange to the select options. This is necesary
+    // if, like in the toolbar, we're creating a dropdown directly rather than a select
+
+    return [
+        <DropdownItem
+                title={ColumnDtypes.BOOL}
+                onClick={onChange ? () => {onChange(ColumnDtypes.BOOL)} : undefined}
+        />,
+        <DropdownItem
+            title={ColumnDtypes.INT}
+            subtext={'Casting to an int will turn all NaN values to 0.'}
+            hideSubtext
+            displaySubtextOnHover
+            onClick={onChange ? () => {onChange(ColumnDtypes.INT)} : undefined}
+        />,
+        <DropdownItem
+            title={ColumnDtypes.FLOAT}
+            onClick={onChange ? () => {onChange(ColumnDtypes.FLOAT)} : undefined}
+
+        />,
+        <DropdownItem
+            title={ColumnDtypes.STRING}
+            onClick={onChange ? () => {onChange(ColumnDtypes.STRING)} : undefined}
+        />,
+        <DropdownItem
+            title={ColumnDtypes.DATETIME}
+            onClick={onChange ? () => {onChange(ColumnDtypes.DATETIME)} : undefined}
+        />,
+        <DropdownItem
+            title={ColumnDtypes.TIMEDELTA}
+            onClick={onChange ? () => {onChange(ColumnDtypes.TIMEDELTA)} : undefined}
+        />
+]
+}
+
 /*
     A card that allows a user to change the dtype of a column.
 */
@@ -93,27 +130,7 @@ function DtypeCard(props: DtypeCardProps): JSX.Element {
                         }}
                         dropdownWidth='medium'
                     >
-                        <DropdownItem
-                            title={ColumnDtypes.BOOL}
-                        />
-                        <DropdownItem
-                            title={ColumnDtypes.INT}
-                            subtext={'Casting to an int will turn all NaN values to 0.'}
-                            hideSubtext
-                            displaySubtextOnHover
-                        />
-                        <DropdownItem
-                            title={ColumnDtypes.FLOAT}
-                        />
-                        <DropdownItem
-                            title={ColumnDtypes.STRING}
-                        />
-                        <DropdownItem
-                            title={ColumnDtypes.DATETIME}
-                        />
-                        <DropdownItem
-                            title={ColumnDtypes.TIMEDELTA}
-                        />
+                        {getDtypeSelectOptions()}
                     </Select>
                 </Col>
             </Row>

--- a/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/DtypeCard.tsx
+++ b/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/DtypeCard.tsx
@@ -67,11 +67,13 @@ export function getDtypeSelectOptions(onChange?: (newDtype: string) => void): JS
 
     return [
         <DropdownItem
-                title={ColumnDtypes.BOOL}
-                onClick={onChange ? () => {onChange(ColumnDtypes.BOOL)} : undefined}
+            title={ColumnDtypes.BOOL}
+            key={ColumnDtypes.BOOL}
+            onClick={onChange ? () => {onChange(ColumnDtypes.BOOL)} : undefined}
         />,
         <DropdownItem
             title={ColumnDtypes.INT}
+            key={ColumnDtypes.INT}
             subtext={'Casting to an int will turn all NaN values to 0.'}
             hideSubtext
             displaySubtextOnHover
@@ -79,22 +81,26 @@ export function getDtypeSelectOptions(onChange?: (newDtype: string) => void): JS
         />,
         <DropdownItem
             title={ColumnDtypes.FLOAT}
+            key={ColumnDtypes.FLOAT}
             onClick={onChange ? () => {onChange(ColumnDtypes.FLOAT)} : undefined}
 
         />,
         <DropdownItem
             title={ColumnDtypes.STRING}
+            key={ColumnDtypes.STRING}
             onClick={onChange ? () => {onChange(ColumnDtypes.STRING)} : undefined}
         />,
         <DropdownItem
             title={ColumnDtypes.DATETIME}
+            key={ColumnDtypes.DATETIME}
             onClick={onChange ? () => {onChange(ColumnDtypes.DATETIME)} : undefined}
         />,
         <DropdownItem
             title={ColumnDtypes.TIMEDELTA}
+            key={ColumnDtypes.TIMEDELTA}
             onClick={onChange ? () => {onChange(ColumnDtypes.TIMEDELTA)} : undefined}
         />
-]
+    ]
 }
 
 /*

--- a/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/DtypeCard.tsx
+++ b/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/DtypeCard.tsx
@@ -69,7 +69,7 @@ function DtypeCard(props: DtypeCardProps): JSX.Element {
     async function changeColumnDtype(newDtype: string) {
         const newStepID = await props.mitoAPI.editChangeColumnDtype(
             props.selectedSheetIndex,
-            props.columnID,
+            [props.columnID],
             newDtype,
             stepID
         )

--- a/mitosheet/src/components/toolbar/Toolbar.tsx
+++ b/mitosheet/src/components/toolbar/Toolbar.tsx
@@ -23,9 +23,10 @@ import ToolbarRowsDropdown from './ToolbarRowsDropdown.tsx';
 import OpenOnboardingChecklist from './OpenChecklistButton';
 import { isVariantB } from '../../utils/experiments';
 import ToolbarFormatDropdown from './ToolbarFormatDropdown';
-import { getSelectedNumberSeriesColumnIDs } from '../endo/selectionUtils';
+import { getSelectedColumnIDsWithEntireSelectedColumn, getSelectedNumberSeriesColumnIDs } from '../endo/selectionUtils';
 import DropdownItem from '../elements/DropdownItem';
 import { TaskpaneType } from '../taskpanes/taskpanes';
+import { getDtypeSelectOptions } from '../taskpanes/ControlPanel/FilterAndSortTab/DtypeCard';
 
 const Toolbar = (
     props: {
@@ -43,9 +44,9 @@ const Toolbar = (
         sheetData: SheetData;
         userProfile: UserProfile;
         setEditorState: React.Dispatch<React.SetStateAction<EditorState | undefined>>;
-        analysisData: AnalysisData
-    }): JSX.Element => {
-    
+        analysisData: AnalysisData,
+        sheetIndex: number
+    }): JSX.Element => {    
 
     return (
         <div className='toolbar-container'>
@@ -149,12 +150,16 @@ const Toolbar = (
                         setEditorState={props.setEditorState}
                     >
                         <Dropdown
-                            display={props.uiState.displayImportToolbarDropdown}
+                            display={props.uiState.toolbarDropdown === 'import'}
                             closeDropdown={() => 
                                 props.setUIState(prevUIState => {
+                                    if (prevUIState.toolbarDropdown !== 'import') {
+                                        return prevUIState;
+                                    }
+
                                     return {
                                         ...prevUIState,
-                                        displayImportToolbarDropdown: false
+                                        toolbarDropdown: undefined
                                     }
                                 })
                             }
@@ -202,7 +207,34 @@ const Toolbar = (
                         action={props.actions[ActionEnum.Change_Dtype]}
                         setEditorState={props.setEditorState}
                         disabledTooltip={isVariantB(props.analysisData) ? undefined : props.actions[ActionEnum.Change_Dtype].isDisabled()}
-                    />
+                    >  
+                        <Dropdown
+                            display={props.uiState.toolbarDropdown === 'dtype'}
+                            closeDropdown={() => 
+                                props.setUIState(prevUIState => {
+                                    if (prevUIState.toolbarDropdown !== 'dtype') {
+                                        return prevUIState;
+                                    }
+
+                                    return {
+                                        ...prevUIState,
+                                        toolbarDropdown: undefined
+                                    }
+                                })
+                            }
+                            width='medium'
+                            
+                        >
+                            {getDtypeSelectOptions((newDtype => {
+                                const selectedColumnIDs = getSelectedColumnIDsWithEntireSelectedColumn(props.gridState.selections, props.sheetData);
+                                void props.mitoAPI.editChangeColumnDtype(
+                                    props.sheetIndex,
+                                    selectedColumnIDs,
+                                    newDtype
+                                )
+                            }))}
+                        </Dropdown>
+                    </ToolbarButton>
                     <div className="toolbar-vertical-line"></div>
                     <ToolbarButton
                         toolbarButtonType={ToolbarButtonType.LESS}
@@ -224,12 +256,16 @@ const Toolbar = (
                         disabledTooltip={isVariantB(props.analysisData) ? undefined : props.actions[ActionEnum.Format_Number_Columns].isDisabled()}
                     >
                         <Dropdown
-                            display={props.uiState.displayFormatToolbarDropdown}
+                            display={props.uiState.toolbarDropdown === 'format'}
                             closeDropdown={() => 
                                 props.setUIState(prevUIState => {
+                                    if (prevUIState.toolbarDropdown !== 'format') {
+                                        return prevUIState;
+                                    }
+
                                     return {
                                         ...prevUIState,
-                                        displayFormatToolbarDropdown: false
+                                        toolbarDropdown: undefined
                                     }
                                 })
                             }

--- a/mitosheet/src/jupyter/api.tsx
+++ b/mitosheet/src/jupyter/api.tsx
@@ -1076,7 +1076,7 @@ export default class MitoAPI {
     */
     async editChangeColumnDtype(
         sheetIndex: number,
-        columnID: ColumnID,
+        columnIDs: ColumnID[],
         newDtype: string,
         stepID?: string
     ): Promise<string> {
@@ -1090,7 +1090,7 @@ export default class MitoAPI {
             'step_id': stepID,
             'params': {
                 'sheet_index': sheetIndex,
-                'column_id': columnID,
+                'column_ids': columnIDs,
                 'new_dtype': newDtype
             }
         }, {});

--- a/mitosheet/src/types.tsx
+++ b/mitosheet/src/types.tsx
@@ -717,8 +717,7 @@ export interface UIState {
     selectedGraphID: GraphID | undefined;
     selectedTabType: 'data' | 'graph';
     currOpenToolbarDropdown: undefined | ToolbarDropdowns;
-    displayImportToolbarDropdown: boolean;
-    displayFormatToolbarDropdown: boolean;
+    toolbarDropdown: 'import' | 'format' | 'dtype' | undefined;
 }
 
 /**

--- a/mitosheet/src/utils/actions.tsx
+++ b/mitosheet/src/utils/actions.tsx
@@ -104,9 +104,7 @@ export const createActions = (
                 setUIState(prevUIState => {
                     return {
                         ...prevUIState,
-                        currOpenTaskpane: {type: TaskpaneType.CONTROL_PANEL},
-                        selectedColumnControlPanelTab: ControlPanelTab.FilterSort,
-                        selectedTabType: 'data'
+                        toolbarDropdown: 'dtype'
                     }
                 })
             },
@@ -481,7 +479,7 @@ export const createActions = (
                 setUIState(prevUIState => {
                     return {
                         ...prevUIState,
-                        displayFormatToolbarDropdown: true
+                        toolbarDropdown: 'format'
                     }
                 })
             },
@@ -590,7 +588,7 @@ export const createActions = (
                 setUIState(prevUIState => {
                     return {
                         ...prevUIState,
-                        displayImportToolbarDropdown: true
+                        toolbarDropdown: 'import'
                     }
                 })
             },


### PR DESCRIPTION
# Description

Implements: https://www.notion.so/trymito/Bulk-change-dtype-ea4de1d94c1b4f669bc8746568a8c2ad

There is one minor complexity: we can't really easily generate a single line of code too easily. It's not the most complicated heuristic to generate less lines of code, but it does get complex pretty quickly. 

I attempted implementing it, and it blew up to about 60 lines of pretty complex code - it's just really tricky b/c (for example), our conversion functions don't all allow you to pass a dataframe rather than just a single column header (e.g. the `to_float_series` function). This then requires complex logic about reasoning when you can group things, which seems both very complex and very error prone. 

Feel free to take a shot at it if you want to get a feel for it. I spent 20 minutes on all the rest of the code, and 40 minutes on this combining alone, before realizing the extent of the complexity!

# Testing

Check new tests. Also, use this!

Also, errors only get thrown for the first error. I think this is pretty much fine and sensible, as users likely won't remember more than 1 or 2 column we mention in that horrible error modal that pops up anyways!

# Documentation

Woo!