### PR TITLE
Full Width Columns

### DIFF
--- a/mitosheet/css/endo/ColumnHeaders.css
+++ b/mitosheet/css/endo/ColumnHeaders.css
@@ -23,7 +23,7 @@
 .column-header-resizer {
     /* We make the cursor appear to the user as something you can use to resize */
     cursor: col-resize;
-    width: 10px;
+    width: 5px;
     height: 100%;
 }
 
@@ -125,6 +125,7 @@
 }
 
 .column-header-final-icons {
+    padding-right: 5px; /* To give some additional separation with the resizer */
     display: flex;
     flex-direction: column;
     justify-content: space-evenly;

--- a/mitosheet/src/components/endo/ColumnHeader.tsx
+++ b/mitosheet/src/components/endo/ColumnHeader.tsx
@@ -14,6 +14,7 @@ import { DEFAULT_HEIGHT } from './EndoGrid';
 import { ControlPanelTab } from '../taskpanes/ControlPanel/ControlPanelTaskpane'
 import { submitRenameColumnHeader } from './columnHeaderUtils';
 import ColumnHeaderDropdown from './ColumnHeaderDropdown';
+import { changeColumnWidthDataArray, guessFullWidth } from './widthUtils';
 
 
 export const HEADER_BACKGROUND_COLOR_DEFAULT = '#E8EBF8' // This is var(--mito-light-blue) - update this if we change this variable
@@ -46,6 +47,7 @@ export const HEADER_TEXT_COLOR_DEFAULT = '#494650' // This is var(--mito-gray) -
 */
 const ColumnHeader = (props: {
     gridState: GridState,
+    setGridState: React.Dispatch<React.SetStateAction<GridState>>
     sheetData: SheetData,
     editorState: EditorState | undefined;
     setEditorState: React.Dispatch<React.SetStateAction<EditorState | undefined>>;
@@ -108,6 +110,16 @@ const ColumnHeader = (props: {
                 props.setColumnHeaderOperation(undefined);
             }}
             draggable="true"
+            onDoubleClick={() => {
+
+                const fullWidth = guessFullWidth(props.sheetData, props.columnIndex, getDisplayColumnHeader(finalColumnHeader))
+                props.setGridState((gridState) => {
+                    return {
+                        ...gridState,
+                        widthDataArray: changeColumnWidthDataArray(props.gridState.sheetIndex, props.gridState.widthDataArray, props.columnIndex, fullWidth)
+                    }
+                })
+            }}
         />
     )
 

--- a/mitosheet/src/components/endo/ColumnHeader.tsx
+++ b/mitosheet/src/components/endo/ColumnHeader.tsx
@@ -14,7 +14,7 @@ import { DEFAULT_HEIGHT } from './EndoGrid';
 import { ControlPanelTab } from '../taskpanes/ControlPanel/ControlPanelTaskpane'
 import { submitRenameColumnHeader } from './columnHeaderUtils';
 import ColumnHeaderDropdown from './ColumnHeaderDropdown';
-import { changeColumnWidthDataArray, guessFullWidth } from './widthUtils';
+import { clickedOnClass } from '../../hooks/useCallOnAnyClick';
 
 
 export const HEADER_BACKGROUND_COLOR_DEFAULT = '#E8EBF8' // This is var(--mito-light-blue) - update this if we change this variable
@@ -58,6 +58,7 @@ const ColumnHeader = (props: {
     setUIState: React.Dispatch<React.SetStateAction<UIState>>;
     mitoAPI: MitoAPI;
     closeOpenEditingPopups: (taskpanesToKeepIfOpen?: TaskpaneType[]) => void;
+    setSelectedColumnsFullWidth: () => void;
 }): JSX.Element => {
 
     const [openColumnHeaderDropdown, setOpenColumnHeaderDropdown] = useState(false);
@@ -110,16 +111,7 @@ const ColumnHeader = (props: {
                 props.setColumnHeaderOperation(undefined);
             }}
             draggable="true"
-            onDoubleClick={() => {
-
-                const fullWidth = guessFullWidth(props.sheetData, props.columnIndex, getDisplayColumnHeader(finalColumnHeader))
-                props.setGridState((gridState) => {
-                    return {
-                        ...gridState,
-                        widthDataArray: changeColumnWidthDataArray(props.gridState.sheetIndex, props.gridState.widthDataArray, props.columnIndex, fullWidth)
-                    }
-                })
-            }}
+            onDoubleClick={() => {props.setSelectedColumnsFullWidth()}}
         />
     )
 
@@ -261,7 +253,13 @@ const ColumnHeader = (props: {
                 })}
                 mito-row-index={'-1'}
                 mito-col-index={props.columnIndex}
-                onClick={() => {
+                onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+
+                    // Don't select if the click was on the resizer (the div with class column-header-resizer)
+                    const targetNode = e.currentTarget
+                    if (clickedOnClass(targetNode, 'column-header-resizer')) {
+                        return;
+                    }
                     // Don't open the control panel if we're editing, user is selecting column
                     if (editingFinalColumnHeader) {
                         return;
@@ -291,7 +289,13 @@ const ColumnHeader = (props: {
                     <>
                         <div
                             className='column-header-final-text'
-                            onClick={(e) => {
+                            onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+
+                                // Don't select if the click was on the resizer (the div with class column-header-resizer)
+                                const targetNode = e.currentTarget
+                                if (clickedOnClass(targetNode, 'column-header-resizer')) {
+                                    return;
+                                }
                                 e.stopPropagation(); // Stop prop, so we don't call the onclick the header container
                             }}
                             onDoubleClick={(e) => {
@@ -398,3 +402,4 @@ const ColumnHeader = (props: {
 }
 
 export default React.memo(ColumnHeader);
+

--- a/mitosheet/src/components/endo/ColumnHeader.tsx
+++ b/mitosheet/src/components/endo/ColumnHeader.tsx
@@ -14,7 +14,6 @@ import { DEFAULT_HEIGHT } from './EndoGrid';
 import { ControlPanelTab } from '../taskpanes/ControlPanel/ControlPanelTaskpane'
 import { submitRenameColumnHeader } from './columnHeaderUtils';
 import ColumnHeaderDropdown from './ColumnHeaderDropdown';
-import { clickedOnClass } from '../../hooks/useCallOnAnyClick';
 import { changeColumnWidthDataArray, guessFullWidth } from './widthUtils';
 
 
@@ -129,16 +128,16 @@ const ColumnHeader = (props: {
                 props.setColumnHeaderOperation(undefined);
             }}
             onMouseDown={(e) => {
-                console.log('stop prop of onMouseDown')
+                // Prevent the onMouseDown event in EndoGrid.tsx from resetting the selected indexes
                 e.stopPropagation();
             }}
             onMouseUp={(e) => {
-                console.log('stop prop of onMouseUp')
+                // Prevent the onMouseUp event in EndoGrid.tsx from resetting the selected indexes
                 e.stopPropagation();
             }}
             onClick={(e) => {
+                // Prevent the onClick event in ColumnHeader from opening the column control panel
                 e.stopPropagation();
-                console.log("stop prop of onClick")
             }}
             draggable="true"
             onDoubleClick={() => {
@@ -307,13 +306,7 @@ const ColumnHeader = (props: {
                 })}
                 mito-row-index={'-1'}
                 mito-col-index={props.columnIndex}
-                onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-
-                    // Don't select if the click was on the resizer (the div with class column-header-resizer)
-                    const targetNode = e.currentTarget
-                    if (clickedOnClass(targetNode, 'column-header-resizer')) {
-                        return;
-                    }
+                onClick={() => {
                     // Don't open the control panel if we're editing, user is selecting column
                     if (editingFinalColumnHeader) {
                         return;
@@ -343,13 +336,7 @@ const ColumnHeader = (props: {
                     <>
                         <div
                             className='column-header-final-text'
-                            onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-
-                                // Don't select if the click was on the resizer (the div with class column-header-resizer)
-                                const targetNode = e.currentTarget
-                                if (clickedOnClass(targetNode, 'column-header-resizer')) {
-                                    return;
-                                }
+                            onClick={(e) => {
                                 e.stopPropagation(); // Stop prop, so we don't call the onclick the header container
                             }}
                             onDoubleClick={(e) => {

--- a/mitosheet/src/components/endo/ColumnHeader.tsx
+++ b/mitosheet/src/components/endo/ColumnHeader.tsx
@@ -139,8 +139,6 @@ const ColumnHeader = (props: {
                 // Then set the full column width of all the selected columns
                 const widthData = getWidthArrayAtFullWidthForColumnIndexes(columnIndexes, props.gridState, props.sheetData)
 
-                // TODO: Do I need to reconcile this with the existing width Data instead of just overwriting it?
-
                 props.setGridState(prevGridState => {
                     return {
                         ...prevGridState,

--- a/mitosheet/src/components/endo/ColumnHeaders.tsx
+++ b/mitosheet/src/components/endo/ColumnHeaders.tsx
@@ -196,6 +196,7 @@ const ColumnHeaders = (props: {
                                     columnIndex={columnIndex}
                                     sheetData={props.sheetData}
                                     gridState={props.gridState}
+                                    setGridState={props.setGridState}
                                     editorState={props.editorState}
                                     setEditorState={props.setEditorState}
                                     containerRef={props.containerRef}

--- a/mitosheet/src/components/endo/ColumnHeaders.tsx
+++ b/mitosheet/src/components/endo/ColumnHeaders.tsx
@@ -2,16 +2,14 @@ import React, { useEffect, useRef, useState } from 'react';
 import '../../../css/endo/ColumnHeaders.css';
 import { getChildrenWithQuery } from './domUtils';
 import { MIN_WIDTH } from './EndoGrid';
-import { getColumnIndexesInSelections, getIndexesFromXAndY } from './selectionUtils';
+import { getIndexesFromXAndY } from './selectionUtils';
 import { calculateCurrentSheetView, calculateTranslate } from './sheetViewUtils';
 import { EditorState, GridState, SheetData, UIState } from '../../types';
 import MitoAPI from '../../jupyter/api';
 import { classNames } from '../../utils/classNames';
 import ColumnHeader from './ColumnHeader';
-import { getColumnHeaderParts, getDisplayColumnHeader } from "../../utils/columnHeaders";
-import { changeColumnWidthDataArray, guessFullWidth } from './widthUtils';
+import { changeColumnWidthDataArray } from './widthUtils';
 import { TaskpaneType } from '../taskpanes/taskpanes';
-import { getCellDataFromCellIndexes } from './utils';
 
 
 /* 
@@ -62,33 +60,6 @@ const ColumnHeaders = (props: {
     const currentSheetView = calculateCurrentSheetView(props.gridState);
     const translate = calculateTranslate(props.gridState);
     const columnHeaderStyle = {transform: `translateX(${-translate.x}px)`}
-
-    const setSelectedColumnsFullWidth = (): void  => {
-        console.log(props.gridState.selections)
-        const columnIndexesInSelections = getColumnIndexesInSelections(props.gridState.selections)
-
-        let widthDataArray = props.gridState.widthDataArray
-        columnIndexesInSelections.forEach(columnIndex => {
-            const columnHeader = getCellDataFromCellIndexes(props.sheetData, -1, columnIndex).columnHeader;
-
-            if (columnHeader === undefined) {
-                return
-            }
-
-            const finalColumnHeader  = getColumnHeaderParts(columnHeader).finalColumnHeader
-            const displayColumnHeader = getDisplayColumnHeader(finalColumnHeader)
-
-            const fullWidth = guessFullWidth(props.sheetData, columnIndex, displayColumnHeader)
-            widthDataArray = changeColumnWidthDataArray(props.gridState.sheetIndex, widthDataArray, columnIndex, fullWidth)
-        })
-
-        props.setGridState((gridState) => {
-            return {
-                ...gridState,
-                widthDataArray: widthDataArray
-            }
-        })
-    }
 
     return (
         <>
@@ -233,7 +204,6 @@ const ColumnHeaders = (props: {
                                     setUIState={props.setUIState}
                                     mitoAPI={props.mitoAPI}
                                     closeOpenEditingPopups={props.closeOpenEditingPopups}
-                                    setSelectedColumnsFullWidth={setSelectedColumnsFullWidth}
                                 />
                             )
                         })}

--- a/mitosheet/src/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/components/endo/EndoGrid.tsx
@@ -17,6 +17,7 @@ import { firstNonNullOrUndefined, getColumnIDsArrayFromSheetDataArray } from "./
 import { ensureCellVisible } from "./visibilityUtils";
 import { reconciliateWidthDataArray } from "./widthUtils";
 import FloatingCellEditor from "./celleditor/FloatingCellEditor";
+import { clickedOnClass } from "../../hooks/useCallOnAnyClick";
 
 // NOTE: these should match the css
 export const DEFAULT_WIDTH = 123;
@@ -380,6 +381,14 @@ function EndoGrid(props: {
                     })
                 } else {
                     // Clear the entire selection, and create a new one. 
+                    
+                    // Don't select if the click was on the resizer (the div with class column-header-resizer)
+                    const targetNode = e.currentTarget
+                    if (clickedOnClass(targetNode, 'column-header-resizer')) {
+                        console.log("RETURN EARLY")
+                        return;
+                    }
+
                     setGridState((gridState) => {
                         return {
                             ...gridState,

--- a/mitosheet/src/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/components/endo/EndoGrid.tsx
@@ -380,17 +380,6 @@ function EndoGrid(props: {
                     })
                 } else {
                     // Clear the entire selection, and create a new one. 
-                    
-                    // Don't select if the click was on the resizer (the div with class column-header-resizer)
-                    /*
-                    const targetNode = e.currentTarget
-                    console.log('target node: ', targetNode)
-                    if (clickedOnClass(targetNode, 'column-header-resizer')) {
-                        console.log("RETURN EARLY")
-                        return;
-                    }
-                    */
-
                     setGridState((gridState) => {
                         return {
                             ...gridState,

--- a/mitosheet/src/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/components/endo/EndoGrid.tsx
@@ -17,7 +17,6 @@ import { firstNonNullOrUndefined, getColumnIDsArrayFromSheetDataArray } from "./
 import { ensureCellVisible } from "./visibilityUtils";
 import { reconciliateWidthDataArray } from "./widthUtils";
 import FloatingCellEditor from "./celleditor/FloatingCellEditor";
-import { clickedOnClass } from "../../hooks/useCallOnAnyClick";
 
 // NOTE: these should match the css
 export const DEFAULT_WIDTH = 123;
@@ -383,11 +382,14 @@ function EndoGrid(props: {
                     // Clear the entire selection, and create a new one. 
                     
                     // Don't select if the click was on the resizer (the div with class column-header-resizer)
+                    /*
                     const targetNode = e.currentTarget
+                    console.log('target node: ', targetNode)
                     if (clickedOnClass(targetNode, 'column-header-resizer')) {
                         console.log("RETURN EARLY")
                         return;
                     }
+                    */
 
                     setGridState((gridState) => {
                         return {

--- a/mitosheet/src/components/endo/widthUtils.tsx
+++ b/mitosheet/src/components/endo/widthUtils.tsx
@@ -125,11 +125,11 @@ export const reconciliateWidthData = (prevWidthData: WidthData | undefined, oldC
     Returns a number of pixels 
 */
 export const guessFullWidth = (sheetData: SheetData, columnIndex: number, displayColumnHeader: string): number => {
-    // Estimate the column header required width as 8px per character and 5px of spacing 
-    const displayColumnHeaderPx = displayColumnHeader.length * 8 + 5
+    // Estimate the column header required width as 9px per character and 10px of spacing 
+    const displayColumnHeaderPx = displayColumnHeader.length * 9 + 10
 
-    // Estimate the data length as 7px per character in the cell with the longest data
-    const dataMaxLength = Math.max(...(sheetData.data[columnIndex].columnData.map(el => String(el).length))) * 7
+    // Estimate the data length as 8px per character in the cell with the longest data
+    const dataMaxLength = Math.max(...(sheetData.data[columnIndex].columnData.map(el => String(el).length))) * 8
 
     // Return the max 
     return Math.max(displayColumnHeaderPx, dataMaxLength)

--- a/mitosheet/src/components/endo/widthUtils.tsx
+++ b/mitosheet/src/components/endo/widthUtils.tsx
@@ -125,11 +125,11 @@ export const reconciliateWidthData = (prevWidthData: WidthData | undefined, oldC
     Returns a number of pixels 
 */
 export const guessFullWidth = (sheetData: SheetData, columnIndex: number, displayColumnHeader: string): number => {
-    // Estimate the column header required width as 10px per character and 20 px of spacing 
-    const displayColumnHeaderPx = displayColumnHeader.length * 10 + 20
+    // Estimate the column header required width as 8px per character and 5px of spacing 
+    const displayColumnHeaderPx = displayColumnHeader.length * 8 + 5
 
-    // Estimate the data length as 10px per character in the cell with the longest data
-    const dataMaxLength = Math.max(...(sheetData.data[columnIndex].columnData.map(el => String(el).length))) * 10
+    // Estimate the data length as 7px per character in the cell with the longest data
+    const dataMaxLength = Math.max(...(sheetData.data[columnIndex].columnData.map(el => String(el).length))) * 7
 
     // Return the max 
     return Math.max(displayColumnHeaderPx, dataMaxLength)

--- a/mitosheet/src/components/endo/widthUtils.tsx
+++ b/mitosheet/src/components/endo/widthUtils.tsx
@@ -117,3 +117,20 @@ export const reconciliateWidthData = (prevWidthData: WidthData | undefined, oldC
 
     return getWidthData(sheetData, oldWidths);
 }
+
+/*
+    Guess the minimum column width such that the entire column header and each cell is displayed
+    completely withour wrapping.
+
+    Returns a number of pixels 
+*/
+export const guessFullWidth = (sheetData: SheetData, columnIndex: number, displayColumnHeader: string): number => {
+    // Estimate the column header required width as 10px per character and 20 px of spacing 
+    const displayColumnHeaderPx = displayColumnHeader.length * 10 + 20
+
+    // Estimate the data length as 10px per character in the cell with the longest data
+    const dataMaxLength = Math.max(...(sheetData.data[columnIndex].columnData.map(el => String(el).length))) * 10
+
+    // Return the max 
+    return Math.max(displayColumnHeaderPx, dataMaxLength)
+}

--- a/mitosheet/src/hooks/useCallOnAnyClick.tsx
+++ b/mitosheet/src/hooks/useCallOnAnyClick.tsx
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 
 export const clickedOnClass = (targetNode: EventTarget | null | undefined, className: string | undefined): boolean => {
     if (targetNode !== null && targetNode instanceof Node && targetNode.nodeType === Node.ELEMENT_NODE && className !== undefined) {
-        const originalElement = targetNode as (HTMLElement | null);
         let currentElement = targetNode as (HTMLElement | null);
 
         // First check all of the parent elements
@@ -12,25 +11,6 @@ export const clickedOnClass = (targetNode: EventTarget | null | undefined, class
                 return true;
             }
             currentElement = currentElement.parentElement;
-        }
-
-        // Then check all of the child elements
-        currentElement = originalElement
-        let childElements: (HTMLElement | Element | null)[] = [currentElement]
-        while (childElements.length > 0) {
-            const childElement = childElements.pop()
-
-            if (childElement === null || childElement === undefined) {
-                continue
-            } 
-
-            if (childElement.classList.contains(className)) {
-                return true;
-            }
-
-            // Add the new children to list of nodes to search
-            const newChildElements = Array.from(childElement.children)
-            childElements = childElements.concat(newChildElements)
         }
     }
     return false;

--- a/mitosheet/src/hooks/useCallOnAnyClick.tsx
+++ b/mitosheet/src/hooks/useCallOnAnyClick.tsx
@@ -3,12 +3,34 @@ import { useEffect } from "react";
 
 export const clickedOnClass = (targetNode: EventTarget | null | undefined, className: string | undefined): boolean => {
     if (targetNode !== null && targetNode instanceof Node && targetNode.nodeType === Node.ELEMENT_NODE && className !== undefined) {
+        const originalElement = targetNode as (HTMLElement | null);
         let currentElement = targetNode as (HTMLElement | null);
+
+        // First check all of the parent elements
         while (currentElement) {
             if (currentElement.classList.contains(className)) {
                 return true;
             }
             currentElement = currentElement.parentElement;
+        }
+
+        // Then check all of the child elements
+        currentElement = originalElement
+        let childElements: (HTMLElement | Element | null)[] = [currentElement]
+        while (childElements.length > 0) {
+            const childElement = childElements.pop()
+
+            if (childElement === null || childElement === undefined) {
+                continue
+            } 
+
+            if (childElement.classList.contains(className)) {
+                return true;
+            }
+
+            // Add the new children to list of nodes to search
+            const newChildElements = Array.from(childElement.children)
+            childElements = childElements.concat(newChildElements)
         }
     }
     return false;


### PR DESCRIPTION
# Description

Allows you to double click on the column resizer to set the column at the min(column header, longest data cell). Performs operations for all selected columns and the column you double click on. 

# Testing

Resize columns using the double click and make sure it works. 

# Documentation

Yeah, we should probably note this somewhere. Maybe we could create a spreadsheet navigation page?