### PR TITLE
Import config improvements

### DIFF
--- a/mitosheet/mitosheet/api/api.py
+++ b/mitosheet/mitosheet/api/api.py
@@ -34,7 +34,7 @@ MAX_QUEUED_API_CALLS = 3
 
 # NOTE: BE CAREFUL WITH THIS. When in development mode, you can set it to False
 # so the API calls are handled in the main thread, to make printing easy
-THREADED = True
+THREADED = False
 
 
 class API:

--- a/mitosheet/mitosheet/api/api.py
+++ b/mitosheet/mitosheet/api/api.py
@@ -34,7 +34,7 @@ MAX_QUEUED_API_CALLS = 3
 
 # NOTE: BE CAREFUL WITH THIS. When in development mode, you can set it to False
 # so the API calls are handled in the main thread, to make printing easy
-THREADED = False
+THREADED = True
 
 
 class API:

--- a/mitosheet/mitosheet/api/get_csv_files_metadata.py
+++ b/mitosheet/mitosheet/api/get_csv_files_metadata.py
@@ -8,8 +8,8 @@ import os
 from typing import Any, Dict
 
 import pandas as pd
-from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL, DEFAULT_DELIMETER, DEFAULT_ENCODING
-from mitosheet.step_performers.import_steps.simple_import import read_csv_get_delimiter_and_encoding_and_decimal
+from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL, DEFAULT_DELIMETER, DEFAULT_ENCODING, DEFAULT_SKIPROWS
+from mitosheet.step_performers.import_steps.simple_import import read_csv_get_delimiter_and_encoding
 from mitosheet.types import StepsManagerType
 
 
@@ -17,29 +17,34 @@ def get_csv_files_metadata(params: Dict[str, Any], steps_manager: StepsManagerTy
     """
     Given a list of 'file_names' that should be CSV files,
     this returns our guesses for delimeters and encodings
-    for these files.
+    for these files, as well as other default parameters that we 
+    don't try to guess
     """
     file_names = params['file_names']
 
     delimeters = []
     encodings = []
     decimals = []
+    skiprows = []
     for file_name in file_names:
         try:
-            _, delimiter, encoding, decimal = read_csv_get_delimiter_and_encoding_and_decimal(file_name)
+            _, delimiter, encoding = read_csv_get_delimiter_and_encoding(file_name)
             delimeters.append(delimiter)
             encodings.append(encoding)
-            decimals.append(decimal)
         except:
             # The default values displayed in the UI
             delimeters.append(DEFAULT_DELIMETER)
-            encodings.append('utf-8')
-            decimals.append(DEFAULT_DECIMAL)
+            encodings.append(DEFAULT_ENCODING)
+
+        # We don't have a good way to guess these params, so we always use the defaults
+        decimals.append(DEFAULT_DECIMAL)
+        skiprows.append(DEFAULT_SKIPROWS)
 
     return json.dumps({
         'delimeters': delimeters,
         'encodings': encodings,
-        'decimals': decimals
+        'decimals': decimals,
+        'skiprows': skiprows 
     })
 
 

--- a/mitosheet/mitosheet/api/get_csv_files_metadata.py
+++ b/mitosheet/mitosheet/api/get_csv_files_metadata.py
@@ -8,7 +8,7 @@ import os
 from typing import Any, Dict
 
 import pandas as pd
-from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_ENCODING
+from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL, DEFAULT_DELIMETER, DEFAULT_ENCODING
 from mitosheet.step_performers.import_steps.simple_import import read_csv_get_delimiter_and_encoding_and_decimal
 from mitosheet.types import StepsManagerType
 
@@ -23,19 +23,23 @@ def get_csv_files_metadata(params: Dict[str, Any], steps_manager: StepsManagerTy
 
     delimeters = []
     encodings = []
+    decimals = []
     for file_name in file_names:
         try:
-            _, delimiter, encoding = read_csv_get_delimiter_and_encoding_and_decimal(file_name)
+            _, delimiter, encoding, decimal = read_csv_get_delimiter_and_encoding_and_decimal(file_name)
             delimeters.append(delimiter)
             encodings.append(encoding)
+            decimals.append(decimal)
         except:
             # The default values displayed in the UI
-            delimeters.append(',')
+            delimeters.append(DEFAULT_DELIMETER)
             encodings.append('utf-8')
+            decimals.append(DEFAULT_DECIMAL)
 
     return json.dumps({
         'delimeters': delimeters,
-        'encodings': encodings
+        'encodings': encodings,
+        'decimals': decimals
     })
 
 

--- a/mitosheet/mitosheet/api/get_csv_files_metadata.py
+++ b/mitosheet/mitosheet/api/get_csv_files_metadata.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 
 import pandas as pd
 from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_ENCODING
-from mitosheet.step_performers.import_steps.simple_import import read_csv_get_delimeter_and_encoding
+from mitosheet.step_performers.import_steps.simple_import import read_csv_get_delimiter_and_encoding_and_decimal
 from mitosheet.types import StepsManagerType
 
 
@@ -25,7 +25,7 @@ def get_csv_files_metadata(params: Dict[str, Any], steps_manager: StepsManagerTy
     encodings = []
     for file_name in file_names:
         try:
-            _, delimiter, encoding = read_csv_get_delimeter_and_encoding(file_name)
+            _, delimiter, encoding = read_csv_get_delimiter_and_encoding_and_decimal(file_name)
             delimeters.append(delimiter)
             encodings.append(encoding)
         except:

--- a/mitosheet/mitosheet/api/get_imported_files_and_dataframes_from_current_steps.py
+++ b/mitosheet/mitosheet/api/get_imported_files_and_dataframes_from_current_steps.py
@@ -40,6 +40,7 @@ def get_import_data_with_single_import_list(step_type: str, params: Dict[str, An
                 'delimeters': get_sublist_at_index_from_optional_list(params.get('delimeters', None), index),
                 'encodings': get_sublist_at_index_from_optional_list(params.get('encodings', None), index),
                 'decimals': get_sublist_at_index_from_optional_list(params.get('decimals', None), index),
+                'skiprows': get_sublist_at_index_from_optional_list(params.get('skiprows', None), index),
                 'error_bad_lines': get_sublist_at_index_from_optional_list(params.get('error_bad_lines', None), index)
             }
         } for index, file_name in enumerate(params['file_names'])]

--- a/mitosheet/mitosheet/api/get_imported_files_and_dataframes_from_current_steps.py
+++ b/mitosheet/mitosheet/api/get_imported_files_and_dataframes_from_current_steps.py
@@ -39,6 +39,7 @@ def get_import_data_with_single_import_list(step_type: str, params: Dict[str, An
                 'file_names': [file_name],
                 'delimeters': get_sublist_at_index_from_optional_list(params.get('delimeters', None), index),
                 'encodings': get_sublist_at_index_from_optional_list(params.get('encodings', None), index),
+                'decimals': get_sublist_at_index_from_optional_list(params.get('decimals', None), index),
                 'error_bad_lines': get_sublist_at_index_from_optional_list(params.get('error_bad_lines', None), index)
             }
         } for index, file_name in enumerate(params['file_names'])]
@@ -50,7 +51,8 @@ def get_import_data_with_single_import_list(step_type: str, params: Dict[str, An
                 'file_name': params['file_name'],
                 'sheet_names': [sheet_name],
                 'has_headers': params['has_headers'],
-                'skiprows': params['skiprows']
+                'skiprows': params['skiprows'],
+                'decimal': params['decimal']
             }
         } for sheet_name in params['sheet_names']]
 

--- a/mitosheet/mitosheet/code_chunks/step_performers/import_steps/excel_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/import_steps/excel_import_code_chunk.py
@@ -4,9 +4,12 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 
-from typing import List
+from typing import Any, Dict, List
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
+from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL
+from mitosheet.step_performers.utils import get_param
+from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_code
 
 
 class ExcelImportCodeChunk(CodeChunk):
@@ -22,23 +25,13 @@ class ExcelImportCodeChunk(CodeChunk):
     def get_code(self) -> List[str]:
         file_name = self.get_param('file_name')
         sheet_names = self.get_param('sheet_names')
-        has_headers = self.get_param('has_headers')
-        skiprows = self.get_param('skiprows')
-        decimal = self.get_param('decimal')
-
-        read_excel_params = {
-            'sheet_name': sheet_names,
-            'skiprows': skiprows,
-            'decimal': f"'{decimal}'"
-        }
-
-        # Get rid of the headers if it doesn't have them
-        if not has_headers:
-            read_excel_params['header'] = None
+        
+        read_excel_params = build_read_excel_params(self.params)
 
         read_excel_line = f'sheet_df_dictonary = pd.read_excel(r\'{file_name}\', engine=\'openpyxl\''
         for key, value in read_excel_params.items():
-            read_excel_line += f', {key}={value}'
+            # We use this slighly misnamed function to make sure values get transpiled right
+            read_excel_line += f", {key}={column_header_to_transpiled_code(value)}"
         read_excel_line += ')'
 
         df_definitions = []
@@ -56,3 +49,24 @@ class ExcelImportCodeChunk(CodeChunk):
     def get_created_sheet_indexes(self) -> List[int]:
         sheet_names = self.get_param('sheet_names')
         return [i for i in range(len(self.post_state.dfs) - len(sheet_names), len(self.post_state.dfs))]
+
+    
+def build_read_excel_params(params: Dict[str, Any]) -> Dict[str, Any]:
+    sheet_names: List[str] = get_param(params, 'sheet_names')
+    has_headers: bool = get_param(params, 'has_headers')
+    skiprows: int = get_param(params, 'skiprows')
+    decimal: str = get_param(params, 'decimal')
+
+    read_excel_params = {
+        'sheet_name': sheet_names,
+        'skiprows': skiprows,
+    }
+
+    # Get rid of the headers if it doesn't have them
+    if not has_headers:
+        read_excel_params['header'] = None
+
+    if decimal is not None and decimal is not DEFAULT_DECIMAL: 
+        read_excel_params['decimal'] = decimal
+
+    return read_excel_params

--- a/mitosheet/mitosheet/code_chunks/step_performers/import_steps/excel_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/import_steps/excel_import_code_chunk.py
@@ -24,10 +24,12 @@ class ExcelImportCodeChunk(CodeChunk):
         sheet_names = self.get_param('sheet_names')
         has_headers = self.get_param('has_headers')
         skiprows = self.get_param('skiprows')
+        decimal = self.get_param('decimal')
 
         read_excel_params = {
             'sheet_name': sheet_names,
-            'skiprows': skiprows
+            'skiprows': skiprows,
+            'decimal': f"'{decimal}'"
         }
 
         # Get rid of the headers if it doesn't have them

--- a/mitosheet/mitosheet/code_chunks/step_performers/import_steps/simple_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/import_steps/simple_import_code_chunk.py
@@ -14,9 +14,10 @@ from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_cod
 DEFAULT_ENCODING = 'utf-8'
 DEFAULT_DELIMETER = ','
 DEFAULT_DECIMAL = '.'
+DEFAULT_SKIPROWS = 0
 DEFAULT_ERROR_BAD_LINES = True
 
-def get_read_csv_params(delimeter: str, encoding: str, decimal: str, error_bad_lines: bool) -> Dict[str, Any]:
+def get_read_csv_params(delimeter: str, encoding: str, decimal: Optional[str], skiprows: Optional[int], error_bad_lines: Optional[bool]) -> Dict[str, Any]:
     from mitosheet.saved_analyses.schema_utils import is_prev_version
     params: Dict[str, Any] = {}
 
@@ -24,9 +25,11 @@ def get_read_csv_params(delimeter: str, encoding: str, decimal: str, error_bad_l
         params['encoding'] = encoding
     if delimeter != DEFAULT_DELIMETER:
         params['sep'] = delimeter
-    if decimal != DEFAULT_DECIMAL: 
+    if decimal is not None and decimal != DEFAULT_DECIMAL: 
         params['decimal'] = decimal
-    if error_bad_lines != DEFAULT_ERROR_BAD_LINES:
+    if skiprows is not None and skiprows != DEFAULT_SKIPROWS:
+        params['skiprows'] = skiprows
+    if error_bad_lines is not None and error_bad_lines != DEFAULT_ERROR_BAD_LINES:
         # See here: https://datascientyst.com/drop-bad-lines-with-read_csv-pandas/
         if is_prev_version(pd.__version__, '1.3.0'):
             params['error_bad_lines'] = error_bad_lines
@@ -36,13 +39,13 @@ def get_read_csv_params(delimeter: str, encoding: str, decimal: str, error_bad_l
     return params
 
 
-def generate_read_csv_code(file_name: str, df_name: str, delimeter: str, encoding: str, decimal: str, error_bad_lines: bool) -> str:
+def generate_read_csv_code(file_name: str, df_name: str, delimeter: str, encoding: str, decimal: Optional[str], skiprows: Optional[int], error_bad_lines: Optional[bool]) -> str:
     """
     Helper function for generating minimal read_csv code 
     depending on the delimeter and the encoding of a file
     """
 
-    params = get_read_csv_params(delimeter, encoding, decimal, error_bad_lines)
+    params = get_read_csv_params(delimeter, encoding, decimal=decimal, skiprows=skiprows, error_bad_lines=error_bad_lines)
     params_string = ', '.join(f'{key}={column_header_to_transpiled_code(value)}' for key, value in params.items())
 
     return f'{df_name} = pd.read_csv(r\'{file_name}\'{", " if len(params_string) > 0 else ""}{params_string})'
@@ -63,6 +66,7 @@ class SimpleImportCodeChunk(CodeChunk):
         file_delimeters = self.get_execution_data('file_delimeters')
         file_encodings = self.get_execution_data('file_encodings')
         file_decimals = self.get_execution_data('file_decimals')
+        file_skiprows = self.get_execution_data('file_skiprows')
         file_error_bad_lines = self.get_execution_data('file_error_bad_lines')
 
         code = ['import pandas as pd']
@@ -73,11 +77,11 @@ class SimpleImportCodeChunk(CodeChunk):
             delimeter = file_delimeters[index]
             encoding = file_encodings[index]
             decimal = file_decimals[index]
+            skiprows = file_skiprows[index]
             error_bad_lines = file_error_bad_lines[index]
 
-
             code.append(
-                generate_read_csv_code(file_name, df_name, delimeter, encoding, decimal, error_bad_lines)
+                generate_read_csv_code(file_name, df_name, delimeter, encoding, decimal, skiprows, error_bad_lines)
             )
             
             index += 1
@@ -94,6 +98,7 @@ class SimpleImportCodeChunk(CodeChunk):
         new_file_delimeters = self.get_execution_data('file_delimeters') + other_code_chunk.get_execution_data('file_delimeters')
         new_file_encodings = self.get_execution_data('file_encodings') + other_code_chunk.get_execution_data('file_encodings')
         new_file_decimals = self.get_execution_data('file_decimals') + other_code_chunk.get_execution_data('file_decimals')
+        new_file_skiprows = self.get_execution_data('file_skiprows') + other_code_chunk.get_execution_data('file_skiprows')
         new_error_bad_lines = self.get_execution_data('file_error_bad_lines') + other_code_chunk.get_execution_data('file_error_bad_lines')
 
         return SimpleImportCodeChunk(
@@ -104,6 +109,7 @@ class SimpleImportCodeChunk(CodeChunk):
                 'file_delimeters': new_file_delimeters,
                 'file_encodings': new_file_encodings,
                 'file_decimals': new_file_decimals,
+                'file_skiprows': new_file_skiprows,
                 'file_error_bad_lines': new_error_bad_lines
             }
         )

--- a/mitosheet/mitosheet/code_chunks/step_performers/import_steps/simple_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/import_steps/simple_import_code_chunk.py
@@ -11,6 +11,7 @@ import pandas as pd
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_code
 
+# Note: These defaults must be the same as the pandas.read_csv defaults
 DEFAULT_ENCODING = 'utf-8'
 DEFAULT_DELIMETER = ','
 DEFAULT_DECIMAL = '.'

--- a/mitosheet/mitosheet/code_chunks/step_performers/import_steps/simple_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/import_steps/simple_import_code_chunk.py
@@ -11,8 +11,7 @@ import pandas as pd
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_code
 
-# We use 'default' instead of None to ensure that we log the encoding even when we don't need to set one.
-DEFAULT_ENCODING = 'default'
+DEFAULT_ENCODING = 'utf-8'
 DEFAULT_DELIMETER = ','
 DEFAULT_DECIMAL = '.'
 DEFAULT_ERROR_BAD_LINES = True

--- a/mitosheet/mitosheet/errors.py
+++ b/mitosheet/mitosheet/errors.py
@@ -498,7 +498,7 @@ def make_invalid_simple_import_error(error_modal: bool=False) -> MitoError:
 
     Occurs when a user tries to simple import and it fails
     """
-    to_fix = f'We were unable to automatically determine a delimiter and encoding. Update import to select a delimiter and encoding.' 
+    to_fix = f'We were unable to automatically determine the import configurations, like delimiter and encoding. Update the import configuration.' 
     
     return MitoError(
         'invalid_simple_import_error', 

--- a/mitosheet/mitosheet/mito_widget.py
+++ b/mitosheet/mitosheet/mito_widget.py
@@ -9,6 +9,7 @@ Main file containing the mito widget.
 """
 import json
 import os
+from sysconfig import get_python_version
 import time
 from typing import Any, Dict, List, Optional, Union
 
@@ -33,7 +34,7 @@ from mitosheet.user.db import USER_JSON_PATH, get_user_field
 from mitosheet.user.location import is_in_google_colab, is_in_vs_code
 from mitosheet.user.schemas import (UJ_MITOSHEET_LAST_FIFTY_USAGES, UJ_RECEIVED_CHECKLISTS,
                                     UJ_RECEIVED_TOURS, UJ_USER_EMAIL)
-from mitosheet.user.utils import get_pandas_version, is_excel_import_enabled, is_pro, is_running_test
+from mitosheet.user.utils import get_pandas_version, is_pro, is_running_test
 
 try:
     from mitosheet_helper_config import MITO_ENTERPRISE_CONFIGURATION 
@@ -108,7 +109,7 @@ class MitoWidget(DOMWidget):
             'isPro': is_pro(),
             'telemetryEnabled': telemetry_turned_on(),
             # Static over a single analysis
-            'excelImportEnabled': is_excel_import_enabled(),
+            'pythonVersion': get_python_version(),
             'pandasVersion': get_pandas_version(),
             'isLocalDeployment': self.is_local_deployment,
             'shouldUpgradeMitosheet': self.should_upgrade_mitosheet,

--- a/mitosheet/mitosheet/mito_widget.py
+++ b/mitosheet/mitosheet/mito_widget.py
@@ -33,7 +33,7 @@ from mitosheet.user.db import USER_JSON_PATH, get_user_field
 from mitosheet.user.location import is_in_google_colab, is_in_vs_code
 from mitosheet.user.schemas import (UJ_MITOSHEET_LAST_FIFTY_USAGES, UJ_RECEIVED_CHECKLISTS,
                                     UJ_RECEIVED_TOURS, UJ_USER_EMAIL)
-from mitosheet.user.utils import is_excel_import_enabled, is_pro, is_running_test
+from mitosheet.user.utils import get_pandas_version, is_excel_import_enabled, is_pro, is_running_test
 
 try:
     from mitosheet_helper_config import MITO_ENTERPRISE_CONFIGURATION 
@@ -109,6 +109,7 @@ class MitoWidget(DOMWidget):
             'telemetryEnabled': telemetry_turned_on(),
             # Static over a single analysis
             'excelImportEnabled': is_excel_import_enabled(),
+            'pandasVersion': get_pandas_version(),
             'isLocalDeployment': self.is_local_deployment,
             'shouldUpgradeMitosheet': self.should_upgrade_mitosheet,
             'numUsages': self.num_usages,

--- a/mitosheet/mitosheet/preprocessing/preprocess_read_file_paths.py
+++ b/mitosheet/mitosheet/preprocessing/preprocess_read_file_paths.py
@@ -13,7 +13,7 @@ from mitosheet.telemetry.telemetry_utils import log
 from mitosheet.preprocessing.preprocess_step_performer import \
     PreprocessStepPerformer
 from mitosheet.step_performers.import_steps.simple_import import (
-    get_valid_dataframe_names, read_csv_get_delimiter_and_encoding_and_decimal)
+    get_valid_dataframe_names, read_csv_get_delimiter_and_encoding)
 from mitosheet.types import StepsManagerType
 
 
@@ -37,18 +37,16 @@ class ReadFilePathsPreprocessStepPerformer(PreprocessStepPerformer):
         df_args: List[pd.DataFrame] = []
         delimeters: List[Optional[str]] = []
         encodings: List[Optional[str]] = []
-        decimals: List[Optional[str]] = []
         for arg in args:
             if isinstance(arg, pd.DataFrame):
                 df_args.append(arg)
                 delimeters.append(None)
                 encodings.append(None)
-                decimals.append(None)
             elif isinstance(arg, str):
                 # If it is a string, we try and read it in as a dataframe
                 try:
                     # We use the simple import 
-                    df, delimeter, encoding, decimal = read_csv_get_delimiter_and_encoding_and_decimal(arg)
+                    df, delimeter, encoding = read_csv_get_delimiter_and_encoding(arg)
 
                     df_args.append(
                         df
@@ -56,7 +54,6 @@ class ReadFilePathsPreprocessStepPerformer(PreprocessStepPerformer):
 
                     delimeters.append(delimeter)
                     encodings.append(encoding)
-                    decimals.append(decimal)
                 except:
                     # If this pd.read_csv fails, then we report this error to the user
                     # as a failed mitosheet call
@@ -71,7 +68,6 @@ class ReadFilePathsPreprocessStepPerformer(PreprocessStepPerformer):
         return df_args, {
             'delimeters': delimeters,
             'encodings': encodings,
-            'decimals': decimals
         }
 
     @classmethod
@@ -94,7 +90,6 @@ class ReadFilePathsPreprocessStepPerformer(PreprocessStepPerformer):
 
         delimeters = execution_data['delimeters'] if execution_data is not None else [None for _ in range(len(df_names))]
         encodings = execution_data['encodings'] if execution_data is not None else [None for _ in range(len(df_names))]
-        decimals = execution_data['decimals'] if execution_data is not None else [None for _ in range(len(df_names))]
 
         num_strs = 0
         for arg_index, arg in enumerate(steps_manager.original_args):
@@ -103,7 +98,7 @@ class ReadFilePathsPreprocessStepPerformer(PreprocessStepPerformer):
                 num_strs += 1
 
                 read_csv_code = generate_read_csv_code(
-                    arg, df_name, delimeters[arg_index], encodings[arg_index], decimals[arg_index], True
+                    arg, df_name, delimeters[arg_index], encodings[arg_index], None, None, None
                 )
 
                 code.append(

--- a/mitosheet/mitosheet/preprocessing/preprocess_read_file_paths.py
+++ b/mitosheet/mitosheet/preprocessing/preprocess_read_file_paths.py
@@ -13,7 +13,7 @@ from mitosheet.telemetry.telemetry_utils import log
 from mitosheet.preprocessing.preprocess_step_performer import \
     PreprocessStepPerformer
 from mitosheet.step_performers.import_steps.simple_import import (
-    get_valid_dataframe_names, read_csv_get_delimeter_and_encoding)
+    get_valid_dataframe_names, read_csv_get_delimiter_and_encoding_and_decimal)
 from mitosheet.types import StepsManagerType
 
 
@@ -37,16 +37,18 @@ class ReadFilePathsPreprocessStepPerformer(PreprocessStepPerformer):
         df_args: List[pd.DataFrame] = []
         delimeters: List[Optional[str]] = []
         encodings: List[Optional[str]] = []
+        decimals: List[Optional[str]] = []
         for arg in args:
             if isinstance(arg, pd.DataFrame):
                 df_args.append(arg)
                 delimeters.append(None)
                 encodings.append(None)
+                decimals.append(None)
             elif isinstance(arg, str):
                 # If it is a string, we try and read it in as a dataframe
                 try:
                     # We use the simple import 
-                    df, delimeter, encoding = read_csv_get_delimeter_and_encoding(arg)
+                    df, delimeter, encoding, decimal = read_csv_get_delimiter_and_encoding_and_decimal(arg)
 
                     df_args.append(
                         df
@@ -54,6 +56,7 @@ class ReadFilePathsPreprocessStepPerformer(PreprocessStepPerformer):
 
                     delimeters.append(delimeter)
                     encodings.append(encoding)
+                    decimals.append(decimal)
                 except:
                     # If this pd.read_csv fails, then we report this error to the user
                     # as a failed mitosheet call
@@ -67,7 +70,8 @@ class ReadFilePathsPreprocessStepPerformer(PreprocessStepPerformer):
                 
         return df_args, {
             'delimeters': delimeters,
-            'encodings': encodings
+            'encodings': encodings,
+            'decimals': decimals
         }
 
     @classmethod
@@ -90,6 +94,7 @@ class ReadFilePathsPreprocessStepPerformer(PreprocessStepPerformer):
 
         delimeters = execution_data['delimeters'] if execution_data is not None else [None for _ in range(len(df_names))]
         encodings = execution_data['encodings'] if execution_data is not None else [None for _ in range(len(df_names))]
+        decimals = execution_data['decimals'] if execution_data is not None else [None for _ in range(len(df_names))]
 
         num_strs = 0
         for arg_index, arg in enumerate(steps_manager.original_args):
@@ -98,7 +103,7 @@ class ReadFilePathsPreprocessStepPerformer(PreprocessStepPerformer):
                 num_strs += 1
 
                 read_csv_code = generate_read_csv_code(
-                    arg, df_name, delimeters[arg_index], encodings[arg_index], True
+                    arg, df_name, delimeters[arg_index], encodings[arg_index], decimals[arg_index], True
                 )
 
                 code.append(

--- a/mitosheet/mitosheet/step_performers/import_steps/excel_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/excel_import.py
@@ -39,12 +39,14 @@ class ExcelImportStepPerformer(StepPerformer):
         sheet_names: List[str] = get_param(params, 'sheet_names')
         has_headers: bool = get_param(params, 'has_headers')
         skiprows: int = get_param(params, 'skiprows')
+        decimal: bool = get_param(params, 'decimal')
 
         post_state = prev_state.copy()
 
         read_excel_params = {
             'sheet_name': sheet_names,
-            'skiprows': skiprows
+            'skiprows': skiprows,
+            'decimal': decimal
         }
 
         # Get rid of the headers if it doesn't have them

--- a/mitosheet/mitosheet/step_performers/import_steps/excel_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/excel_import.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import pandas as pd
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.code_chunks.step_performers.import_steps.excel_import_code_chunk import \
-    ExcelImportCodeChunk
+    ExcelImportCodeChunk, build_read_excel_params
 from mitosheet.errors import make_file_not_found_error
 from mitosheet.state import DATAFRAME_SOURCE_IMPORTED, State
 from mitosheet.step_performers.step_performer import StepPerformer
@@ -36,23 +36,11 @@ class ExcelImportStepPerformer(StepPerformer):
     @classmethod
     def execute(cls, prev_state: State, params: Dict[str, Any]) -> Tuple[State, Optional[Dict[str, Any]]]:
         file_name: str = get_param(params, 'file_name')
-        sheet_names: List[str] = get_param(params, 'sheet_names')
-        has_headers: bool = get_param(params, 'has_headers')
-        skiprows: int = get_param(params, 'skiprows')
-        decimal: bool = get_param(params, 'decimal')
+
+        read_excel_params = build_read_excel_params(params)
 
         post_state = prev_state.copy()
-
-        read_excel_params = {
-            'sheet_name': sheet_names,
-            'skiprows': skiprows,
-            'decimal': decimal
-        }
-
-        # Get rid of the headers if it doesn't have them
-        if not has_headers:
-            read_excel_params['header'] = None
-
+        
         if not os.path.exists(file_name):
             raise make_file_not_found_error(file_name)
 

--- a/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
@@ -129,7 +129,7 @@ class SimpleImportStepPerformer(StepPerformer):
 
 
 
-def read_csv_get_delimiter_and_encoding_and_decimal(file_name: str) -> Tuple[pd.DataFrame, str, str]:
+def read_csv_get_delimiter_and_encoding_and_decimal(file_name: str) -> Tuple[pd.DataFrame, str, str, str]:
     """
     Given a file_name, will read in the file as a CSV, and
     return the df, delimeter, decimal separator, and encoding of the file

--- a/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import chardet
 import pandas as pd
 from mitosheet.code_chunks.code_chunk import CodeChunk
-from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL, DEFAULT_DELIMETER, DEFAULT_ENCODING, SimpleImportCodeChunk, get_read_csv_params
+from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL, DEFAULT_DELIMETER, DEFAULT_ENCODING, DEFAULT_ERROR_BAD_LINES, DEFAULT_SKIPROWS, SimpleImportCodeChunk, get_read_csv_params
 from mitosheet.step_performers.utils import get_param
 
 from mitosheet.utils import get_valid_dataframe_names
@@ -43,6 +43,7 @@ class SimpleImportStepPerformer(StepPerformer):
         delimeters: Optional[List[str]] = get_param(params, 'delimeters')
         encodings: Optional[List[str]] = get_param(params, 'encodings')
         decimals: Optional[List[str]] = get_param(params, 'decimals')
+        skiprows: Optional[List[str]] = get_param(params, 'skiprows')
         error_bad_lines: Optional[List[bool]] = get_param(params, 'error_bad_lines')
 
         use_deprecated_id_algorithm: bool = get_param(params, 'use_deprecated_id_algorithm') if get_param(params, 'use_deprecated_id_algorithm') else False
@@ -59,6 +60,7 @@ class SimpleImportStepPerformer(StepPerformer):
         file_delimeters = []
         file_encodings = []
         file_decimals = []
+        file_skiprows = []
         file_error_bad_lines = []
 
         just_final_file_names = [basename(normpath(file_name)) for file_name in file_names]
@@ -68,18 +70,23 @@ class SimpleImportStepPerformer(StepPerformer):
             
             partial_pandas_start_time = perf_counter()
 
-            # NOTE: if you specify one, specify them all!
             try:
-                if delimeters is not None and encodings is not None and error_bad_lines is not None and decimals is not None:
+                # NOTE: if you specify one, specify them all!
+                if None not in [delimeters, encodings, decimals, skiprows, error_bad_lines]:
                     delimeter = delimeters[index]
                     encoding = encodings[index]
                     decimal = decimals[index]
+                    _skiprows = skiprows[index]
                     _error_bad_lines = error_bad_lines[index]
-                    df = pd.read_csv(file_name, **get_read_csv_params(delimeter, encoding, decimal, _error_bad_lines))
+                    df = pd.read_csv(file_name, **get_read_csv_params(delimeter, encoding, decimal, _skiprows, _error_bad_lines))
                     pandas_processing_time += (perf_counter() - partial_pandas_start_time)
                 else:
-                    df, delimeter, encoding, decimal = read_csv_get_delimiter_and_encoding_and_decimal(file_name)
-                    _error_bad_lines = True
+                    # If you don't specify all of the params, we guess the params we're able to and use 
+                    # the default values for the rest of them
+                    df, delimeter, encoding = read_csv_get_delimiter_and_encoding(file_name)
+                    decimal = DEFAULT_DECIMAL
+                    _skiprows = DEFAULT_SKIPROWS
+                    _error_bad_lines = DEFAULT_ERROR_BAD_LINES
                     pandas_processing_time += (perf_counter() - partial_pandas_start_time)
             except:
                 if os.path.exists(file_name):
@@ -91,6 +98,7 @@ class SimpleImportStepPerformer(StepPerformer):
             file_delimeters.append(delimeter)
             file_encodings.append(encoding)
             file_decimals.append(decimal)
+            file_skiprows.append(_skiprows)
             file_error_bad_lines.append(_error_bad_lines)
             
             post_state.add_df_to_state(
@@ -106,6 +114,7 @@ class SimpleImportStepPerformer(StepPerformer):
             'file_delimeters': file_delimeters,
             'file_encodings': file_encodings,
             'file_decimals': file_decimals,
+            'file_skiprows': file_skiprows,
             'file_error_bad_lines': file_error_bad_lines,
             'pandas_processing_time': pandas_processing_time
         }
@@ -129,14 +138,13 @@ class SimpleImportStepPerformer(StepPerformer):
 
 
 
-def read_csv_get_delimiter_and_encoding_and_decimal(file_name: str) -> Tuple[pd.DataFrame, str, str, str]:
+def read_csv_get_delimiter_and_encoding(file_name: str) -> Tuple[pd.DataFrame, str, str]:
     """
     Given a file_name, will read in the file as a CSV, and
     return the df, delimeter, decimal separator, and encoding of the file
     """
     encoding = DEFAULT_ENCODING
     delimeter = DEFAULT_DELIMETER
-    decimal = DEFAULT_DECIMAL
     try:
         # First attempt to read csv without specifying an encoding, just with a delimeter
         delimeter = guess_delimeter(file_name)
@@ -146,16 +154,16 @@ def read_csv_get_delimiter_and_encoding_and_decimal(file_name: str) -> Tuple[pd.
         try: 
             encoding = guess_encoding(file_name)
             delimeter = guess_delimeter(file_name, encoding=encoding)
-            decimal = guess_decimal(file_name)
+
             # Read the file as dataframe 
-            df = pd.read_csv(file_name, sep=delimeter, encoding=encoding, decimal=decimal)
+            df = pd.read_csv(file_name, sep=delimeter, encoding=encoding)
         except: 
             # Sometimes guess_encoding, guesses 'ascii' when we want 'latin-1', 
             # so if guess_encoding fails, we try latin-1
             encoding = 'latin-1'
-            df = pd.read_csv(file_name, sep=delimeter, encoding=encoding, decimal=decimal)
+            df = pd.read_csv(file_name, sep=delimeter, encoding=encoding)
         
-    return df, delimeter, encoding, decimal
+    return df, delimeter, encoding
 
 
 def guess_delimeter(file_name: str, encoding: str=None) -> str:
@@ -176,9 +184,3 @@ def guess_encoding(file_name: str) -> str:
     with open(file_name, 'rb') as f:
         result = chardet.detect(f.readline())
         return result['encoding']
-
-def guess_decimal(file_name: str, encoding: str=None) -> str:
-    """
-    For now, always guesses that the decimal is a .
-    """
-    return '.'

--- a/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
@@ -45,9 +45,6 @@ class SimpleImportStepPerformer(StepPerformer):
         decimals: Optional[List[str]] = get_param(params, 'decimals')
         skiprows: Optional[List[int]] = get_param(params, 'skiprows')
         error_bad_lines: Optional[List[bool]] = get_param(params, 'error_bad_lines')
-
-        print(params)
-
         use_deprecated_id_algorithm: bool = get_param(params, 'use_deprecated_id_algorithm') if get_param(params, 'use_deprecated_id_algorithm') else False
 
         # If any of the files are directories, we throw an error to let

--- a/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/simple_import.py
@@ -43,7 +43,7 @@ class SimpleImportStepPerformer(StepPerformer):
         delimeters: Optional[List[str]] = get_param(params, 'delimeters')
         encodings: Optional[List[str]] = get_param(params, 'encodings')
         decimals: Optional[List[str]] = get_param(params, 'decimals')
-        skiprows: Optional[List[str]] = get_param(params, 'skiprows')
+        skiprows: Optional[List[int]] = get_param(params, 'skiprows')
         error_bad_lines: Optional[List[bool]] = get_param(params, 'error_bad_lines')
 
         use_deprecated_id_algorithm: bool = get_param(params, 'use_deprecated_id_algorithm') if get_param(params, 'use_deprecated_id_algorithm') else False
@@ -72,7 +72,7 @@ class SimpleImportStepPerformer(StepPerformer):
 
             try:
                 # NOTE: if you specify one, specify them all!
-                if None not in [delimeters, encodings, decimals, skiprows, error_bad_lines]:
+                if delimeters is not None and encodings is not None and decimals is not None and skiprows is not None and error_bad_lines is not None:
                     delimeter = delimeters[index]
                     encoding = encodings[index]
                     decimal = decimals[index]

--- a/mitosheet/mitosheet/telemetry/telemetry_utils.py
+++ b/mitosheet/mitosheet/telemetry/telemetry_utils.py
@@ -194,7 +194,11 @@ except:
 try:
     from pandas import __version__ as pandas_version
 except:
-    pandas_version = 'unkown'
+    pandas_version = 'no pandas'
+try:
+    from ipywidgets import __version__ as ipywidgets_version
+except:
+    ipywidgets_version = 'no pandas'
 
 
 location = None
@@ -212,6 +216,7 @@ def _get_enviornment_params() -> Dict[str, Any]:
     enviornment_params = {
         'version_python': sys.version_info,
         'version_pandas': pandas_version,
+        'version_ipywidgets': ipywidgets_version,
         'version_jupyterlab': jupyterlab_version,
         'version_notebook': notebook_version,
         'version_mito': __version__,
@@ -320,6 +325,7 @@ def identify() -> None:
         analytics.identify(static_user_id, {
             'version_python': sys.version_info,
             'version_pandas': pandas_version,
+            'version_ipywidgets': ipywidgets_version,
             'version_sys': sys.version,
             'version_mito': __version__,
             'package_name': package_name, 

--- a/mitosheet/mitosheet/telemetry/telemetry_utils.py
+++ b/mitosheet/mitosheet/telemetry/telemetry_utils.py
@@ -191,6 +191,11 @@ try:
     from notebook import __version__ as notebook_version
 except:
     notebook_version = 'No notebook'
+try:
+    from pandas import __version__ as pandas_version
+except:
+    pandas_version = 'unkown'
+
 
 location = None
 
@@ -206,6 +211,7 @@ def _get_enviornment_params() -> Dict[str, Any]:
     # Add the python properties to every log event we can
     enviornment_params = {
         'version_python': sys.version_info,
+        'version_pandas': pandas_version,
         'version_jupyterlab': jupyterlab_version,
         'version_notebook': notebook_version,
         'version_mito': __version__,
@@ -313,6 +319,7 @@ def identify() -> None:
         # NOTE: we do not log anything when tests are running
         analytics.identify(static_user_id, {
             'version_python': sys.version_info,
+            'version_pandas': pandas_version,
             'version_sys': sys.version,
             'version_mito': __version__,
             'package_name': package_name, 

--- a/mitosheet/mitosheet/tests/decorators.py
+++ b/mitosheet/mitosheet/tests/decorators.py
@@ -35,6 +35,11 @@ pandas_post_1_4_only = pytest.mark.skipif(
     reason='This test only runs on later versions of Pandas. API inconsistencies make it fail on earlier versions'
 )
 
+pandas_post_1_5_only = pytest.mark.skipif(
+    is_prev_version(pd.__version__, '1.5.0'), 
+    reason='This test only runs on later versions of Pandas. API inconsistencies make it fail on earlier versions'
+)
+
 pandas_pre_1_2_only = pytest.mark.skipif(
     not is_prev_version(pd.__version__, '1.2.0'), 
     reason='This test only runs on later versions of Pandas. API inconsistencies make it fail on earlier versions'

--- a/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_import.py
+++ b/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_import.py
@@ -65,7 +65,7 @@ def test_can_import_multiple_sheets():
     # Create with no dataframes
     mito = create_mito_wrapper_dfs()
     # And then import just a test file
-    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0, DEFAULT_DECIMAL)
+    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0)
 
     # Make sure a step has been created, and that the dataframe is the correct dataframe
     assert mito.curr_step.step_type == 'excel_import'
@@ -87,7 +87,7 @@ def test_can_import_multiple_sheets_then_delete_no_optimize():
     # Create with no dataframes
     mito = create_mito_wrapper_dfs()
     # And then import just a test file
-    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0, DEFAULT_DECIMAL)
+    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0)
     mito.delete_dataframe(0)
 
     # Make sure a step has been created, and that the dataframe is the correct dataframe
@@ -109,7 +109,7 @@ def test_can_import_multiple_sheets_then_delete_last_no_optimize():
     # Create with no dataframes
     mito = create_mito_wrapper_dfs()
     # And then import just a test file
-    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0, DEFAULT_DECIMAL)
+    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0)
     mito.delete_dataframe(1)
 
     # Make sure a step has been created, and that the dataframe is the correct dataframe
@@ -131,7 +131,7 @@ def test_can_import_multiple_sheets_then_multiple_deletes():
     # Create with no dataframes
     mito = create_mito_wrapper_dfs()
     # And then import just a test file
-    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0, DEFAULT_DECIMAL)
+    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0)
     mito.delete_dataframe(0)
     mito.delete_dataframe(0)
 
@@ -151,7 +151,7 @@ def test_can_import_multiple_sheets_then_multiple_deletes_later_in_analysis():
 
     mito = create_mito_wrapper_dfs(df)
 
-    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0, DEFAULT_DECIMAL)
+    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0)
     mito.delete_dataframe(2)
     mito.delete_dataframe(1)
 
@@ -171,7 +171,7 @@ def test_remove_multiple_one_by_one_does_not_optimize_till_all_gone():
 
     mito = create_mito_wrapper_dfs(df)
 
-    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0, DEFAULT_DECIMAL)
+    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0)
     mito.delete_dataframe(2)
 
     assert len(mito.dfs) == 2

--- a/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_import.py
+++ b/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_import.py
@@ -5,6 +5,7 @@
 # Distributed under the terms of the GPL License.
 import os
 import pandas as pd
+from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL
 
 from mitosheet.tests.test_utils import create_mito_wrapper_dfs
 from mitosheet.tests.decorators import pandas_post_1_only, python_post_3_6_only
@@ -20,7 +21,7 @@ def test_can_import_a_single_excel():
     # Create with no dataframes
     mito = create_mito_wrapper_dfs()
     # And then import just a test file
-    mito.excel_import(TEST_FILE, ['Sheet1'], True, 0)
+    mito.excel_import(TEST_FILE, ['Sheet1'], True, 0, DEFAULT_DECIMAL)
 
     # Make sure a step has been created, and that the dataframe is the correct dataframe
     assert mito.curr_step.step_type == 'excel_import'
@@ -40,7 +41,7 @@ def test_can_import_with_no_headers_and_skiprows():
     # Create with no dataframes
     mito = create_mito_wrapper_dfs()
     # And then import just a test file
-    mito.excel_import(TEST_FILE, ['Sheet1'], False, 2)
+    mito.excel_import(TEST_FILE, ['Sheet1'], False, 2, DEFAULT_DECIMAL)
 
     # Make sure a step has been created, and that the dataframe is the correct dataframe
     assert mito.curr_step.step_type == 'excel_import'
@@ -64,7 +65,7 @@ def test_can_import_multiple_sheets():
     # Create with no dataframes
     mito = create_mito_wrapper_dfs()
     # And then import just a test file
-    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0)
+    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0, DEFAULT_DECIMAL)
 
     # Make sure a step has been created, and that the dataframe is the correct dataframe
     assert mito.curr_step.step_type == 'excel_import'
@@ -86,7 +87,7 @@ def test_can_import_multiple_sheets_then_delete_no_optimize():
     # Create with no dataframes
     mito = create_mito_wrapper_dfs()
     # And then import just a test file
-    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0)
+    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0, DEFAULT_DECIMAL)
     mito.delete_dataframe(0)
 
     # Make sure a step has been created, and that the dataframe is the correct dataframe
@@ -108,7 +109,7 @@ def test_can_import_multiple_sheets_then_delete_last_no_optimize():
     # Create with no dataframes
     mito = create_mito_wrapper_dfs()
     # And then import just a test file
-    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0)
+    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0, DEFAULT_DECIMAL)
     mito.delete_dataframe(1)
 
     # Make sure a step has been created, and that the dataframe is the correct dataframe
@@ -130,7 +131,7 @@ def test_can_import_multiple_sheets_then_multiple_deletes():
     # Create with no dataframes
     mito = create_mito_wrapper_dfs()
     # And then import just a test file
-    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0)
+    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0, DEFAULT_DECIMAL)
     mito.delete_dataframe(0)
     mito.delete_dataframe(0)
 
@@ -150,7 +151,7 @@ def test_can_import_multiple_sheets_then_multiple_deletes_later_in_analysis():
 
     mito = create_mito_wrapper_dfs(df)
 
-    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0)
+    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0, DEFAULT_DECIMAL)
     mito.delete_dataframe(2)
     mito.delete_dataframe(1)
 
@@ -170,7 +171,7 @@ def test_remove_multiple_one_by_one_does_not_optimize_till_all_gone():
 
     mito = create_mito_wrapper_dfs(df)
 
-    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0)
+    mito.excel_import(TEST_FILE, ['Sheet1', 'Sheet2'], True, 0, DEFAULT_DECIMAL)
     mito.delete_dataframe(2)
 
     assert len(mito.dfs) == 2
@@ -181,3 +182,15 @@ def test_remove_multiple_one_by_one_does_not_optimize_till_all_gone():
 
     # Remove the test file
     os.remove(TEST_FILE)
+
+
+def test_comma_decimal_excel_import():
+    df_comma = pd.DataFrame({'KG': ['267,88', '458,99', '125,89', '1,55', '1']}) 
+    df_result = pd.DataFrame({'KG': [267.88, 458.99, 125.89, 1.55, 1]}) 
+    with pd.ExcelWriter(TEST_FILE) as writer:  
+        df_comma.to_excel(writer, sheet_name='Sheet1', index=False)
+
+    mito = create_mito_wrapper_dfs()
+    mito.excel_import(TEST_FILE, ['Sheet1'], True, 0, ',')
+    
+    assert mito.dfs[0].equals(df_result)

--- a/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_import.py
+++ b/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_import.py
@@ -184,6 +184,8 @@ def test_remove_multiple_one_by_one_does_not_optimize_till_all_gone():
     os.remove(TEST_FILE)
 
 
+@pandas_post_1_only
+@python_post_3_6_only
 def test_comma_decimal_excel_import():
     df_comma = pd.DataFrame({'KG': ['267,88', '458,99', '125,89', '1,55', '1']}) 
     df_result = pd.DataFrame({'KG': [267.88, 458.99, 125.89, 1.55, 1]}) 

--- a/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_import.py
+++ b/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_import.py
@@ -8,7 +8,7 @@ import pandas as pd
 from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL
 
 from mitosheet.tests.test_utils import create_mito_wrapper_dfs
-from mitosheet.tests.decorators import pandas_post_1_only, python_post_3_6_only
+from mitosheet.tests.decorators import pandas_post_1_only, pandas_post_1_4_only, python_post_3_6_only
 
 TEST_FILE = 'file.xlsx'
 
@@ -184,7 +184,7 @@ def test_remove_multiple_one_by_one_does_not_optimize_till_all_gone():
     os.remove(TEST_FILE)
 
 
-@pandas_post_1_only
+@pandas_post_1_4_only
 @python_post_3_6_only
 def test_comma_decimal_excel_import():
     df_comma = pd.DataFrame({'KG': ['267,88', '458,99', '125,89', '1,55', '1']}) 

--- a/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_import.py
+++ b/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_import.py
@@ -194,3 +194,6 @@ def test_comma_decimal_excel_import():
     mito.excel_import(TEST_FILE, ['Sheet1'], True, 0, ',')
     
     assert mito.dfs[0].equals(df_result)
+
+    # Remove the test file
+    os.remove(TEST_FILE)

--- a/mitosheet/mitosheet/tests/test_ts_types.py
+++ b/mitosheet/mitosheet/tests/test_ts_types.py
@@ -219,13 +219,17 @@ def test_update_events_enum_defined():
 def test_update_events_default_import_decimal():
     default_delimiter = get_constant_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "DEFAULT_DELIMETER")
     default_encoding = get_constant_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "DEFAULT_ENCODING")
-    default_decimal = get_constant_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "DEFAULT_DECIMAL")
+    _default_decimal = get_constant_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "DEFAULT_DECIMAL")
     default_skiprows = get_constant_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "DEFAULT_SKIPROWS")
     default_error_bad_lines = get_constant_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "DEFAULT_ERROR_BAD_LINES")
+
+    # We must make sure the DEFAULT_DECIMAL reference to the Decimal enum is correct.
+    decimalEnum = get_enum_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "Decimal")
+    default_decimal = decimalEnum[_default_decimal.split('.')[1]]
     
     assert default_delimiter == f'"{DEFAULT_DELIMETER}"'
     assert default_encoding == f'"{DEFAULT_ENCODING}"'
-    assert default_decimal == f'"{DEFAULT_DECIMAL}"'
+    assert default_decimal == f'{DEFAULT_DECIMAL}'
     assert int(default_skiprows) == DEFAULT_SKIPROWS
     assert bool(default_error_bad_lines) == DEFAULT_ERROR_BAD_LINES
 

--- a/mitosheet/mitosheet/tests/test_ts_types.py
+++ b/mitosheet/mitosheet/tests/test_ts_types.py
@@ -3,7 +3,7 @@
 
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
-from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL, DEFAULT_DELIMETER, DEFAULT_ENCODING
+from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL, DEFAULT_DELIMETER, DEFAULT_ENCODING, DEFAULT_ERROR_BAD_LINES, DEFAULT_SKIPROWS
 from mitosheet.data_in_mito import DataTypeInMito
 from mitosheet.mito_config import DEFAULT_SUPPORT_EMAIL, MEC_CONFIG_KEY_SUPPORT_EMAIL, MEC_CONFIG_KEY_VERSION, MitoConfig
 from mitosheet.state import (
@@ -220,7 +220,12 @@ def test_update_events_default_import_decimal():
     default_delimiter = get_constant_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "DEFAULT_DELIMETER")
     default_encoding = get_constant_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "DEFAULT_ENCODING")
     default_decimal = get_constant_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "DEFAULT_DECIMAL")
+    default_skiprows = get_constant_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "DEFAULT_SKIPROWS")
+    default_error_bad_lines = get_constant_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "DEFAULT_ERROR_BAD_LINES")
     
     assert default_delimiter == f'"{DEFAULT_DELIMETER}"'
     assert default_encoding == f'"{DEFAULT_ENCODING}"'
     assert default_decimal == f'"{DEFAULT_DECIMAL}"'
+    assert int(default_skiprows) == DEFAULT_SKIPROWS
+    assert bool(default_error_bad_lines) == DEFAULT_ERROR_BAD_LINES
+

--- a/mitosheet/mitosheet/tests/test_ts_types.py
+++ b/mitosheet/mitosheet/tests/test_ts_types.py
@@ -3,6 +3,7 @@
 
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
+from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL, DEFAULT_DELIMETER, DEFAULT_ENCODING
 from mitosheet.data_in_mito import DataTypeInMito
 from mitosheet.mito_config import DEFAULT_SUPPORT_EMAIL, MEC_CONFIG_KEY_SUPPORT_EMAIL, MEC_CONFIG_KEY_VERSION, MitoConfig
 from mitosheet.state import (
@@ -214,3 +215,12 @@ def test_update_events_enum_defined():
     for UPDATE in UPDATES:
         assert UPDATE['event_type'] in update_types.values()
 
+
+def test_update_events_default_import_decimal():
+    default_delimiter = get_constant_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "DEFAULT_DELIMETER")
+    default_encoding = get_constant_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "DEFAULT_ENCODING")
+    default_decimal = get_constant_from_ts_file("./src/components/import/CSVImportConfigScreen.tsx", "DEFAULT_DECIMAL")
+    
+    assert default_delimiter == f'"{DEFAULT_DELIMETER}"'
+    assert default_encoding == f'"{DEFAULT_ENCODING}"'
+    assert default_decimal == f'"{DEFAULT_DECIMAL}"'

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -775,6 +775,7 @@ class MitoWidgetTestWrapper:
         delimeters: Optional[List[str]]=None, 
         encodings: Optional[List[str]]=None, 
         decimals: Optional[List[str]]=None, 
+        skiprows: Optional[List[int]]=None,
         error_bad_lines: Optional[List[bool]]=None
     ) -> bool:
         return self.mito_widget.receive_message(
@@ -789,6 +790,7 @@ class MitoWidgetTestWrapper:
                     'delimeters': delimeters,
                     'encodings': encodings,
                     'decimals': decimals,
+                    'skiprows': skiprows,
                     'error_bad_lines': error_bad_lines,
                 }
             }

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -795,7 +795,7 @@ class MitoWidgetTestWrapper:
         )
 
     @check_transpiled_code_after_call
-    def excel_import(self, file_name: str, sheet_names: List[str], has_headers: bool, skiprows: int, decimal: str) -> bool:
+    def excel_import(self, file_name: str, sheet_names: List[str], has_headers: bool, skiprows: int, decimal: Optional[str]=None) -> bool:
         return self.mito_widget.receive_message(
             self.mito_widget,
             {

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -769,7 +769,14 @@ class MitoWidgetTestWrapper:
         )
 
     @check_transpiled_code_after_call
-    def simple_import(self, file_names: List[str], delimeters: Optional[List[str]]=None, encodings: Optional[List[str]]=None, error_bad_lines: Optional[List[bool]]=None) -> bool:
+    def simple_import(
+        self, 
+        file_names: List[str], 
+        delimeters: Optional[List[str]]=None, 
+        encodings: Optional[List[str]]=None, 
+        decimals: Optional[List[str]]=None, 
+        error_bad_lines: Optional[List[bool]]=None
+    ) -> bool:
         return self.mito_widget.receive_message(
             self.mito_widget,
             {
@@ -781,6 +788,7 @@ class MitoWidgetTestWrapper:
                     'file_names': file_names,
                     'delimeters': delimeters,
                     'encodings': encodings,
+                    'decimals': decimals,
                     'error_bad_lines': error_bad_lines,
                 }
             }

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -795,7 +795,7 @@ class MitoWidgetTestWrapper:
         )
 
     @check_transpiled_code_after_call
-    def excel_import(self, file_name: str, sheet_names: List[str], has_headers: bool, skiprows: int) -> bool:
+    def excel_import(self, file_name: str, sheet_names: List[str], has_headers: bool, skiprows: int, decimal: str) -> bool:
         return self.mito_widget.receive_message(
             self.mito_widget,
             {
@@ -808,6 +808,7 @@ class MitoWidgetTestWrapper:
                     'sheet_names': sheet_names,
                     'has_headers': has_headers,
                     'skiprows': skiprows,
+                    'decimal': decimal
                 }   
             }
         )

--- a/mitosheet/mitosheet/tests/updates/test_clear.py
+++ b/mitosheet/mitosheet/tests/updates/test_clear.py
@@ -7,6 +7,7 @@ import os
 import sys
 import pandas as pd
 import pytest
+from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL
 
 from mitosheet.tests.test_utils import create_mito_wrapper_dfs
 from mitosheet.tests.decorators import pandas_post_1_only, python_post_3_6_only
@@ -108,7 +109,7 @@ def test_clear_resets_excel_imports():
     df1 = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})
     df1.to_excel('test.xlsx', index=False)
 
-    mito.excel_import('test.xlsx', sheet_names=['Sheet1'], has_headers=True, skiprows=0)
+    mito.excel_import('test.xlsx', sheet_names=['Sheet1'], has_headers=True, skiprows=0, decimal=DEFAULT_DECIMAL)
     mito.add_column(1, 'C')
     mito.add_column(1, 'D')
 

--- a/mitosheet/mitosheet/tests/updates/test_update_existing_import.py
+++ b/mitosheet/mitosheet/tests/updates/test_update_existing_import.py
@@ -130,6 +130,10 @@ def test_replay_steps_correctly():
     # Make sure the updates occured correctly 
     assert mito.dfs[0].equals(pd.DataFrame({'Unnamed: 0': [0, 1, 2], 'A': [10, 20, 30], 'B': [10, 20, 30]}))
 
+    # Remove the test files
+    os.remove(TEST_CSV_FILE)
+    os.remove(TEST_CSV_FILE_TWO)
+
 def test_undo_works():
     # Make dataframes and files for test
     df1 = pd.DataFrame(data={'A': [1, 2, 3]})
@@ -168,6 +172,10 @@ def test_undo_works():
 
     # Make sure the updates occured correctly 
     assert mito.dfs[0].equals(pd.DataFrame({'Unnamed: 0': [0, 1, 2], 'A': [1, 2, 3], 'B': [1, 2, 3]}, index=[0, 1, 2]))
+
+    # Remove the test files
+    os.remove(TEST_CSV_FILE)
+    os.remove(TEST_CSV_FILE_TWO)
 
 
 def test_redo_works():
@@ -209,6 +217,10 @@ def test_redo_works():
     # Make sure the updates occured correctly 
     assert mito.dfs[0].equals(pd.DataFrame({'Unnamed: 0': [0, 1, 2], 'A': [1, 2, 3], 'B': [1, 2, 3]}, index=[0, 1, 2]))
 
+    # Remove the test files
+    os.remove(TEST_CSV_FILE)
+    os.remove(TEST_CSV_FILE_TWO)
+
 
 @pandas_post_1_only
 @python_post_3_6_only
@@ -248,6 +260,10 @@ def test_update_imports_is_atomic():
 
     assert mito.dfs[0].equals(df)
     assert mito.dfs[1].equals(df1)
+
+    # Remove the test files
+    os.remove(TEST_CSV_FILE)
+    os.remove(TEST_EXCEL_FILE)
 
 
 @pandas_post_1_only
@@ -298,6 +314,10 @@ def test_update_imports_with_multiple_imports_per_step():
     assert mito.dfs[0].equals(df1)
     assert mito.dfs[1].equals(df1)
     assert mito.dfs[2].equals(df1)
+
+    # Remove the test files
+    os.remove(TEST_CSV_FILE)
+    os.remove(TEST_EXCEL_FILE)
 
 
 @pandas_post_1_only
@@ -385,6 +405,10 @@ def test_test_import_returns_good_data():
     assert result["5"] == DATAFRAME_IMPORT_ERROR
     assert len(result) == 3
 
+    # Remove the test files
+    os.remove(TEST_CSV_FILE)
+    os.remove(TEST_EXCEL_FILE)
+
 
 @pandas_post_1_only
 @python_post_3_6_only
@@ -437,6 +461,10 @@ def test_test_import_correct_index_for_multiple_items_in_one_step():
     assert result["3"] == 'no such file does not exist.'
     assert len(result) == 2
 
+    # Remove the test files
+    os.remove(TEST_CSV_FILE)
+    os.remove(TEST_EXCEL_FILE)
+
 
 @pandas_post_1_only
 @python_post_3_6_only
@@ -453,7 +481,7 @@ def test_update_imports_replays_unchanged_files_correctly_from_steps():
     
     # Create with no dataframes
     mito = create_mito_wrapper_dfs(df1)
-    mito.simple_import([TEST_CSV_FILE], [','], [encoding], [','], [False])
+    mito.simple_import([TEST_CSV_FILE], [','], [encoding], [','], [0], [False])
     mito.excel_import(TEST_EXCEL_FILE, ['Sheet1'], True, 0, ',')
 
     # Test that all parameters are handled properly from get_imported_files_and_dataframes_from_current_steps
@@ -466,6 +494,7 @@ def test_update_imports_replays_unchanged_files_correctly_from_steps():
     assert import_data_json[0]['imports'][0]['params']['delimeters'] == [',']
     assert import_data_json[0]['imports'][0]['params']['encodings'] == [encoding]
     assert import_data_json[0]['imports'][0]['params']['decimals'] == [","]
+    assert import_data_json[0]['imports'][0]['params']['skiprows'] == [0]
     assert import_data_json[0]['imports'][0]['params']['error_bad_lines'] == [False]
 
     assert import_data_json[1]['imports'][0]['params']['file_name'] == TEST_EXCEL_FILE
@@ -479,6 +508,10 @@ def test_update_imports_replays_unchanged_files_correctly_from_steps():
     assert mito.dfs[0].equals(df1)
     assert mito.dfs[1].equals(df2_result)
     assert mito.dfs[2].equals(df2_result)
+
+    # Remove the test files
+    os.remove(TEST_CSV_FILE)
+    os.remove(TEST_EXCEL_FILE)
 
 
 @pandas_post_1_only
@@ -496,7 +529,7 @@ def test_update_imports_replays_unchanged_files_correctly_from_analysis_name():
     
     # Create with no dataframes
     mito = create_mito_wrapper_dfs(df1)
-    mito.simple_import([TEST_CSV_FILE], [','], [encoding], [','], [False])
+    mito.simple_import([TEST_CSV_FILE], [','], [encoding], [','], [0], [False])
     mito.excel_import(TEST_EXCEL_FILE, ['Sheet1'], True, 0, ',')
 
     # Test that all parameters are handled properly from get_imported_files_and_dataframes_from_current_steps
@@ -509,6 +542,7 @@ def test_update_imports_replays_unchanged_files_correctly_from_analysis_name():
     assert import_data_json[0]['imports'][0]['params']['delimeters'] == [',']
     assert import_data_json[0]['imports'][0]['params']['encodings'] == [encoding]
     assert import_data_json[0]['imports'][0]['params']['decimals'] == [","]
+    assert import_data_json[0]['imports'][0]['params']['skiprows'] == [0]
     assert import_data_json[0]['imports'][0]['params']['error_bad_lines'] == [False]
 
     assert import_data_json[1]['imports'][0]['params']['file_name'] == TEST_EXCEL_FILE
@@ -522,3 +556,8 @@ def test_update_imports_replays_unchanged_files_correctly_from_analysis_name():
     assert mito.dfs[0].equals(df1)
     assert mito.dfs[1].equals(df2_result)
     assert mito.dfs[2].equals(df2_result)
+
+
+    # Remove the test files
+    os.remove(TEST_CSV_FILE)
+    os.remove(TEST_EXCEL_FILE)

--- a/mitosheet/mitosheet/tests/updates/test_update_existing_import.py
+++ b/mitosheet/mitosheet/tests/updates/test_update_existing_import.py
@@ -8,6 +8,7 @@ Contains tests for existing import update events.
 """
 import pandas as pd
 import os
+from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL
 from mitosheet.tests.test_utils import create_mito_wrapper, create_mito_wrapper_dfs
 from mitosheet.tests.decorators import pandas_post_1_only, python_post_3_6_only
 
@@ -33,7 +34,7 @@ def test_overwrite_multiple_imports():
     # Create with no dataframes
     mito = create_mito_wrapper_dfs()
     # And then import three sheets from the excel file
-    mito.excel_import(TEST_EXCEL_FILE, ['Sheet1', 'Sheet2', 'Sheet3'], True, 0)
+    mito.excel_import(TEST_EXCEL_FILE, ['Sheet1', 'Sheet2', 'Sheet3'], True, 0, DEFAULT_DECIMAL)
 
     step_id = mito.curr_step.step_id
 
@@ -58,6 +59,7 @@ def test_overwrite_multiple_imports():
                         'sheet_names': ['Sheet3'],
                         'has_headers': True,
                         'skiprows': 0,
+                        'decimal': '.'
                     }
                 },
                 {
@@ -219,7 +221,7 @@ def test_update_imports_is_atomic():
     
     # Create with no dataframes
     mito = create_mito_wrapper_dfs()
-    mito.excel_import(TEST_EXCEL_FILE, ['Sheet1'], True, 0)
+    mito.excel_import(TEST_EXCEL_FILE, ['Sheet1'], True, 0, DEFAULT_DECIMAL)
     mito.simple_import([TEST_CSV_FILE])
 
     mito.update_existing_imports([
@@ -261,7 +263,7 @@ def test_update_imports_with_multiple_imports_per_step():
     # Create with no dataframes
     mito = create_mito_wrapper_dfs()
     mito.simple_import([TEST_CSV_FILE, TEST_CSV_FILE])
-    mito.excel_import(TEST_EXCEL_FILE, ['Sheet1'], True, 0)
+    mito.excel_import(TEST_EXCEL_FILE, ['Sheet1'], True, 0, DEFAULT_DECIMAL)
 
     mito.update_existing_imports([
         {
@@ -339,7 +341,8 @@ def test_test_import_returns_good_data():
                     'file_name': TEST_EXCEL_FILE,
                     'sheet_names': ['Sheet1'],
                     'has_headers': True,
-                    'skiprows': 0
+                    'skiprows': 0,
+                    'decimal': '.'
                 }
             }]
         },
@@ -351,7 +354,8 @@ def test_test_import_returns_good_data():
                     'file_name': 'fake_file',
                     'sheet_names': ['Sheet1'],
                     'has_headers': True,
-                    'skiprows': 0
+                    'skiprows': 0,
+                    'decimal': '.'
                 }
             }]
         },

--- a/mitosheet/mitosheet/tests/updates/test_update_existing_import.py
+++ b/mitosheet/mitosheet/tests/updates/test_update_existing_import.py
@@ -11,7 +11,7 @@ import os
 import json
 from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL
 from mitosheet.tests.test_utils import create_mito_wrapper, create_mito_wrapper_dfs
-from mitosheet.tests.decorators import pandas_post_1_only, python_post_3_6_only
+from mitosheet.tests.decorators import pandas_post_1_only, pandas_post_1_4_only, python_post_3_6_only
 
 TEST_EXCEL_FILE = 'excel_file.xlsx'
 TEST_CSV_FILE = 'csv_file.csv'
@@ -466,7 +466,7 @@ def test_test_import_correct_index_for_multiple_items_in_one_step():
     os.remove(TEST_EXCEL_FILE)
 
 
-@pandas_post_1_only
+@pandas_post_1_4_only
 @python_post_3_6_only
 def test_update_imports_replays_unchanged_files_correctly_from_steps():
     # Make dataframes and files for test
@@ -514,7 +514,7 @@ def test_update_imports_replays_unchanged_files_correctly_from_steps():
     os.remove(TEST_EXCEL_FILE)
 
 
-@pandas_post_1_only
+@pandas_post_1_4_only
 @python_post_3_6_only
 def test_update_imports_replays_unchanged_files_correctly_from_analysis_name():
     # Make dataframes and files for test

--- a/mitosheet/mitosheet/user/utils.py
+++ b/mitosheet/mitosheet/user/utils.py
@@ -105,25 +105,18 @@ def should_upgrade_mitosheet() -> bool:
     mitosheet_last_upgraded_date = datetime.strptime(last_upgraded_date_stored, '%Y-%m-%d')
     return (datetime.now() - mitosheet_last_upgraded_date).days > 21
 
-def is_excel_import_enabled() -> bool:
-    """
-    Returns true if Python > 3.6 is installed, and Pandas > 0.25.0 is installed,
-    as this is when openpyxl works.
-
-    See here: https://pandas.pydata.org/pandas-docs/dev/whatsnew/v0.25.0.html
-    """
-    from mitosheet.saved_analyses.schema_utils import is_prev_version
-
-    python_version_valid = sys.version_info.minor > 6
-    pandas_version_valid = not is_prev_version(pd.__version__, '0.25.0')
-
-    return python_version_valid and pandas_version_valid
-
 def get_pandas_version() -> str:
     """
     Returns the pandas version
     """
     return pd.__version__
+
+
+def get_python_version() -> str:
+    """
+    Returns the Python version
+    """
+    return sys.version_info.minor
 
 
 def check_pro_acccess_code(access_code: Optional[str]) -> bool:

--- a/mitosheet/mitosheet/user/utils.py
+++ b/mitosheet/mitosheet/user/utils.py
@@ -112,7 +112,7 @@ def get_pandas_version() -> str:
     return pd.__version__
 
 
-def get_python_version() -> str:
+def get_python_version() -> int:
     """
     Returns the Python version
     """

--- a/mitosheet/mitosheet/user/utils.py
+++ b/mitosheet/mitosheet/user/utils.py
@@ -119,6 +119,12 @@ def is_excel_import_enabled() -> bool:
 
     return python_version_valid and pandas_version_valid
 
+def get_pandas_version() -> str:
+    """
+    Returns the pandas version
+    """
+    return pd.__version__
+
 
 def check_pro_acccess_code(access_code: Optional[str]) -> bool:
     """Checks if the passed access code is correct, by hashing it and comparing to the hashed value"""

--- a/mitosheet/src/components/import/CSVImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/CSVImportConfigScreen.tsx
@@ -128,7 +128,7 @@ const DECIMAL_TOOLTIP = 'Set the character used to separate the decimal places.'
 const ERROR_BAD_LINES_TOOLTIP = 'Turn on to skip any lines that are missing fields.'
 
 export const DEFAULT_DELIMETER = ",";
-export const DEFAULT_ENCODING = "default";
+export const DEFAULT_ENCODING = "utf-8";
 export const DEFAULT_DECIMAL = ".";
 export const DEFAULT_ERROR_BAD_LINES = true;
 
@@ -232,7 +232,7 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
     const error_bad_lines = props.params.error_bad_lines
 
     const currentDelimeter = delimeters !== undefined ? delimeters[0] : DEFAULT_DELIMETER;
-    const currentEncoding = ((encodings !== undefined ? encodings[0] : DEFAULT_ENCODING) === 'default') ? 'utf-8' : (encodings !== undefined ? encodings[0] : 'utf-8');
+    const currentEncoding = encodings !== undefined ? encodings[0] : DEFAULT_ENCODING;
     const currentDecimal = decimals !== undefined ? decimals[0] : DEFAULT_DECIMAL
     const currentErrorBadLines = error_bad_lines !== undefined ? error_bad_lines[0] : DEFAULT_ERROR_BAD_LINES;
     

--- a/mitosheet/src/components/import/CSVImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/CSVImportConfigScreen.tsx
@@ -363,7 +363,9 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
                             width='medium'
                             onChange={(e) => {
                                 const newSkiprows = e.target.value;
-                                const newSkiprowsNumber = parseFloat(newSkiprows)
+                                // Since we can only skip integer number of rows, we don't let the user add a decimal,
+                                // which they probably won't anyways
+                                const newSkiprowsNumber = Math.floor(parseFloat(newSkiprows))
 
                                 props.setParams(prevParams => {
                                     return {

--- a/mitosheet/src/components/import/CSVImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/CSVImportConfigScreen.tsx
@@ -127,9 +127,9 @@ const ENCODING_TOOLTIP = 'Set the encoding used to save this file.' // I can't t
 const DECIMAL_TOOLTIP = 'Set the character used to separate the decimal places.'
 const ERROR_BAD_LINES_TOOLTIP = 'Turn on to skip any lines that are missing fields.'
 
-export const DEFAULT_DELIMETER = ',';
-export const DEFAULT_ENCODING = 'default';
-export const DEFAULT_DECIMAL = '.';
+export const DEFAULT_DELIMETER = ",";
+export const DEFAULT_ENCODING = "default";
+export const DEFAULT_DECIMAL = ".";
 export const DEFAULT_ERROR_BAD_LINES = true;
 
 

--- a/mitosheet/src/components/import/CSVImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/CSVImportConfigScreen.tsx
@@ -120,12 +120,16 @@ const ENCODINGS = [
     "utf_8_sig"
 ] 
 
+const DECIMALS = ['.', ',']
+
 const DELIMETER_TOOLTIP = 'The text that seperates one column from another.'
 const ENCODING_TOOLTIP = 'Set the encoding used to save this file.' // I can't think of anything better lol
+const DECIMAL_TOOLTIP = 'Set the character used to separate the decimal places.'
 const ERROR_BAD_LINES_TOOLTIP = 'Turn on to skip any lines that are missing fields.'
 
 export const DEFAULT_DELIMETER = ',';
 export const DEFAULT_ENCODING = 'default';
+export const DEFAULT_DECIMAL = '.';
 export const DEFAULT_ERROR_BAD_LINES = true;
 
 
@@ -152,13 +156,15 @@ interface CSVImportConfigScreenProps {
 // This is our guesses about the metadata of the file
 export interface CSVFileMetadata {
     delimeters: string[],
-    encodings: string[]
+    encodings: string[],
+    decimals: string[]
 }
 
 export interface CSVImportParams {
     file_names: string[],
     delimeters?: string[],
     encodings?: string[],
+    decimals?: string[],
     error_bad_lines?: boolean[],
 }
 
@@ -192,7 +198,8 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
                 return {
                     ...prevParams,
                     delimeters: loadedData?.delimeters || [DEFAULT_DELIMETER],
-                    encodings: loadedData?.encodings || [DEFAULT_ENCODING]
+                    encodings: loadedData?.encodings || [DEFAULT_ENCODING],
+                    decimals: loadedData?.decimals || [DEFAULT_DECIMAL]
                 }
             })
         },
@@ -206,7 +213,7 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
                 ...prevParams,
                 delimeters: fileMetadata?.delimeters || [DEFAULT_DELIMETER],
                 encodings: fileMetadata?.encodings || [DEFAULT_ENCODING],
-                error_bad_lines: [DEFAULT_ERROR_BAD_LINES]
+                error_bad_lines: [DEFAULT_ERROR_BAD_LINES],
             }
         })
     }
@@ -221,10 +228,12 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
 
     const delimeters = props.params.delimeters;
     const encodings = props.params.encodings;
+    const decimals = props.params.decimals;
     const error_bad_lines = props.params.error_bad_lines
 
     const currentDelimeter = delimeters !== undefined ? delimeters[0] : DEFAULT_DELIMETER;
     const currentEncoding = ((encodings !== undefined ? encodings[0] : DEFAULT_ENCODING) === 'default') ? 'utf-8' : (encodings !== undefined ? encodings[0] : 'utf-8');
+    const currentDecimal = decimals !== undefined ? decimals[0] : DEFAULT_DECIMAL
     const currentErrorBadLines = error_bad_lines !== undefined ? error_bad_lines[0] : DEFAULT_ERROR_BAD_LINES;
     
     return (
@@ -301,6 +310,34 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
                             }}>
                             {(ENCODINGS).map((encoding) => {
                                 return <DropdownItem key={encoding} title={encoding}/>
+                            })}
+                        </Select>
+                    </Col>
+                </Row>
+                <Row justify='space-between' align='center' title={DECIMAL_TOOLTIP}>
+                    <Col>
+                        <Row justify='start' align='center' suppressTopBottomMargin>
+                            <p className='text-header-3'>
+                                Decimal Separator
+                            </p>
+                            <Tooltip title={DECIMAL_TOOLTIP}/>
+                        </Row>
+                    </Col>
+                    <Col>
+                        <Select 
+                            searchable
+                            width='medium' 
+                            value={currentDecimal} 
+                            onChange={(newDecimalSeparator) => {
+                                props.setParams(prevParams => {
+                                    return {
+                                        ...prevParams,
+                                        decimals: [newDecimalSeparator]
+                                    }
+                                })
+                            }}>
+                            {(DECIMALS).map((decimalSeparator) => {
+                                return <DropdownItem key={decimalSeparator} title={decimalSeparator}/>
                             })}
                         </Select>
                     </Col>

--- a/mitosheet/src/components/import/CSVImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/CSVImportConfigScreen.tsx
@@ -120,7 +120,14 @@ const ENCODINGS = [
     "utf_8_sig"
 ] 
 
-export const DECIMALS = ['.', ',']
+export enum Decimal {
+    PERIOD = '.',
+    COMMA = ','
+}
+export const decimalCharToTitle: Record<Decimal, string> = {
+    [Decimal.PERIOD] : 'period',
+    [Decimal.COMMA]: 'comma'
+}
 
 const DELIMETER_TOOLTIP = 'The text that seperates one column from another.'
 const ENCODING_TOOLTIP = 'Set the encoding used to save this file.' // I can't think of anything better lol
@@ -130,7 +137,7 @@ const ERROR_BAD_LINES_TOOLTIP = 'Turn on to skip any lines that are missing fiel
 
 export const DEFAULT_DELIMETER = ",";
 export const DEFAULT_ENCODING = "utf-8";
-export const DEFAULT_DECIMAL = ".";
+export const DEFAULT_DECIMAL = Decimal.PERIOD;
 export const DEFAULT_SKIPROWS = 0;
 export const DEFAULT_ERROR_BAD_LINES = true;
 
@@ -158,7 +165,7 @@ interface CSVImportConfigScreenProps {
 export interface CSVFileMetadata {
     delimeters: string[],
     encodings: string[],
-    decimals: string[]
+    decimals: Decimal[]
     skiprows: number[]
 }
 
@@ -166,7 +173,7 @@ export interface CSVImportParams {
     file_names: string[],
     delimeters?: string[],
     encodings?: string[],
-    decimals?: string[],
+    decimals?: Decimal[],
     skiprows?: number[]
     error_bad_lines?: boolean[],
 }
@@ -202,7 +209,8 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
                     ...prevParams,
                     delimeters: loadedData?.delimeters || [DEFAULT_DELIMETER],
                     encodings: loadedData?.encodings || [DEFAULT_ENCODING],
-                    decimals: loadedData?.decimals || [DEFAULT_DECIMAL]
+                    decimals: loadedData?.decimals || [DEFAULT_DECIMAL],
+                    skiprows: loadedData?.skiprows || [DEFAULT_SKIPROWS],
                 }
             })
         },
@@ -216,6 +224,8 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
                 ...prevParams,
                 delimeters: fileMetadata?.delimeters || [DEFAULT_DELIMETER],
                 encodings: fileMetadata?.encodings || [DEFAULT_ENCODING],
+                decimals: fileMetadata?.decimals || [DEFAULT_DECIMAL],
+                skiprows: fileMetadata?.skiprows || [DEFAULT_SKIPROWS],
                 error_bad_lines: [DEFAULT_ERROR_BAD_LINES],
             }
         })
@@ -332,17 +342,18 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
                         <Select 
                             searchable
                             width='medium' 
-                            value={currentDecimal} 
+                            value={decimalCharToTitle[currentDecimal]} 
                             onChange={(newDecimalSeparator) => {
                                 props.setParams(prevParams => {
                                     return {
                                         ...prevParams,
-                                        decimals: [newDecimalSeparator]
+                                        decimals: [newDecimalSeparator as Decimal]
                                     }
                                 })
                             }}>
-                            {(DECIMALS).map((decimalSeparator) => {
-                                return <DropdownItem key={decimalSeparator} title={decimalSeparator}/>
+                            {(Object.keys(decimalCharToTitle)).map(decimalCharacter => {
+                                const decimalTitle = decimalCharToTitle[decimalCharacter as Decimal]
+                                return <DropdownItem key={decimalTitle} title={decimalTitle} id={decimalCharacter}/>
                             })}
                         </Select>
                     </Col>

--- a/mitosheet/src/components/import/CSVImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/CSVImportConfigScreen.tsx
@@ -120,7 +120,7 @@ const ENCODINGS = [
     "utf_8_sig"
 ] 
 
-const DECIMALS = ['.', ',']
+export const DECIMALS = ['.', ',']
 
 const DELIMETER_TOOLTIP = 'The text that seperates one column from another.'
 const ENCODING_TOOLTIP = 'Set the encoding used to save this file.' // I can't think of anything better lol

--- a/mitosheet/src/components/import/CSVImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/CSVImportConfigScreen.tsx
@@ -129,11 +129,11 @@ export const decimalCharToTitle: Record<Decimal, string> = {
     [Decimal.COMMA]: 'comma'
 }
 
-const DELIMETER_TOOLTIP = 'The text that seperates one column from another.'
-const ENCODING_TOOLTIP = 'Set the encoding used to save this file.' // I can't think of anything better lol
-const DECIMAL_TOOLTIP = 'Set the character used to separate the decimal places.'
-const SKIP_ROWS_TOOLTIP = 'The number of rows at the top of the file to skip when reading data into the dataframe'
-const ERROR_BAD_LINES_TOOLTIP = 'Turn on to skip any lines that are missing fields.'
+export const DELIMETER_TOOLTIP = 'The text that seperates one column from another.'
+export const ENCODING_TOOLTIP = 'Set the encoding used to save this file.' // I can't think of anything better lol
+export const DECIMAL_TOOLTIP = 'Set the character used to separate the decimal places.'
+export const SKIP_ROWS_TOOLTIP = 'The number of rows at the top of the file to skip when reading data into the dataframe'
+export const ERROR_BAD_LINES_TOOLTIP = 'Turn on to skip any lines that are missing fields.'
 
 export const DEFAULT_DELIMETER = ",";
 export const DEFAULT_ENCODING = "utf-8";

--- a/mitosheet/src/components/import/CSVImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/CSVImportConfigScreen.tsx
@@ -125,13 +125,14 @@ export const DECIMALS = ['.', ',']
 const DELIMETER_TOOLTIP = 'The text that seperates one column from another.'
 const ENCODING_TOOLTIP = 'Set the encoding used to save this file.' // I can't think of anything better lol
 const DECIMAL_TOOLTIP = 'Set the character used to separate the decimal places.'
+const SKIP_ROWS_TOOLTIP = 'The number of rows at the top of the file to skip when reading data into the dataframe'
 const ERROR_BAD_LINES_TOOLTIP = 'Turn on to skip any lines that are missing fields.'
 
 export const DEFAULT_DELIMETER = ",";
 export const DEFAULT_ENCODING = "utf-8";
 export const DEFAULT_DECIMAL = ".";
+export const DEFAULT_SKIPROWS = 0;
 export const DEFAULT_ERROR_BAD_LINES = true;
-
 
 interface CSVImportConfigScreenProps {
     mitoAPI: MitoAPI;
@@ -158,6 +159,7 @@ export interface CSVFileMetadata {
     delimeters: string[],
     encodings: string[],
     decimals: string[]
+    skiprows: number[]
 }
 
 export interface CSVImportParams {
@@ -165,6 +167,7 @@ export interface CSVImportParams {
     delimeters?: string[],
     encodings?: string[],
     decimals?: string[],
+    skiprows?: number[]
     error_bad_lines?: boolean[],
 }
 
@@ -229,11 +232,13 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
     const delimeters = props.params.delimeters;
     const encodings = props.params.encodings;
     const decimals = props.params.decimals;
-    const error_bad_lines = props.params.error_bad_lines
+    const skiprows = props.params.skiprows;
+    const error_bad_lines = props.params.error_bad_lines;
 
     const currentDelimeter = delimeters !== undefined ? delimeters[0] : DEFAULT_DELIMETER;
     const currentEncoding = encodings !== undefined ? encodings[0] : DEFAULT_ENCODING;
     const currentDecimal = decimals !== undefined ? decimals[0] : DEFAULT_DECIMAL
+    const currentSkiprows = skiprows !== undefined ? skiprows[0] : DEFAULT_SKIPROWS
     const currentErrorBadLines = error_bad_lines !== undefined ? error_bad_lines[0] : DEFAULT_ERROR_BAD_LINES;
     
     return (
@@ -251,7 +256,7 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
                 <Row justify='space-between' align='center' title={DELIMETER_TOOLTIP}>
                     <Col>
                         <Row justify='start' align='center' suppressTopBottomMargin>
-                            <p className='text-header-3'>
+                            <p className='text-body-1'>
                                 Delimeter
                             </p>
                             <Tooltip title={DELIMETER_TOOLTIP}/>
@@ -289,7 +294,7 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
                 <Row justify='space-between' align='center' title={ENCODING_TOOLTIP}>
                     <Col>
                         <Row justify='start' align='center' suppressTopBottomMargin>
-                            <p className='text-header-3'>
+                            <p className='text-body-1'>
                                 Encoding
                             </p>
                             <Tooltip title={ENCODING_TOOLTIP}/>
@@ -317,7 +322,7 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
                 <Row justify='space-between' align='center' title={DECIMAL_TOOLTIP}>
                     <Col>
                         <Row justify='start' align='center' suppressTopBottomMargin>
-                            <p className='text-header-3'>
+                            <p className='text-body-1'>
                                 Decimal Separator
                             </p>
                             <Tooltip title={DECIMAL_TOOLTIP}/>
@@ -342,11 +347,38 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
                         </Select>
                     </Col>
                 </Row>
+                <Row justify='space-between' align='center' title={SKIP_ROWS_TOOLTIP}>
+                    <Col>
+                        <Row justify='start' align='center' suppressTopBottomMargin>
+                            <p className='text-body-1'>
+                                Number of Rows to Skip
+                            </p>
+                            <Tooltip title={SKIP_ROWS_TOOLTIP}/>
+                        </Row>
+                    </Col>
+                    <Col>
+                        <Input
+                            value={"" + currentSkiprows}
+                            type='number'
+                            width='medium'
+                            onChange={(e) => {
+                                const newSkiprows = e.target.value;
+                                const newSkiprowsNumber = parseFloat(newSkiprows)
+
+                                props.setParams(prevParams => {
+                                    return {
+                                        ...prevParams,
+                                        skiprows: [newSkiprowsNumber]
+                                    }
+                                })
+                            }}
+                        />
+                    </Col>
+                </Row>
                 <Row justify='space-between' align='center' title={ERROR_BAD_LINES_TOOLTIP}>
                     <Col>
                         <Row justify='start' align='center' suppressTopBottomMargin>
-
-                            <p className='text-header-3'>
+                            <p className='text-body-1'>
                                 Skip Invalid Lines
                             </p>
                             <Tooltip title={ERROR_BAD_LINES_TOOLTIP}/>

--- a/mitosheet/src/components/import/FileBrowser/FileBrowser.tsx
+++ b/mitosheet/src/components/import/FileBrowser/FileBrowser.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import MitoAPI from '../../../jupyter/api';
 import { AnalysisData, UIState, UserProfile } from '../../../types';
+import { isExcelImportEnabled } from '../../../utils/packageVersion';
 import TextButton from '../../elements/TextButton';
 import ConfigureIcon from '../../icons/ConfigureIcon';
 import Col from '../../layout/Col';
@@ -130,7 +131,7 @@ function FileBrowser(props: FileBrowserProps): JSX.Element {
 
     const importButtonStatus = getImportButtonStatus(
         selectedFile, 
-        props.userProfile.excelImportEnabled, 
+        isExcelImportEnabled(props.userProfile),
         fileBrowserState.loadingImport,
         props.isUpdate
     );

--- a/mitosheet/src/components/import/FileBrowser/FileBrowserBody.tsx
+++ b/mitosheet/src/components/import/FileBrowser/FileBrowserBody.tsx
@@ -5,6 +5,7 @@ import '../../../../css/taskpanes/Import/FileBrowser.css';
 import MitoAPI from '../../../jupyter/api';
 import { UIState, UserProfile } from '../../../types';
 import { classNames } from '../../../utils/classNames';
+import { isExcelImportEnabled } from '../../../utils/packageVersion';
 import SortArrowIcon from '../../icons/SortArrowIcon';
 import Col from '../../layout/Col';
 import Row from '../../layout/Row';
@@ -258,7 +259,7 @@ function FileBrowserBody(props: FileBrowserProps): JSX.Element {
                                     setFileBrowserState={props.setFileBrowserState}
                                     currPathParts={props.currPathParts}
                                     setCurrPathParts={props.setCurrPathParts}
-                                    excelImportEnabled={props.userProfile.excelImportEnabled}
+                                    excelImportEnabled={isExcelImportEnabled(props.userProfile)}
                                     setImportState={props.setImportState}
                                     importCSVFile={props.importCSVFile}
                                 />

--- a/mitosheet/src/components/import/XLSXImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/XLSXImportConfigScreen.tsx
@@ -13,11 +13,13 @@ import MultiToggleItem from '../elements/MultiToggleItem';
 import RadioButtonBox from '../elements/RadioButtonBox';
 import Select from '../elements/Select';
 import TextButton from '../elements/TextButton';
+import Row from '../layout/Row';
 import Spacer from '../layout/Spacer';
 import DefaultTaskpane from '../taskpanes/DefaultTaskpane/DefaultTaskpane';
 import DefaultTaskpaneBody from '../taskpanes/DefaultTaskpane/DefaultTaskpaneBody';
 import DefaultTaskpaneFooter from '../taskpanes/DefaultTaskpane/DefaultTaskpaneFooter';
 import DefaultTaskpaneHeader from '../taskpanes/DefaultTaskpane/DefaultTaskpaneHeader';
+import { DECIMALS, DEFAULT_DECIMAL } from './CSVImportConfigScreen';
 
 
 interface XLSXImportConfigScreenProps {
@@ -49,6 +51,7 @@ export interface ExcelImportParams {
     sheet_names: string[],
     has_headers: boolean,
     skiprows: number | string,
+    decimal: string
 }
 
 export const getDefaultParams = (filePath: string): ExcelImportParams => {
@@ -57,6 +60,7 @@ export const getDefaultParams = (filePath: string): ExcelImportParams => {
         sheet_names: [],
         has_headers: true,
         skiprows: 0,
+        decimal: DEFAULT_DECIMAL
     }
 }
 
@@ -124,7 +128,7 @@ function XLSXImportConfigScreen(props: XLSXImportConfigScreenProps): JSX.Element
                 backCallback={props.backCallback}
                 notCloseable={props.notCloseable}
             />
-            <DefaultTaskpaneBody noScroll>
+            <DefaultTaskpaneBody>
                 <div> 
                     {!props.isUpdate &&
                         <MultiToggleBox
@@ -183,43 +187,72 @@ function XLSXImportConfigScreen(props: XLSXImportConfigScreenProps): JSX.Element
                             loading={loading}
                         />
                     }
-                    
-                    <p className='text-body-1 mt-20px'>
-                        Has Header Row
-                    </p>
-                    <Select
-                        value={params.has_headers ? 'Yes' : 'No'}
-                        onChange={(newValue: string) => props.setParams(prevParams => {
-                            return {
-                                ...prevParams,
-                                has_headers: newValue === 'Yes'
-                            }
-                        })}
-                    >
-                        <DropdownItem
-                            title='Yes'
-                        />
-                        <DropdownItem
-                            title='No'
-                        />
-                    </Select>
-                    <p className='text-body-1 mt-20px'>
-                        Number of Rows to Skip
-                    </p>
-                    <Input
-                        value={"" + params.skiprows}
-                        type='number'
-                        onChange={(e) => {
-                            const newValue = e.target.value;
+                    <Row justify='space-between' align='center'>
+                        <p className='text-body-1'>
+                            Has Header Row
+                        </p>
 
-                            props.setParams(prevParams => {
+                        <Select
+                            value={params.has_headers ? 'Yes' : 'No'}
+                            width='medium'
+                            onChange={(newValue: string) => props.setParams(prevParams => {
                                 return {
                                     ...prevParams,
-                                    skiprows: newValue
+                                    has_headers: newValue === 'Yes'
                                 }
-                            })
-                        }}
-                    />
+                            })}
+                        >
+                            <DropdownItem
+                                title='Yes'
+                            />
+                            <DropdownItem
+                                title='No'
+                            />
+                        </Select>
+                    </Row>
+
+                    <Row justify='space-between' align='center'>
+                        <p className='text-body-1'>
+                            Number of Rows to Skip
+                        </p>
+                        <Input
+                            value={"" + params.skiprows}
+                            type='number'
+                            width='medium'
+                            onChange={(e) => {
+                                const newValue = e.target.value;
+
+                                props.setParams(prevParams => {
+                                    return {
+                                        ...prevParams,
+                                        skiprows: newValue
+                                    }
+                                })
+                            }}
+                        />
+                    </Row>
+
+                    <Row justify='space-between' align='center'>
+                        <p className='text-body-1'>
+                            Decimal Separator
+                        </p>
+                        <Select 
+                            value={params.decimal} 
+                            width='medium'
+                            onChange={(newDecimalSeparator) => {
+                                props.setParams(prevParams => {
+                                    return {
+                                        ...prevParams,
+                                        decimal: newDecimalSeparator
+                                    }
+                                })
+                            }}>
+                            {(DECIMALS).map((decimalSeparator) => {
+                                return <DropdownItem key={decimalSeparator} title={decimalSeparator}/>
+                            })}
+                        </Select>
+                    </Row>
+                    
                     {/* 
                         We note that we might have to adjust these size checks, depending
                         on feedback from users going forward.

--- a/mitosheet/src/components/import/XLSXImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/XLSXImportConfigScreen.tsx
@@ -14,13 +14,15 @@ import MultiToggleItem from '../elements/MultiToggleItem';
 import RadioButtonBox from '../elements/RadioButtonBox';
 import Select from '../elements/Select';
 import TextButton from '../elements/TextButton';
+import Tooltip from '../elements/Tooltip';
+import Col from '../layout/Col';
 import Row from '../layout/Row';
 import Spacer from '../layout/Spacer';
 import DefaultTaskpane from '../taskpanes/DefaultTaskpane/DefaultTaskpane';
 import DefaultTaskpaneBody from '../taskpanes/DefaultTaskpane/DefaultTaskpaneBody';
 import DefaultTaskpaneFooter from '../taskpanes/DefaultTaskpane/DefaultTaskpaneFooter';
 import DefaultTaskpaneHeader from '../taskpanes/DefaultTaskpane/DefaultTaskpaneHeader';
-import { Decimal, decimalCharToTitle, DEFAULT_DECIMAL } from './CSVImportConfigScreen';
+import { Decimal, decimalCharToTitle, DECIMAL_TOOLTIP, DEFAULT_DECIMAL, SKIP_ROWS_TOOLTIP } from './CSVImportConfigScreen';
 
 
 interface XLSXImportConfigScreenProps {
@@ -81,6 +83,8 @@ const getButtonMessage = (params: ExcelImportParams, loading: boolean, isUpdate:
 function getSuccessMessage(params: ExcelImportParams): string {
     return `Imported ${params.sheet_names.length} sheet${params.sheet_names.length === 1 ? '' : 's'}.`
 }
+
+const HAS_HEADER_ROW_TOOLTIP = 'Select "Yes" if Mito should set the first non-skipped row as the column headers. Select "No" if Mito should generate column headers'
 
 
 /* 
@@ -189,75 +193,96 @@ function XLSXImportConfigScreen(props: XLSXImportConfigScreenProps): JSX.Element
                             loading={loading}
                         />
                     }
-                    <Row justify='space-between' align='center'>
-                        <p className='text-body-1'>
-                            Has Header Row
-                        </p>
-
-                        <Select
-                            value={params.has_headers ? 'Yes' : 'No'}
-                            width='medium'
-                            onChange={(newValue: string) => props.setParams(prevParams => {
-                                return {
-                                    ...prevParams,
-                                    has_headers: newValue === 'Yes'
-                                }
-                            })}
-                        >
-                            <DropdownItem
-                                title='Yes'
-                            />
-                            <DropdownItem
-                                title='No'
-                            />
-                        </Select>
-                    </Row>
-
-                    <Row justify='space-between' align='center'>
-                        <p className='text-body-1'>
-                            Number of Rows to Skip
-                        </p>
-                        <Input
-                            value={"" + params.skiprows}
-                            type='number'
-                            width='medium'
-                            onChange={(e) => {
-                                const newValue = e.target.value;
-
-                                props.setParams(prevParams => {
+                    <Row justify='space-between' align='center' title={HAS_HEADER_ROW_TOOLTIP}>
+                        <Col>
+                            <Row justify='start' align='center' suppressTopBottomMargin>
+                                <p className='text-body-1'>
+                                    Has Header Row
+                                </p>
+                                <Tooltip title={HAS_HEADER_ROW_TOOLTIP}/>
+                            </Row>
+                        </Col>
+                        <Col>
+                            <Select
+                                value={params.has_headers ? 'Yes' : 'No'}
+                                width='medium'
+                                onChange={(newValue: string) => props.setParams(prevParams => {
                                     return {
                                         ...prevParams,
-                                        skiprows: newValue
+                                        has_headers: newValue === 'Yes'
                                     }
-                                })
-                            }}
-                        />
+                                })}
+                            >
+                                <DropdownItem
+                                    title='Yes'
+                                />
+                                <DropdownItem
+                                    title='No'
+                                />
+                            </Select>
+                        </Col>
+                        
+                    </Row>
+
+                    <Row justify='space-between' align='center' title={SKIP_ROWS_TOOLTIP}>
+                        <Col>
+                            <Row justify='start' align='center' suppressTopBottomMargin>
+                                <p className='text-body-1'>
+                                    Number of Rows to Skip
+                                </p>
+                                <Tooltip title={SKIP_ROWS_TOOLTIP} />
+                            </Row>
+                        </Col>
+                        <Col>
+                            <Input
+                                value={"" + params.skiprows}
+                                type='number'
+                                width='medium'
+                                onChange={(e) => {
+                                    const newValue = e.target.value;
+
+                                    props.setParams(prevParams => {
+                                        return {
+                                            ...prevParams,
+                                            skiprows: newValue
+                                        }
+                                    })
+                                }}
+                            />
+                        </Col>
                     </Row>
                     {/*
                         Decimal was only added to the read_excel pandas api in version 1.4, so 
                         if the user is on a previous version, we don't show it.
                     */}
                     {isAtLeastBenchmarkVersion(props.userProfile.pandasVersion, '1.4.0') && 
-                        <Row justify='space-between' align='center'>
-                            <p className='text-body-1'>
-                                Decimal Separator
-                            </p>
-                            <Select 
-                                width='medium' 
-                                value={decimalCharToTitle[params.decimal]} 
-                                onChange={(newDecimalSeparator) => {
-                                    props.setParams(prevParams => {
-                                        return {
-                                            ...prevParams,
-                                            decimals: [newDecimalSeparator as Decimal]
-                                        }
-                                    })
-                                }}>
-                                {(Object.keys(decimalCharToTitle)).map(decimalCharacter => {
-                                    const decimalTitle = decimalCharToTitle[decimalCharacter as Decimal]
-                                    return <DropdownItem key={decimalTitle} title={decimalTitle} id={decimalCharacter}/>
-                                })}
-                            </Select>
+                        <Row justify='space-between' align='center' title={DECIMAL_TOOLTIP}>
+                            <Col>
+                                <Row justify='start' align='center' suppressTopBottomMargin>
+                                    <p className='text-body-1'>
+                                        Decimal Separator
+                                    </p>
+                                    <Tooltip title={DECIMAL_TOOLTIP} />
+                                </Row>
+                            </Col>
+                            <Col>
+                                <Select 
+                                    width='medium' 
+                                    value={decimalCharToTitle[params.decimal]} 
+                                    onChange={(newDecimalSeparator) => {
+                                        props.setParams(prevParams => {
+                                            return {
+                                                ...prevParams,
+                                                decimals: [newDecimalSeparator as Decimal]
+                                            }
+                                        })
+                                    }}>
+                                    {(Object.keys(decimalCharToTitle)).map(decimalCharacter => {
+                                        const decimalTitle = decimalCharToTitle[decimalCharacter as Decimal]
+                                        return <DropdownItem key={decimalTitle} title={decimalTitle} id={decimalCharacter}/>
+                                    })}
+                                </Select>
+                            </Col>
                         </Row>
                     }
                     {/* 

--- a/mitosheet/src/components/import/XLSXImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/XLSXImportConfigScreen.tsx
@@ -20,7 +20,7 @@ import DefaultTaskpane from '../taskpanes/DefaultTaskpane/DefaultTaskpane';
 import DefaultTaskpaneBody from '../taskpanes/DefaultTaskpane/DefaultTaskpaneBody';
 import DefaultTaskpaneFooter from '../taskpanes/DefaultTaskpane/DefaultTaskpaneFooter';
 import DefaultTaskpaneHeader from '../taskpanes/DefaultTaskpane/DefaultTaskpaneHeader';
-import { DECIMALS, DEFAULT_DECIMAL } from './CSVImportConfigScreen';
+import { Decimal, decimalCharToTitle, DEFAULT_DECIMAL } from './CSVImportConfigScreen';
 
 
 interface XLSXImportConfigScreenProps {
@@ -53,7 +53,7 @@ export interface ExcelImportParams {
     sheet_names: string[],
     has_headers: boolean,
     skiprows: number | string,
-    decimal: string
+    decimal: Decimal
 }
 
 export const getDefaultParams = (filePath: string): ExcelImportParams => {
@@ -243,18 +243,19 @@ function XLSXImportConfigScreen(props: XLSXImportConfigScreenProps): JSX.Element
                                 Decimal Separator
                             </p>
                             <Select 
-                                value={params.decimal} 
-                                width='medium'
+                                width='medium' 
+                                value={decimalCharToTitle[params.decimal]} 
                                 onChange={(newDecimalSeparator) => {
                                     props.setParams(prevParams => {
                                         return {
                                             ...prevParams,
-                                            decimal: newDecimalSeparator
+                                            decimals: [newDecimalSeparator as Decimal]
                                         }
                                     })
                                 }}>
-                                {(DECIMALS).map((decimalSeparator) => {
-                                    return <DropdownItem key={decimalSeparator} title={decimalSeparator}/>
+                                {(Object.keys(decimalCharToTitle)).map(decimalCharacter => {
+                                    const decimalTitle = decimalCharToTitle[decimalCharacter as Decimal]
+                                    return <DropdownItem key={decimalTitle} title={decimalTitle} id={decimalCharacter}/>
                                 })}
                             </Select>
                         </Row>

--- a/mitosheet/src/components/import/XLSXImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/XLSXImportConfigScreen.tsx
@@ -4,8 +4,9 @@ import React from 'react';
 
 import { useStateFromAPIAsync } from '../../hooks/useStateFromAPIAsync';
 import MitoAPI from '../../jupyter/api';
-import { AnalysisData, UIState } from '../../types';
+import { AnalysisData, UIState, UserProfile } from '../../types';
 import { toggleInArray } from '../../utils/arrays';
+import { isAfterBenchmarkVersion } from '../../utils/packageVersion';
 import DropdownItem from '../elements/DropdownItem';
 import Input from '../elements/Input';
 import MultiToggleBox from '../elements/MultiToggleBox';
@@ -25,6 +26,7 @@ import { DECIMALS, DEFAULT_DECIMAL } from './CSVImportConfigScreen';
 interface XLSXImportConfigScreenProps {
     mitoAPI: MitoAPI;
     analysisData: AnalysisData;
+    userProfile: UserProfile;
     setUIState: React.Dispatch<React.SetStateAction<UIState>>;
     isUpdate: boolean;
 
@@ -231,28 +233,32 @@ function XLSXImportConfigScreen(props: XLSXImportConfigScreenProps): JSX.Element
                             }}
                         />
                     </Row>
-
-                    <Row justify='space-between' align='center'>
-                        <p className='text-body-1'>
-                            Decimal Separator
-                        </p>
-                        <Select 
-                            value={params.decimal} 
-                            width='medium'
-                            onChange={(newDecimalSeparator) => {
-                                props.setParams(prevParams => {
-                                    return {
-                                        ...prevParams,
-                                        decimal: newDecimalSeparator
-                                    }
-                                })
-                            }}>
-                            {(DECIMALS).map((decimalSeparator) => {
-                                return <DropdownItem key={decimalSeparator} title={decimalSeparator}/>
-                            })}
-                        </Select>
-                    </Row>
-                    
+                    {/*
+                        Decimal was only added to the read_excel pandas api in version 1.4, so 
+                        if the user is on a previous version, we don't show it.
+                    */}
+                    {isAfterBenchmarkVersion(props.userProfile.pandasVersion, '1.4.0') && 
+                        <Row justify='space-between' align='center'>
+                            <p className='text-body-1'>
+                                Decimal Separator
+                            </p>
+                            <Select 
+                                value={params.decimal} 
+                                width='medium'
+                                onChange={(newDecimalSeparator) => {
+                                    props.setParams(prevParams => {
+                                        return {
+                                            ...prevParams,
+                                            decimal: newDecimalSeparator
+                                        }
+                                    })
+                                }}>
+                                {(DECIMALS).map((decimalSeparator) => {
+                                    return <DropdownItem key={decimalSeparator} title={decimalSeparator}/>
+                                })}
+                            </Select>
+                        </Row>
+                    }
                     {/* 
                         We note that we might have to adjust these size checks, depending
                         on feedback from users going forward.

--- a/mitosheet/src/components/import/XLSXImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/XLSXImportConfigScreen.tsx
@@ -6,7 +6,7 @@ import { useStateFromAPIAsync } from '../../hooks/useStateFromAPIAsync';
 import MitoAPI from '../../jupyter/api';
 import { AnalysisData, UIState, UserProfile } from '../../types';
 import { toggleInArray } from '../../utils/arrays';
-import { isAfterBenchmarkVersion } from '../../utils/packageVersion';
+import { isAtLeastBenchmarkVersion } from '../../utils/packageVersion';
 import DropdownItem from '../elements/DropdownItem';
 import Input from '../elements/Input';
 import MultiToggleBox from '../elements/MultiToggleBox';
@@ -237,7 +237,7 @@ function XLSXImportConfigScreen(props: XLSXImportConfigScreenProps): JSX.Element
                         Decimal was only added to the read_excel pandas api in version 1.4, so 
                         if the user is on a previous version, we don't show it.
                     */}
-                    {isAfterBenchmarkVersion(props.userProfile.pandasVersion, '1.4.0') && 
+                    {isAtLeastBenchmarkVersion(props.userProfile.pandasVersion, '1.4.0') && 
                         <Row justify='space-between' align='center'>
                             <p className='text-body-1'>
                                 Decimal Separator

--- a/mitosheet/src/components/taskpanes/FileImport/FileImportTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/FileImport/FileImportTaskpane.tsx
@@ -101,6 +101,7 @@ function FileImportTaskpane(props: ImportTaskpaneProps): JSX.Element {
             <XLSXImportConfigTaskpane
                 mitoAPI={props.mitoAPI}
                 analysisData={props.analysisData}
+                userProfile={props.userProfile}
                 setUIState={props.setUIState}
                 
                 fileName={importState.fileName}

--- a/mitosheet/src/components/taskpanes/FileImport/XLSXImportConfigTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/FileImport/XLSXImportConfigTaskpane.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import useSendEditOnClick from '../../../hooks/useSendEditOnClick';
 import MitoAPI from '../../../jupyter/api';
-import { AnalysisData, StepType, UIState } from '../../../types';
+import { AnalysisData, StepType, UIState, UserProfile } from '../../../types';
 import { DEFAULT_DECIMAL } from '../../import/CSVImportConfigScreen';
 import XLSXImportConfigScreen, { ExcelImportParams } from '../../import/XLSXImportConfigScreen';
 import { ImportState } from './FileImportTaskpane';
@@ -13,6 +13,7 @@ import { ImportState } from './FileImportTaskpane';
 interface XLSXImportConfigTaskpaneProps {
     mitoAPI: MitoAPI;
     analysisData: AnalysisData;
+    userProfile: UserProfile;
     setUIState: React.Dispatch<React.SetStateAction<UIState>>;
 
     fileName: string;
@@ -50,6 +51,7 @@ function XLSXImportConfigTaskpane(props: XLSXImportConfigTaskpaneProps): JSX.Ele
         <XLSXImportConfigScreen
             mitoAPI={props.mitoAPI}
             analysisData={props.analysisData}
+            userProfile={props.userProfile}
             setUIState={props.setUIState}
             isUpdate={false}
 

--- a/mitosheet/src/components/taskpanes/FileImport/XLSXImportConfigTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/FileImport/XLSXImportConfigTaskpane.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import useSendEditOnClick from '../../../hooks/useSendEditOnClick';
 import MitoAPI from '../../../jupyter/api';
 import { AnalysisData, StepType, UIState } from '../../../types';
+import { DEFAULT_DECIMAL } from '../../import/CSVImportConfigScreen';
 import XLSXImportConfigScreen, { ExcelImportParams } from '../../import/XLSXImportConfigScreen';
 import { ImportState } from './FileImportTaskpane';
 
@@ -25,6 +26,7 @@ export const getDefaultXLSXParams = (filePath: string): ExcelImportParams => {
         file_name: filePath,
         sheet_names: [],
         has_headers: true,
+        decimal: DEFAULT_DECIMAL,
         skiprows: 0,
     }
 }

--- a/mitosheet/src/components/taskpanes/UpdateImports/UpdateImportsTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/UpdateImports/UpdateImportsTaskpane.tsx
@@ -358,6 +358,7 @@ const UpdateImportsTaskpane = (props: UpdateImportsTaskpaneProps): JSX.Element =
             <XLSXImportConfigScreen
                 mitoAPI={props.mitoAPI}
                 analysisData={props.analysisData}
+                userProfile={props.userProfile}
                 setUIState={props.setUIState}
                 isUpdate={true}
             

--- a/mitosheet/src/types.tsx
+++ b/mitosheet/src/types.tsx
@@ -686,6 +686,7 @@ export interface UserProfile {
 
     isPro: boolean;
     excelImportEnabled: boolean;
+    pandasVersion: string;
     telemetryEnabled: boolean;
     isLocalDeployment: boolean;
     shouldUpgradeMitosheet: boolean;

--- a/mitosheet/src/types.tsx
+++ b/mitosheet/src/types.tsx
@@ -672,7 +672,8 @@ export interface AnalysisData {
  * @param userEmail - the email of the user. May be an empty string if they have not signed up yet
  * @param receivedTours - a list of the tours they have received
  * @param isPro - if the user is a pro user
- * @param excelImportEnabled - if the user has the necessary packages optional dependencies, and Python and Pandas version to import Excel files.
+ * @param pythonVersion - the version of the user's python installation
+ * @param pandasVersion - ther version of th user's pandas isntallation
  * @param telemetryEnabled - if the user has telemetry enabled
  * @param isLocalDeployment - if the user is deployed locally or not
  * @param shouldUpgradeMitosheet - if the user should upgrade their mitosheet
@@ -685,8 +686,8 @@ export interface UserProfile {
     receivedChecklists: Record<ChecklistID, string[] | undefined>;
 
     isPro: boolean;
-    excelImportEnabled: boolean;
     pandasVersion: string;
+    pythonVersion: string;
     telemetryEnabled: boolean;
     isLocalDeployment: boolean;
     shouldUpgradeMitosheet: boolean;

--- a/mitosheet/src/utils/packageVersion.tsx
+++ b/mitosheet/src/utils/packageVersion.tsx
@@ -5,26 +5,31 @@ import { UserProfile } from "../types"
     to the current version; note that this assumes semantic versioning
     with x.y.z!
 */
-export const isAfterBenchmarkVersion = (currentVersion: string, benchmarkVersion: string): boolean => {
-    console.log(currentVersion)
-    console.log(currentVersion.split('.').map(versionPart => parseInt(versionPart)))
+export const isAtLeastBenchmarkVersion = (currentVersion: string, benchmarkVersion: string): boolean => {
     const currentVersionParts = currentVersion.split('.').map(versionPart => parseInt(versionPart))
-    console.log('111')
     const benchmarkVersionParts = benchmarkVersion.split('.').map(versionPart => parseInt(versionPart))
 
-    if (benchmarkVersionParts[0] > currentVersionParts[0]) {
-        return false
+    // Make sure that the current version is of the format x.y.z
+    if (currentVersionParts.length == 1) {
+        currentVersionParts[1] = 0
+    }
+    if (currentVersionParts.length == 2) {
+        currentVersionParts[2] = 0
     }
 
-    if (benchmarkVersionParts[1] > currentVersionParts[1]) {
-        return false
+    let i = 0
+    for (i; i < currentVersionParts.length; i ++) {
+        if (currentVersionParts[i] > benchmarkVersionParts[i]) {
+            return true 
+        } 
+
+        if (currentVersionParts[i] < benchmarkVersionParts[i]) {
+            return false 
+        }
     }
 
-    if (benchmarkVersionParts[2] > currentVersionParts[2]) {
-        return false
-    }
-
-    return true
+    // If they are the same version, return True 
+    return true 
 }
 
 /*
@@ -34,6 +39,5 @@ export const isAfterBenchmarkVersion = (currentVersion: string, benchmarkVersion
     See here: https://pandas.pydata.org/pandas-docs/dev/whatsnew/v0.25.0.html
 */
 export const isExcelImportEnabled = (userProfile: UserProfile): boolean => {
-    console.log("Pandas Version: ", userProfile.pandasVersion)
-    return isAfterBenchmarkVersion(userProfile.pythonVersion, '3.6.0') && isAfterBenchmarkVersion(userProfile.pandasVersion, '0.25.0')
+    return isAtLeastBenchmarkVersion(userProfile.pythonVersion, '3.6.0') && isAtLeastBenchmarkVersion(userProfile.pandasVersion, '0.25.0')
 }

--- a/mitosheet/src/utils/packageVersion.tsx
+++ b/mitosheet/src/utils/packageVersion.tsx
@@ -1,0 +1,26 @@
+
+/*
+    Returns True if the passed version is a previous version compared
+    to the current version; note that this assumes semantic versioning
+    with x.y.z!
+*/
+export const isAfterBenchmarkVersion = (currentVersion: string, benchmarkVersion: string): boolean => {
+    const benchmarkVersionParts = benchmarkVersion.split('.').map(versionPart => parseInt(versionPart))
+    const currentVersionParts = currentVersion.split('.').map(versionPart => parseInt(versionPart))
+
+    if (benchmarkVersionParts[0] > currentVersionParts[0]) {
+        return false
+    }
+
+    if (benchmarkVersionParts[1] > currentVersionParts[1]) {
+        return false
+    }
+
+    if (benchmarkVersionParts[2] > currentVersionParts[2]) {
+        return false
+    }
+
+    return true
+}
+
+    

--- a/mitosheet/src/utils/packageVersion.tsx
+++ b/mitosheet/src/utils/packageVersion.tsx
@@ -17,8 +17,7 @@ export const isAtLeastBenchmarkVersion = (currentVersion: string, benchmarkVersi
         currentVersionParts[2] = 0
     }
 
-    let i = 0
-    for (i; i < currentVersionParts.length; i ++) {
+    for (let i = 0; i < currentVersionParts.length; i ++) {
         if (currentVersionParts[i] > benchmarkVersionParts[i]) {
             return true 
         } 

--- a/mitosheet/src/utils/packageVersion.tsx
+++ b/mitosheet/src/utils/packageVersion.tsx
@@ -1,3 +1,4 @@
+import { UserProfile } from "../types"
 
 /*
     Returns True if the passed version is a previous version compared
@@ -5,8 +6,11 @@
     with x.y.z!
 */
 export const isAfterBenchmarkVersion = (currentVersion: string, benchmarkVersion: string): boolean => {
-    const benchmarkVersionParts = benchmarkVersion.split('.').map(versionPart => parseInt(versionPart))
+    console.log(currentVersion)
+    console.log(currentVersion.split('.').map(versionPart => parseInt(versionPart)))
     const currentVersionParts = currentVersion.split('.').map(versionPart => parseInt(versionPart))
+    console.log('111')
+    const benchmarkVersionParts = benchmarkVersion.split('.').map(versionPart => parseInt(versionPart))
 
     if (benchmarkVersionParts[0] > currentVersionParts[0]) {
         return false
@@ -23,4 +27,13 @@ export const isAfterBenchmarkVersion = (currentVersion: string, benchmarkVersion
     return true
 }
 
-    
+/*
+    Returns true if Python > 3.6 is installed, and Pandas > 0.25.0 is installed,
+    as this is when openpyxl works.
+
+    See here: https://pandas.pydata.org/pandas-docs/dev/whatsnew/v0.25.0.html
+*/
+export const isExcelImportEnabled = (userProfile: UserProfile): boolean => {
+    console.log("Pandas Version: ", userProfile.pandasVersion)
+    return isAfterBenchmarkVersion(userProfile.pythonVersion, '3.6.0') && isAfterBenchmarkVersion(userProfile.pandasVersion, '0.25.0')
+}


### PR DESCRIPTION
# Description

- Adds the `decimal` configuration option to excel and csv imports
- Adds the `skiprows`configuration options to csv imports
- Refactors some of the simple import and excel import code to make adding params a bit easier in the future
- Logs user's pandas version as `version_pandas`
- Moves the package checking infrastructure to the frontend so we can just check it where we need it instead of having to continually add to the UserProfile.

Note: `decimal` was only added to read_excel in version 1.4 of pandas, so I only display that configuration option in the XLSX config taskpane when the user is post 1.4. 

# Testing

- See the tests
- Import files using `dev` and then switch to this branch and make sure imports still work
- Make sure that the `decimal` config is only available in the Excel import taskpane on or after pandas 1.4

Here is a csv and excel file with `,` decimals for testing:
[test_comma_decimal.xlsx](https://github.com/mito-ds/monorepo/files/9881195/test_comma_decimal.xlsx)
[test_comma_decimal.csv](https://github.com/mito-ds/monorepo/files/9881196/test_comma_decimal.csv)

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.