### PR TITLE
mitosheet: use all selected columns in fillnan taskpane

### DIFF
--- a/mitosheet/src/components/endo/ColumnHeaderDropdown.tsx
+++ b/mitosheet/src/components/endo/ColumnHeaderDropdown.tsx
@@ -108,12 +108,12 @@ export default function ColumnHeaderDropdown(props: {
                 title='Fill NaN Values'
                 onClick={() => {
                     const columnIndexesSelected = getColumnIndexesInSelections(props.gridState.selections);
-                    const columnIDsToDelete = columnIndexesSelected.map(colIdx => props.sheetData?.data[colIdx]?.columnID || '').filter(columnID => columnID !== '')
+                    const columnIDsToFillNaN = columnIndexesSelected.map(colIdx => props.sheetData?.data[colIdx]?.columnID || '').filter(columnID => columnID !== '')
 
                     props.setUIState(prevUIState => {
                         return {
                             ...prevUIState,
-                            currOpenTaskpane: {type: TaskpaneType.FILL_NA, startingColumnIDs: columnIDsToDelete},
+                            currOpenTaskpane: {type: TaskpaneType.FILL_NA, startingColumnIDs: columnIDsToFillNaN},
                         }
                     })
                 }}

--- a/mitosheet/src/components/endo/ColumnHeaderDropdown.tsx
+++ b/mitosheet/src/components/endo/ColumnHeaderDropdown.tsx
@@ -107,10 +107,13 @@ export default function ColumnHeaderDropdown(props: {
             <DropdownItem 
                 title='Fill NaN Values'
                 onClick={() => {
+                    const columnIndexesSelected = getColumnIndexesInSelections(props.gridState.selections);
+                    const columnIDsToDelete = columnIndexesSelected.map(colIdx => props.sheetData?.data[colIdx]?.columnID || '').filter(columnID => columnID !== '')
+
                     props.setUIState(prevUIState => {
                         return {
                             ...prevUIState,
-                            currOpenTaskpane: {type: TaskpaneType.FILL_NA, startingColumnIDs: [props.columnID]},
+                            currOpenTaskpane: {type: TaskpaneType.FILL_NA, startingColumnIDs: columnIDsToDelete},
                         }
                     })
                 }}


### PR DESCRIPTION
# Description

When the user has multiple columns selected, and they right click on the column header to access the fill nan taskpane, this pr opens the taskpane with all of the selected columns toggled `on` in the fill nan taskpane. 

# Testing

Try above. 

# Documentation

No. 