### PR TITLE
mitosheet: add different export options for graphs

### DIFF
--- a/mitosheet/mitosheet/step_performers/graph_steps/plotly_express_graphs.py
+++ b/mitosheet/mitosheet/step_performers/graph_steps/plotly_express_graphs.py
@@ -554,8 +554,4 @@ def get_plotly_express_graph_code(
         graph_styling_code(graph_type, all_column_headers, is_safety_filter_applied, graph_styling_params)
     )
 
-    # We use fig.show(renderer="iframe") which works in both JLab 2 & 3
-    # and renders in line,
-    code.append('fig.show(renderer="iframe")')
-
     return "\n".join(code)

--- a/mitosheet/src/components/elements/TextButton.tsx
+++ b/mitosheet/src/components/elements/TextButton.tsx
@@ -63,9 +63,14 @@ interface TextButtonProps {
     className?: string
 
     /**
-        * @param [disabledTooltip] -- Messaage to display as tooltip when button is disabled 
+        * @param [disabledTooltip] - Messaage to display as tooltip when button is disabled 
     */
     disabledTooltip?: string
+
+    /**
+        * @param [title] - Message to dispaly as tooltip. Overwridden by disabledTooltip if button is disabled
+    */
+    title?: string
 }
 
 /**
@@ -100,7 +105,7 @@ const TextButton = (props: TextButtonProps): JSX.Element => {
                 download={disabled ? undefined : props.download}
                 onClick={disabled ? () => {return} : props.onClick}
                 target={props.target}
-                title={props.disabled && props.disabledTooltip ? props.disabledTooltip : undefined}
+                title={props.disabled && props.disabledTooltip ? props.disabledTooltip : props.title ? props.title : undefined}
             >
                 {props.children}
             </a>
@@ -113,7 +118,7 @@ const TextButton = (props: TextButtonProps): JSX.Element => {
                 type={props.type}
                 disabled={props.disabled}
                 autoFocus={props.autoFocus}
-                title={props.disabled && props.disabledTooltip ? props.disabledTooltip : undefined}
+                title={props.disabled && props.disabledTooltip ? props.disabledTooltip : props.title ? props.title : undefined}
             >
                 {props.children}
             </button>

--- a/mitosheet/src/components/taskpanes/Graph/GraphExportTab.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/GraphExportTab.tsx
@@ -51,6 +51,7 @@ function GraphExportTab(
                     variant='dark'
                     onClick={copyShowGraphCode}
                     disabled={props.loading || props.graphOutput === undefined}
+                    title={'Click to copy code that creates graph and displays it in the notebook'}
                 >
                     {!showGraphCodeCopied
                         ? "Copy Show Graph Code"
@@ -63,6 +64,7 @@ function GraphExportTab(
                     variant='dark'
                     onClick={copyExportHTMLGraphCode}
                     disabled={props.loading || props.graphOutput === undefined}
+                    title={'Click to copy code that creates graph and exports it as an html file'}
                 >
                     {!exportHTMLGraphCodeCopied
                         ? "Copy Export HTML Graph Code"
@@ -79,6 +81,7 @@ function GraphExportTab(
                         downloadLink?.click()
                     }}
                     disabled={props.loading || props.graphOutput === undefined}
+                    title={'Click to download graph as png'}
                 >
                     Download as PNG
                 </TextButton>

--- a/mitosheet/src/components/taskpanes/Graph/GraphExportTab.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/GraphExportTab.tsx
@@ -14,17 +14,32 @@ function GraphExportTab(
         mitoAPI: MitoAPI;
         graphParams: GraphParamsFrontend
         loading: boolean
-        graphOutput: GraphOutput
+        graphOutput: GraphOutput,
+        graphTabName: string,
         mitoContainerRef: React.RefObject<HTMLDivElement>
     }): JSX.Element {
 
-    const [_copyGraphCode, graphCodeCopied] = useCopyToClipboard(props.graphOutput?.graphGeneratedCode);
+    // We append the correct export code for showing and for exporting to html
+    const [_copyShowGraphCode, showGraphCodeCopied] = useCopyToClipboard(
+        (props.graphOutput?.graphGeneratedCode || '') + `\nfig.show(renderer="iframe")`
+    );
+    const [_copyExportHTMLGraphCode, exportHTMLGraphCodeCopied] = useCopyToClipboard(
+        (props.graphOutput?.graphGeneratedCode || '') + `\nfig.write_html("${props.graphTabName}.html")`
+    );
 
-    const copyGraphCode = () => {
-        _copyGraphCode()
+    const copyShowGraphCode = () => {
+        _copyShowGraphCode()
 
         // Log that the user copied the graph code
         void props.mitoAPI.log('copy_graph_code', {
+            'graph_type': props.graphParams.graphCreation.graph_type
+        });
+    }
+    const copyExportHTMLGraphCode = () => {
+        _copyExportHTMLGraphCode()
+
+        // Log that the user copied the graph code
+        void props.mitoAPI.log('copy_export_html_graph_code', {
             'graph_type': props.graphParams.graphCreation.graph_type
         });
     }
@@ -34,11 +49,23 @@ function GraphExportTab(
             <div>
                 <TextButton
                     variant='dark'
-                    onClick={copyGraphCode}
+                    onClick={copyShowGraphCode}
                     disabled={props.loading || props.graphOutput === undefined}
                 >
-                    {!graphCodeCopied
-                        ? "Copy Graph Code"
+                    {!showGraphCodeCopied
+                        ? "Copy Show Graph Code"
+                        : "Copied to Clipboard!"
+                    }
+                </TextButton>
+            </div>
+            <div>
+                <TextButton
+                    variant='dark'
+                    onClick={copyExportHTMLGraphCode}
+                    disabled={props.loading || props.graphOutput === undefined}
+                >
+                    {!exportHTMLGraphCodeCopied
+                        ? "Copy Export HTML Graph Code"
                         : "Copied to Clipboard!"
                     }
                 </TextButton>

--- a/mitosheet/src/components/taskpanes/Graph/GraphSidebar.tsx
+++ b/mitosheet/src/components/taskpanes/Graph/GraphSidebar.tsx
@@ -67,6 +67,7 @@ const GraphSidebar = (props: {
 
     const dataSourceSheetIndex = graphParams.graphCreation.sheet_index
     const graphOutput = props.graphDataDict[graphID]?.graphOutput
+    const graphTabName = props.graphDataDict[graphID]?.graphTabName;
     const [loading, setLoading] = useState<boolean>(false)
 
     const [selectedGraphSidebarTab, setSelectedGraphSidebarTab] = useState<GraphSidebarTab>(GraphSidebarTab.Setup)
@@ -255,6 +256,7 @@ const GraphSidebar = (props: {
                         }
                         {selectedGraphSidebarTab === GraphSidebarTab.Export && 
                             <GraphExportTab 
+                                graphTabName={graphTabName}
                                 graphParams={graphParams}
                                 mitoAPI={props.mitoAPI}
                                 loading={loading}


### PR DESCRIPTION
# Description

Per spec: https://www.notion.so/trymito/Download-graph-as-HTML-d43470a091e7465d98c8b705e0885364

Takes a slightly simpler approach of just appending the export code on the frontend, which is nice methinks!

Can you think of better text for these buttons?

# Testing

Test both export options.

# Documentation

Minor updates necessary.