### PR TITLE
mitosheet: fix search string in unique values tab

### DIFF
--- a/mitosheet/src/utils/strings.tsx
+++ b/mitosheet/src/utils/strings.tsx
@@ -12,6 +12,8 @@ export const fuzzyMatch = (stringOne: string, stringTwo: string): number => {
     stringOne = stringOne.toLowerCase();
     stringTwo = stringTwo.toLowerCase();
 
+    console.log(stringOne, stringTwo)
+
     // TODO: for now, we just search for the string, the string with spaces removed
     // and the string with underscores and dashes. In the future, we can make this 
     // handle more common typos using some existing fuzzy match algorithm
@@ -20,6 +22,7 @@ export const fuzzyMatch = (stringOne: string, stringTwo: string): number => {
         return 1;
     } 
     const possibleTypos = [
+        stringTwo,
         stringTwo.replace(' ', '-'),
         stringTwo.replace(' ', '_'),
         stringTwo.replace(' ', '.'),
@@ -28,9 +31,19 @@ export const fuzzyMatch = (stringOne: string, stringTwo: string): number => {
         stringTwo.replace('-', ' '),
         stringTwo.replace('.', ' '),
     ]
+
+    // For now, we ignore commas in string one so the most common number
+    // formatting does not mess up search.
+    const stringOneIgnoredCharacters = [
+        stringOne,
+        stringOne.replace(',', '')
+    ]
+
     for (let i = 0; i < possibleTypos.length; i++) {
-        if (stringOne.includes(possibleTypos[i])) {
-            return 1;
+        for (let j = 0; j < stringOneIgnoredCharacters.length; j++) {
+            if (stringOneIgnoredCharacters[j].includes(possibleTypos[i])) {
+                return 1;
+            }
         }
     }
     

--- a/mitosheet/src/utils/strings.tsx
+++ b/mitosheet/src/utils/strings.tsx
@@ -12,8 +12,6 @@ export const fuzzyMatch = (stringOne: string, stringTwo: string): number => {
     stringOne = stringOne.toLowerCase();
     stringTwo = stringTwo.toLowerCase();
 
-    console.log(stringOne, stringTwo)
-
     // TODO: for now, we just search for the string, the string with spaces removed
     // and the string with underscores and dashes. In the future, we can make this 
     // handle more common typos using some existing fuzzy match algorithm


### PR DESCRIPTION
# Description

Fixes bug with search in unique values tab where if the value was `6000` as int, so that Mito formatted it to `6,000`, searching for `6000` did not return the correct result. 

# Testing

Try testing above scenario

# Documentation

No. 