### PR TITLE
mitosheet: add npm scripts to build documentation

### DIFF
--- a/mitosheet/package.json
+++ b/mitosheet/package.json
@@ -51,6 +51,9 @@
     "build:all": "npm run build:lib && npm run build:labextension && npm run build:nbextension",
     "build": "npm run build:all",
 
+    "build:docs:update_frontend": "python docs/make_function_docs.py update_frontend",
+    "build:docs:generate_markdown": "python docs/make_function_docs.py generate_markdown",
+
     "watch:lib": "tsc -w",
     "watch:nbextension": "webpack --watch --mode=development",
     "watch:labextension": "jupyter labextension watch .",


### PR DESCRIPTION
# Description

It is nicer for new developers to have a simple and straightforward API to build. No need to go in docs, understand how to build so forth an so on. package.json provides such API. This PR adds two new scripts to easily rebuild the functions documentation.

# Testing

Run:

```
npm run build:docs:update_frontend
npm run build:docs:generate_markdown

```

