### PR TITLE
Mito config 2

### DIFF
--- a/mitosheet/README.md
+++ b/mitosheet/README.md
@@ -31,7 +31,7 @@ jupyter lab
 
 ### For Windows
 
-First, delete any existing virtual enviornment that you have in this folder, and create a new virtual enviornment. 
+First, delete any existing virtual environment that you have in this folder, and create a new virtual environment. 
 
 On Windows (in command prompt, not powershell):
 ```
@@ -60,7 +60,7 @@ npm install
 jlpm run watch
 ```
 
-NOTE: On Windows, this seperate terminal _must_ be a Adminstrator terminal. To launch an admin terminal, search for Command Prompt, and then right click on the app and click Run as adminstrator. Then navigate to the virtual enviornment, start it, and then run `jlpm run watch`. 
+NOTE: On Windows, this seperate terminal _must_ be a Adminstrator terminal. To launch an admin terminal, search for Command Prompt, and then right click on the app and click Run as adminstrator. Then navigate to the virtual environment, start it, and then run `jlpm run watch`. 
 
 Furthermore, if the final `jlpm run watch` or `npm install` command fails, you may need to run `export NODE_OPTIONS=--openssl-legacy-provider`. 
 
@@ -83,7 +83,7 @@ deactivate; rm -rf venv; python3 -m venv venv && source venv/bin/activate && pyt
 
 ## Mitosheet with JupyterLab 2.0
 
-First, delete any existing virtual enviornment that you have in this folder, and create a new virtual enviornment.
+First, delete any existing virtual environment that you have in this folder, and create a new virtual environment.
 
 On Mac:
 ```

--- a/mitosheet/dev/jswatch.sh
+++ b/mitosheet/dev/jswatch.sh
@@ -3,7 +3,7 @@
 # checktestpypi.sh: this script should be run in the monorepo/mitosheet folder
 # and will just run the javascript watch command
 
-# Activate the enviornment
+# Activate the environment
 source venv/bin/activate
 
 # Make sure the Node options are set properly, or later build commands fail

--- a/mitosheet/dev/realinstall.sh
+++ b/mitosheet/dev/realinstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # realinstall.sh: this is a script that you can run from anywhere on your 
-# computer, and it will create a new folder, a clean virtual enviornment,
+# computer, and it will create a new folder, a clean virtual environment,
 # and install the `mitosheet` package on it. 
 
 # Create a folder name

--- a/mitosheet/dev/testinstall.sh
+++ b/mitosheet/dev/testinstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # testinstall.sh: this is a script that you can run from anywhere on your 
-# computer, and it will create a new folder, a clean virtual enviornment,
+# computer, and it will create a new folder, a clean virtual environment,
 # and install the `mitosheet` package from test pypi. 
 
 # Create a folder name

--- a/mitosheet/mitosheet/mito_config.py
+++ b/mitosheet/mitosheet/mito_config.py
@@ -7,6 +7,8 @@
 from typing import Any, Dict, Optional
 import os
 
+from mitosheet.telemetry.telemetry_utils import log
+
 # Note: Do not change these keys, we need them for looking up 
 # the environment variables from previous mito_config_versions.
 MITO_CONFIG_VERSION_KEY = 'MITO_CONFIG_VERSION'
@@ -72,6 +74,7 @@ class MitoConfig:
 
     def get_version(self) -> str:
         if self.mec is None or self.mec[MITO_CONFIG_VERSION_KEY] is None:
+            log('loaded_mito_enterprise_config')
             return '1' # NOTE: update this to be the most recent version, when we bump the version
         return self.mec[MITO_CONFIG_VERSION_KEY]
 

--- a/mitosheet/mitosheet/mito_config.py
+++ b/mitosheet/mitosheet/mito_config.py
@@ -13,7 +13,7 @@ MITO_CONFIG_VERSION_KEY = 'MITO_CONFIG_VERSION'
 MITO_CONFIG_SUPPORT_EMAIL_KEY = 'MITO_CONFIG_SUPPORT_EMAIL'
 
 # The default values to use if the mec does not define them
-DEFAULT_SUPPORT_EMAIL = 'founders@sagacollab.com'
+DEFAULT_MITO_CONFIG_SUPPORT_EMAIL = 'founders@sagacollab.com'
 
 # When updating the MEC_VERSION, add a function here 
 # to update the previous mec to the new version. For example, 
@@ -36,8 +36,8 @@ def upgrade_mito_enterprise_configuration(mec: Optional[Dict[str, Any]]) -> Opti
     return _mec
 
 # Since Mito needs to look up indivdual environment variables, we need to 
-# know the names of the variables associated with each mito congif version,
-# so we store them as a list here. 
+# know the names of the variables associated with each mito config version. 
+# To do so we store them as a list here. 
 mec_version_keys = {
     '1': [MITO_CONFIG_VERSION_KEY, MITO_CONFIG_SUPPORT_EMAIL_KEY]
 }
@@ -59,25 +59,25 @@ def create_mec_from_environment_variables() -> Optional[Dict[str, Any]]:
 
 class MitoConfig:
     """
-    The MitoConfig class is repsonsible for 1) reading the settings from the 
-    environment variables 2) returning them as a mito_enterprise_configuration object
-    used by the rest of the app. 
+    The MitoConfig class is repsonsible for reading the settings from the 
+    environment variables and returning them as the most updated version of the 
+    mito_enterprise_configuration object that is used by the rest of the app. 
 
     If the environment variables does not exist or does not set every configuration option, 
     the MitoConfig class sets defaults. 
     """
     def __init__(self):
-        mito_enterprise_configuration: Optional[Dict[str, Any]] = create_mec_from_environment_variables()
-        self.mec = upgrade_mito_enterprise_configuration(mito_enterprise_configuration)
+        mec_potentially_outdated = create_mec_from_environment_variables()
+        self.mec = upgrade_mito_enterprise_configuration(mec_potentially_outdated)
 
-    def get_version(self) -> Optional[str]:
-        if self.mec is None:
+    def get_version(self) -> str:
+        if self.mec is None or self.mec[MITO_CONFIG_VERSION_KEY] is None:
             return '1' # NOTE: update this to be the most recent version, when we bump the version
         return self.mec[MITO_CONFIG_VERSION_KEY]
 
     def get_support_email(self) -> str:
         if self.mec is None or self.mec[MITO_CONFIG_SUPPORT_EMAIL_KEY] is None:
-            return DEFAULT_SUPPORT_EMAIL
+            return DEFAULT_MITO_CONFIG_SUPPORT_EMAIL
         return self.mec[MITO_CONFIG_SUPPORT_EMAIL_KEY]
 
     # Add new mito configuration options here ...

--- a/mitosheet/mitosheet/mito_config.py
+++ b/mitosheet/mitosheet/mito_config.py
@@ -40,7 +40,7 @@ def upgrade_mito_enterprise_configuration(mec: Optional[Dict[str, Any]]) -> Opti
 # Since Mito needs to look up indivdual environment variables, we need to 
 # know the names of the variables associated with each mito config version. 
 # To do so we store them as a list here. 
-mec_version_keys = {
+MEC_VERSION_KEYS = {
     '1': [MITO_CONFIG_VERSION_KEY, MITO_CONFIG_SUPPORT_EMAIL_KEY]
 }
 
@@ -54,7 +54,7 @@ def create_mec_from_environment_variables() -> Optional[Dict[str, Any]]:
         return None
 
     mec: Dict[str, Any] = {}
-    for key in mec_version_keys[config_version]:
+    for key in MEC_VERSION_KEYS[config_version]:
         mec[key] = os.environ.get(key)
 
     return mec
@@ -72,13 +72,15 @@ class MitoConfig:
         mec_potentially_outdated = create_mec_from_environment_variables()
         self.mec = upgrade_mito_enterprise_configuration(mec_potentially_outdated)
 
-    def get_version(self) -> str:
-        if self.mec is None or self.mec[MITO_CONFIG_VERSION_KEY] is None:
+        if self.mec is not None:
             log('loaded_mito_enterprise_config')
+
+    def _get_version(self) -> str:
+        if self.mec is None or self.mec[MITO_CONFIG_VERSION_KEY] is None:
             return '1' # NOTE: update this to be the most recent version, when we bump the version
         return self.mec[MITO_CONFIG_VERSION_KEY]
 
-    def get_support_email(self) -> str:
+    def _get_support_email(self) -> str:
         if self.mec is None or self.mec[MITO_CONFIG_SUPPORT_EMAIL_KEY] is None:
             return DEFAULT_MITO_CONFIG_SUPPORT_EMAIL
         return self.mec[MITO_CONFIG_SUPPORT_EMAIL_KEY]
@@ -87,7 +89,7 @@ class MitoConfig:
 
     def get_mito_config(self) -> Dict[str, Any]:
         return {
-            MITO_CONFIG_VERSION_KEY: self.get_version(),
-            MITO_CONFIG_SUPPORT_EMAIL_KEY: self.get_support_email()
+            MITO_CONFIG_VERSION_KEY: self._get_version(),
+            MITO_CONFIG_SUPPORT_EMAIL_KEY: self._get_support_email()
         }
 

--- a/mitosheet/mitosheet/mito_config.py
+++ b/mitosheet/mitosheet/mito_config.py
@@ -7,8 +7,6 @@
 from typing import Any, Dict, Optional
 import os
 
-# These variables must match the variables defined in 
-# mito_config.py of the mitosheet_helper_config package.
 # Note: Do not change these keys, we need them for looking up 
 # the environment variables from previous mito_config_versions.
 MITO_CONFIG_VERSION_KEY = 'MITO_CONFIG_VERSION'
@@ -19,7 +17,7 @@ DEFAULT_SUPPORT_EMAIL = 'founders@sagacollab.com'
 
 # When updating the MEC_VERSION, add a function here 
 # to update the previous mec to the new version. For example, 
-# if mec_version=3, mec_upgrade_functions should look like:
+# if mec_version='3', mec_upgrade_functions should look like:
 # {
 #    '1': upgrade_mec_1_to_2,
 #    '2': upgrade_mec_2_to_3
@@ -62,20 +60,17 @@ def create_mec_from_environment_variables() -> Optional[Dict[str, Any]]:
 class MitoConfig:
     """
     The MitoConfig class is repsonsible for 1) reading the settings from the 
-    mito_helper_config package if it is installed and 2) returning the configuration variables
+    environment variables 2) returning them as a mito_enterprise_configuration object
     used by the rest of the app. 
 
-    If the mito_helper_configuration package does not exist or does not set every configuration option, 
+    If the enviornment variables does not exist or does not set every configuration option, 
     the MitoConfig class sets defaults. 
-
-    See https://github.com/mito-ds/mitosheet_helper_config/blob/main/mitosheet_helper_config/README.md for
-    information about developing with the mito_helper_config package.
     """
     def __init__(self):
         mito_enterprise_configuration: Optional[Dict[str, Any]] = create_mec_from_environment_variables()
         self.mec = upgrade_mito_enterprise_configuration(mito_enterprise_configuration)
 
-    def get_version(self) -> Optional[int] :
+    def get_version(self) -> Optional[int]:
         if self.mec is None:
             return '1' # NOTE: update this to be the most recent version, when we bump the version
         return self.mec[MITO_CONFIG_VERSION_KEY]

--- a/mitosheet/mitosheet/mito_config.py
+++ b/mitosheet/mitosheet/mito_config.py
@@ -63,14 +63,14 @@ class MitoConfig:
     environment variables 2) returning them as a mito_enterprise_configuration object
     used by the rest of the app. 
 
-    If the enviornment variables does not exist or does not set every configuration option, 
+    If the environment variables does not exist or does not set every configuration option, 
     the MitoConfig class sets defaults. 
     """
     def __init__(self):
         mito_enterprise_configuration: Optional[Dict[str, Any]] = create_mec_from_environment_variables()
         self.mec = upgrade_mito_enterprise_configuration(mito_enterprise_configuration)
 
-    def get_version(self) -> Optional[int]:
+    def get_version(self) -> Optional[str]:
         if self.mec is None:
             return '1' # NOTE: update this to be the most recent version, when we bump the version
         return self.mec[MITO_CONFIG_VERSION_KEY]

--- a/mitosheet/mitosheet/mito_widget.py
+++ b/mitosheet/mitosheet/mito_widget.py
@@ -36,11 +36,6 @@ from mitosheet.user.schemas import (UJ_MITOSHEET_LAST_FIFTY_USAGES, UJ_RECEIVED_
                                     UJ_RECEIVED_TOURS, UJ_USER_EMAIL)
 from mitosheet.user.utils import get_pandas_version, is_pro, is_running_test
 
-try:
-    from mitosheet_helper_config import MITO_ENTERPRISE_CONFIGURATION 
-except ImportError:
-    MITO_ENTERPRISE_CONFIGURATION = None
-
 
 class MitoWidget(DOMWidget):
     """
@@ -69,7 +64,7 @@ class MitoWidget(DOMWidget):
         # Set up the state container to hold private widget state
         self.steps_manager = StepsManager(args, analysis_to_replay=analysis_to_replay)
 
-        self.mito_config = MitoConfig(MITO_ENTERPRISE_CONFIGURATION)
+        self.mito_config = MitoConfig()
 
         # Set up message handler
         self.on_msg(self.receive_message)

--- a/mitosheet/mitosheet/step_performers/import_steps/dataframe_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/dataframe_import.py
@@ -25,11 +25,11 @@ def get_variable_with_name_from_caller(variable_name: str) -> Optional[Any]:
     It will first check ipython to see if it is defined, and get the variable
     from this context. 
 
-    If ipython is not defined, it will assume we are in some other python enviornment,
+    If ipython is not defined, it will assume we are in some other python environment,
     and attempt to get the variable from the callers stack frames.
 
     This is useful so that we can test this function (e.g. pytest does not run in
-    an ipython enviornment).
+    an ipython environment).
     """
     ipython = get_ipython()
     if ipython is not None:

--- a/mitosheet/mitosheet/telemetry/telemetry_utils.py
+++ b/mitosheet/mitosheet/telemetry/telemetry_utils.py
@@ -203,9 +203,9 @@ except:
 
 location = None
 
-def _get_enviornment_params() -> Dict[str, Any]:
+def _get_environment_params() -> Dict[str, Any]:
     """
-    Get data relevant for tracking the enviornment, so we can 
+    Get data relevant for tracking the environment, so we can 
     ensure Mitosheet compatibility with any system
     """
     global location
@@ -213,7 +213,7 @@ def _get_enviornment_params() -> Dict[str, Any]:
         location = get_location()
     
     # Add the python properties to every log event we can
-    enviornment_params = {
+    environment_params = {
         'version_python': sys.version_info,
         'version_pandas': pandas_version,
         'version_ipywidgets': ipywidgets_version,
@@ -225,7 +225,7 @@ def _get_enviornment_params() -> Dict[str, Any]:
         'is_docker': is_docker()
     }
 
-    return enviornment_params
+    return environment_params
 
 experiment = None
 def _get_experiment_params() -> Dict[str, Any]:
@@ -370,8 +370,8 @@ def log(log_event: str, params: Dict[str, Any]=None, steps_manager: StepsManager
     # Then, get the logs for the processing time of the operation
     final_params = {**final_params, **_get_processing_time_log_params(steps_manager=steps_manager, start_time=start_time)}
 
-    # Then, get the params for the enviornment 
-    final_params = {**final_params, **_get_enviornment_params()}
+    # Then, get the params for the environment 
+    final_params = {**final_params, **_get_environment_params()}
 
     # Then, get the params for the all experiments
     final_params = {**final_params, **_get_experiment_params()}

--- a/mitosheet/mitosheet/tests/test_mito_config.py
+++ b/mitosheet/mitosheet/tests/test_mito_config.py
@@ -15,6 +15,10 @@ def delete_env_var_if_exists(env_var: str) -> None:
         del os.environ[env_var]
 
 def test_keys_did_not_change():
+    # We must not change these keys so we can still read old 
+    # mito configs that users have not upgraded to the most 
+    # recent config version. If we don't preserve these keys, 
+    # we won't know which environment variables to read.
     assert MITO_CONFIG_VERSION_KEY == 'MITO_CONFIG_VERSION'
     assert MITO_CONFIG_SUPPORT_EMAIL_KEY == 'MITO_CONFIG_SUPPORT_EMAIL'
 

--- a/mitosheet/mitosheet/tests/test_mito_config.py
+++ b/mitosheet/mitosheet/tests/test_mito_config.py
@@ -7,16 +7,38 @@
 from mitosheet.mito_config import MITO_CONFIG_SUPPORT_EMAIL_KEY, MITO_CONFIG_VERSION_KEY, MitoConfig
 import os
 
+def delete_env_var_if_exists(env_var: str) -> None: 
+    """
+    Deletes the environment variable only if it exists to avoid errors. Helpful for testing.
+    """
+    if os.environ.get(env_var) is not None:
+        del os.environ[env_var]
+
 def test_keys_did_not_change():
     assert MITO_CONFIG_VERSION_KEY == 'MITO_CONFIG_VERSION'
     assert MITO_CONFIG_SUPPORT_EMAIL_KEY == 'MITO_CONFIG_SUPPORT_EMAIL'
 
 def test_none_works():
+    # Delete the environmnet variables so we can test the none condition
+    delete_env_var_if_exists(MITO_CONFIG_SUPPORT_EMAIL_KEY)
+    delete_env_var_if_exists(MITO_CONFIG_VERSION_KEY)
+
     mito_config = MitoConfig()
-    assert mito_config.get_mito_config() == {
+    mito_config_dict = mito_config.get_mito_config()
+    assert mito_config_dict == {
         MITO_CONFIG_VERSION_KEY: '1',
         MITO_CONFIG_SUPPORT_EMAIL_KEY: 'founders@sagacollab.com'
     }
+
+
+def test_none_config_version_key_is_string():
+    # Delete the environmnet variables so we can test the none condition
+    delete_env_var_if_exists(MITO_CONFIG_SUPPORT_EMAIL_KEY)
+    delete_env_var_if_exists(MITO_CONFIG_VERSION_KEY)
+
+    mito_config = MitoConfig()
+    mito_config_dict = mito_config.get_mito_config()
+    assert isinstance(mito_config_dict[MITO_CONFIG_VERSION_KEY], str)
 
 def test_version_1_works():
     # Set environment variables
@@ -31,6 +53,7 @@ def test_version_1_works():
     }    
 
     # Delete the environmnet variables for the next test
-    del os.environ[MITO_CONFIG_VERSION_KEY]
-    del os.environ[MITO_CONFIG_SUPPORT_EMAIL_KEY]
+    delete_env_var_if_exists(MITO_CONFIG_SUPPORT_EMAIL_KEY)
+    delete_env_var_if_exists(MITO_CONFIG_VERSION_KEY)
+
 

--- a/mitosheet/mitosheet/tests/test_mito_config.py
+++ b/mitosheet/mitosheet/tests/test_mito_config.py
@@ -3,26 +3,34 @@
 
 # Copyright (c) Mito.
 # Distributed under the terms of the Modified BSD License.
-import pandas as pd
-import pytest
-import json
 
-from mitosheet.mito_config import MEC_CONFIG_KEY_SUPPORT_EMAIL, MEC_CONFIG_KEY_VERSION, MitoConfig
+from mitosheet.mito_config import MITO_CONFIG_SUPPORT_EMAIL_KEY, MITO_CONFIG_VERSION_KEY, MitoConfig
+import os
 
+def test_keys_did_not_change():
+    assert MITO_CONFIG_VERSION_KEY == 'MITO_CONFIG_VERSION'
+    assert MITO_CONFIG_SUPPORT_EMAIL_KEY == 'MITO_CONFIG_SUPPORT_EMAIL'
 
 def test_none_works():
-    mito_config = MitoConfig(None)
+    mito_config = MitoConfig()
     assert mito_config.get_mito_config() == {
-        MEC_CONFIG_KEY_VERSION: 1,
-        MEC_CONFIG_KEY_SUPPORT_EMAIL: 'founders@sagacollab.com'
+        MITO_CONFIG_VERSION_KEY: '1',
+        MITO_CONFIG_SUPPORT_EMAIL_KEY: 'founders@sagacollab.com'
     }
 
 def test_version_1_works():
-    mito_config = MitoConfig({
-        MEC_CONFIG_KEY_VERSION: 1,
-        MEC_CONFIG_KEY_SUPPORT_EMAIL: 'nate@sagacollab.com'
-    })
+    # Set environment variables
+    os.environ[MITO_CONFIG_VERSION_KEY] = "1"
+    os.environ[MITO_CONFIG_SUPPORT_EMAIL_KEY] = "aaron@sagacollab.com"
+    
+    # Test reading environment variables works properly
+    mito_config = MitoConfig()
     assert mito_config.get_mito_config() == {
-        MEC_CONFIG_KEY_VERSION: 1,
-        MEC_CONFIG_KEY_SUPPORT_EMAIL: 'nate@sagacollab.com'
-    }
+        MITO_CONFIG_VERSION_KEY: '1',
+        MITO_CONFIG_SUPPORT_EMAIL_KEY: 'aaron@sagacollab.com'
+    }    
+
+    # Delete the environmnet variables for the next test
+    del os.environ[MITO_CONFIG_VERSION_KEY]
+    del os.environ[MITO_CONFIG_SUPPORT_EMAIL_KEY]
+

--- a/mitosheet/mitosheet/tests/test_ts_types.py
+++ b/mitosheet/mitosheet/tests/test_ts_types.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL, DEFAULT_DELIMETER, DEFAULT_ENCODING, DEFAULT_ERROR_BAD_LINES, DEFAULT_SKIPROWS
 from mitosheet.data_in_mito import DataTypeInMito
-from mitosheet.mito_config import DEFAULT_SUPPORT_EMAIL, MEC_CONFIG_KEY_SUPPORT_EMAIL, MEC_CONFIG_KEY_VERSION, MitoConfig
+from mitosheet.mito_config import DEFAULT_SUPPORT_EMAIL, MitoConfig
 from mitosheet.state import (
     DATAFRAME_SOURCE_DUPLICATED,
     DATAFRAME_SOURCE_IMPORTED,
@@ -198,7 +198,7 @@ def test_graph_safety_filter_cutoff_matches():
 
 def test_mito_enterprise_keys_match():
     mito_enterprise_config_keys = get_enum_from_ts_file("./src/types.tsx", "MitoEnterpriseConfigKey")
-    assert set(mito_enterprise_config_keys.values()) == set(MitoConfig(None).get_mito_config().keys())
+    assert set(mito_enterprise_config_keys.values()) == set(MitoConfig().get_mito_config().keys())
 
 def test_user_profile_defaults_matches():
     user_profile_support_email = get_constant_from_ts_file(

--- a/mitosheet/mitosheet/tests/test_ts_types.py
+++ b/mitosheet/mitosheet/tests/test_ts_types.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL, DEFAULT_DELIMETER, DEFAULT_ENCODING, DEFAULT_ERROR_BAD_LINES, DEFAULT_SKIPROWS
 from mitosheet.data_in_mito import DataTypeInMito
-from mitosheet.mito_config import DEFAULT_SUPPORT_EMAIL, MitoConfig
+from mitosheet.mito_config import DEFAULT_MITO_CONFIG_SUPPORT_EMAIL, MitoConfig
 from mitosheet.state import (
     DATAFRAME_SOURCE_DUPLICATED,
     DATAFRAME_SOURCE_IMPORTED,
@@ -206,7 +206,7 @@ def test_user_profile_defaults_matches():
         'DEFAULT_SUPPORT_EMAIL'
     )
 
-    assert user_profile_support_email == f"\'{DEFAULT_SUPPORT_EMAIL}\'"
+    assert user_profile_support_email == f"\'{DEFAULT_MITO_CONFIG_SUPPORT_EMAIL}\'"
 
 def test_update_events_enum_defined():
     update_types = get_enum_from_ts_file("./src/types.tsx", "UpdateType")

--- a/mitosheet/mitosheet/user/create.py
+++ b/mitosheet/mitosheet/user/create.py
@@ -55,7 +55,7 @@ def try_create_user_json_file() -> None:
         with open(USER_JSON_PATH, 'w+') as f:
             f.write(json.dumps(USER_JSON_DEFAULT))
 
-        # Then, we take special care to put all the testing/CI enviornments 
+        # Then, we take special care to put all the testing/CI environments 
         # (e.g. Github actions) under one ID and email
         from mitosheet.user.utils import is_running_test
         if is_running_test():

--- a/mitosheet/mitosheet/user/utils.py
+++ b/mitosheet/mitosheet/user/utils.py
@@ -33,9 +33,9 @@ def is_running_test() -> bool:
     inside of a test, which is useful for making sure we don't generate 
     tons of logs.
     """
-    # Pytest injects PYTEST_CURRENT_TEST into the current enviornment when running
+    # Pytest injects PYTEST_CURRENT_TEST into the current environment when running
     running_pytests = "PYTEST_CURRENT_TEST" in os.environ
-    # Github injects CI into the enviornment when running
+    # Github injects CI into the environment when running
     running_ci = 'CI' in os.environ and os.environ['CI'] is not None
 
     return running_pytests or running_ci

--- a/mitosheet/src/types.tsx
+++ b/mitosheet/src/types.tsx
@@ -626,8 +626,8 @@ interface Experiment {
 }
 
 export enum MitoEnterpriseConfigKey {
-    MEC_VERSION = 'mec_version',
-    SUPPORT_EMAIL = 'support_email'
+    MEC_VERSION = 'MITO_CONFIG_VERSION',
+    SUPPORT_EMAIL = 'MITO_CONFIG_SUPPORT_EMAIL'
 }
 
 

--- a/mitosheet/switch.py
+++ b/mitosheet/switch.py
@@ -1,5 +1,5 @@
 """
-The switch.py package is responsible for switching the enviornment
+The switch.py package is responsible for switching the environment
 between mitosheet, mitosheet2, and mitosheet3. Usage is:
 ```
 python switch.py [mitosheet | mitosheet2 | mitosheet3]


### PR DESCRIPTION
# Description

- Moves the mito-configuration approach to using environment variables instead of the mitosheet-helper-config package. 
- Also spells the word `environment` correctly all over the codebase, lol. 

Note that if you create the environment variables in the notebook and then refresh the kernel the environment variables are no longer set. As per the investigation below: The order of operations matter -- the environment variables need to be added, then the jupyter server needs to be launched.

# Testing

Set environment variables in the notebook and make sure Mito updates correctly: 
```
os.environ['MITO_CONFIG_VERSION_KEY'] = "1"
os.environ['MITO_CONFIG_SUPPORT_EMAIL_KEY'] = "aaron@sagacollab.com"
```



Then delete the environment variables and make sure Mito goes back to our defaults. 
```
del os.environ['MITO_CONFIG_VERSION_KEY']
del os.environ['MITO_CONFIG_SUPPORT_EMAIL_KEY'] = "aaron@sagacollab.com"
```

# Documentation

Note if any new documentation needs to addressed or reviewed.