### PR TITLE
trymito: switch github for install docs

### DIFF
--- a/trymito.io/components/CTAButtons/CTAButtons.tsx
+++ b/trymito.io/components/CTAButtons/CTAButtons.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { MITO_INSTALLATION_DOCS_LINK } from '../Header/Header';
 import TextButton from '../TextButton/TextButton';
 import styles from './CTAButtons.module.css'
 
@@ -9,7 +10,7 @@ const CTAButtons = (props: {variant: 'download' | 'contact'}): JSX.Element => {
             {props.variant === 'download' && 
                 <TextButton 
                     text='Install Mito for Jupyter'
-                    href='https://github.com/mito-ds/monorepo'
+                    href={MITO_INSTALLATION_DOCS_LINK}
                 />
             }
             {props.variant === 'contact' && 

--- a/trymito.io/components/Footer/Footer.tsx
+++ b/trymito.io/components/Footer/Footer.tsx
@@ -3,6 +3,7 @@ import Image from "next/image"
 import footerStyle from './Footer.module.css'
 import pageStyle from '../../styles/Page.module.css'
 import { MITO_GITHUB_LINK } from '../GithubButton/GithubButton';
+import { MITO_INSTALLATION_DOCS_LINK } from '../Header/Header';
 
 const Footer = (): JSX.Element => {
 
@@ -38,7 +39,7 @@ const Footer = (): JSX.Element => {
                         <a href={MITO_GITHUB_LINK} target="_blank" rel="noreferrer">GitHub</a>
                     </li>
                     <li className='text-nav'>
-                        <a href='https://docs.trymito.io/getting-started/installing-mito' target="_blank" rel="noreferrer">Install</a>
+                        <a href={MITO_INSTALLATION_DOCS_LINK} target="_blank" rel="noreferrer">Install</a>
                     </li>
                     <li className='text-nav'>
                         <Link href='/security'>Security</Link>

--- a/trymito.io/components/Header/Header.tsx
+++ b/trymito.io/components/Header/Header.tsx
@@ -7,6 +7,7 @@ import CloseButton from '../../public/CloseButton.png'
 import TranslucentButton from "../TranslucentButton/TranslucentButton"
 import GithubButton, { MITO_GITHUB_LINK } from "../GithubButton/GithubButton"
 
+export const MITO_INSTALLATION_DOCS_LINK = 'https://docs.trymito.io/getting-started/installing-mito'
 
 const Header = (): JSX.Element => {
 
@@ -47,7 +48,7 @@ const Header = (): JSX.Element => {
                 text='Star on Github'
               />              
               <TranslucentButton
-                href='https://github.com/mito-ds/monorepo'
+                href={MITO_INSTALLATION_DOCS_LINK}
               >
                 <>
                   Install

--- a/trymito.io/pages/plans.tsx
+++ b/trymito.io/pages/plans.tsx
@@ -7,7 +7,7 @@ import pageStyles from '../styles/Page.module.css'
 import plansStyles from '../styles/Plans.module.css'
 import iconAndTextCardStyles from '../styles/IconAndTextCard.module.css'
 
-import Header from '../components/Header/Header';
+import Header, { MITO_INSTALLATION_DOCS_LINK } from '../components/Header/Header';
 import Footer from '../components/Footer/Footer';
 import PlanBullet from '../components/PlanBullet/PlanBullet';
 import TranslucentButton from '../components/TranslucentButton/TranslucentButton';
@@ -385,7 +385,7 @@ const Plans: NextPage = () => {
                 <div className={plansStyles.plan_cta}>
                   <TextButton 
                     text='Get Started'
-                    href='https://docs.trymito.io/getting-started/installing-mito'
+                    href={MITO_INSTALLATION_DOCS_LINK}
                   />
                 </div>
               </div>


### PR DESCRIPTION
# Description

Moves the install buttons back to our installation docs instead of GitHub. 

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.