### PR TITLE
Ipywidget 7

### DIFF
--- a/mitosheet/package.json
+++ b/mitosheet/package.json
@@ -25,7 +25,7 @@
   },
   "version": "0.3.131",
   "dependencies": {
-    "@jupyter-widgets/base": "^4 || ^5 || ^6",
+    "@jupyter-widgets/base": "^4",
     "@jupyterlab/notebook": "^3.0.6",
     "@types/fscreen": "^1.0.1",
     "@types/react-dom": "^17.0.2",

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -209,11 +209,11 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
         packages                 = setuptools.find_packages(exclude=['deployment']),
         install_requires=[        
             "jupyterlab~=3.0",
-            'ipywidgets>=7',
+            'ipywidgets>=7,<8; python_version<"3.10"',
+            'ipywidgets~=7.7.0; python_version>="3.10"',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which
             # is equivlaent to the @jupyter-widgets/jupyterlab-manager extension for jlab 2
-            'jupyterlab-widgets>=3.0; python_version>="3.7"',
-            'jupyterlab-widgets>=1.0; python_version<"3.7"',
+            'jupyterlab-widgets~=1.0.0',
             # We allow users to have many versions of pandas installed. All functionality should
             # work, with the exception of Excel import, which might require additonal dependencies
             'pandas>=0.24.2',
@@ -225,7 +225,7 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
             'openpyxl',
             # xlsxwriter is needed for adding formatting to exported Excel sheets. 
             # We pin to a pretty old version because the formatting functionality hasn't changed in a long time.
-            'xlsxwriter>=0.6.9,<=3.0.2 '
+            'xlsxwriter>=0.6.9,<=3.0.2'
         ],
         extras_require = {
             'test': [

--- a/mitosheet/setup.py
+++ b/mitosheet/setup.py
@@ -209,6 +209,9 @@ elif name == 'mitosheet' or name == 'mitosheet3' or name == 'mitosheet-private':
         packages                 = setuptools.find_packages(exclude=['deployment']),
         install_requires=[        
             "jupyterlab~=3.0",
+            # According to this documentation (https://ipywidgets.readthedocs.io/en/7.x/changelog.html),
+            # ipywidgets 7.7 is the first release to support Python 3.10.
+            # Mito does not support ipywidgets 8 because it is still in testing
             'ipywidgets>=7,<8; python_version<"3.10"',
             'ipywidgets~=7.7.0; python_version>="3.10"',
             # In JLab 3, we move to needing to install the jupyterlab-widgets package, which

--- a/mitosheet/src/jupyter/widget.tsx
+++ b/mitosheet/src/jupyter/widget.tsx
@@ -62,20 +62,12 @@ import { ModalEnum } from '../components/modals/modals';
 import { convertBackendtoFrontendGraphParams } from '../components/taskpanes/Graph/graphUtils';
 
 
-/**
- * In IPyWidgets 8.0, the type of parameters we need moved from InitializeParameters
- * to IInitializeParameters. So we create this fancy conditional types to support
- * both earlier versions as well, as they are necessary on JupyterLab 2.0. 
- */
-type InitializeParametersOf<T> = T extends { IInitializeParameters: unknown } ? T["IInitializeParameters"] : (T extends { InitializeParameters: unknown } ? T["InitializeParameters"] : never);
-
-
 export class ExampleView extends DOMWidgetView {
     // Used to make code in the notebook not flash when read in for replaying.
     // See write-code-to-cell below.
     creationSeconds: undefined | number;
 
-    initialize(parameters: InitializeParametersOf<WidgetView>): void {
+    initialize(parameters: WidgetView.InitializeParameters): void {
         super.initialize(parameters);
 
         // Bind the functions we pass down to other classes

--- a/mitosheet/switch.py
+++ b/mitosheet/switch.py
@@ -154,7 +154,7 @@ MITOSHEET_PACKAGE_JSON = """{
   },
   "version": "0.3.131",
   "dependencies": {
-    "@jupyter-widgets/base": "^4 || ^5 || ^6",
+    "@jupyter-widgets/base": "^4",
     "@jupyterlab/notebook": "^3.0.6",
     "@types/fscreen": "^1.0.1",
     "@types/react-dom": "^17.0.2",
@@ -275,7 +275,7 @@ def switch(new_package):
       open('package.json', 'w').write(MITOSHEET_TWO_PACKAGE_JSON)
     elif new_package == 'mitosheet':    
       open('package.json', 'w').write(MITOSHEET_PACKAGE_JSON.replace('REPLACE_WITH_PACKAGE_NAME_WITH_REPLACE', 'mitosheet'))
-    elif new_package == 'mitosheet3':    
+    elif new_package == 'mitosheet3':  
       open('package.json', 'w').write(MITOSHEET_PACKAGE_JSON.replace('REPLACE_WITH_PACKAGE_NAME_WITH_REPLACE', 'mitosheet3'))
     elif new_package == 'mitosheet-private':
        open('package.json', 'w').write(MITOSHEET_PACKAGE_JSON.replace('REPLACE_WITH_PACKAGE_NAME_WITH_REPLACE', 'mitosheet-private'))


### PR DESCRIPTION
# Description

Moves from ipywidgets 8 -> 7 since ipywidgets 7 has been patched to support Python 3.10

# Testing

See tests below. This is tested on
- All major versions of Python from 3.6 -> 3.10
- ipywidgets 7.6.3 and 7.7.2
- jupyterlab-widgets 1.0.2
- Notebook/Lab
- Windows/Mac

# Documentation

Note if any new documentation needs to addressed or reviewed.