### PR TITLE
mitosheet: fix formula in formula bar

### DIFF
--- a/mitosheet/src/components/endo/ColumnHeader.tsx
+++ b/mitosheet/src/components/endo/ColumnHeader.tsx
@@ -89,7 +89,6 @@ const ColumnHeader = (props: {
     }
 
     const closeColumnHeaderEditor = () => {
-        console.log("closing column header editor")
         props.setEditorState(undefined);
         // We then focus on the grid, as we are no longer focused on the editor
         setTimeout(() => focusGrid(props.containerRef.current), 100);
@@ -223,7 +222,6 @@ const ColumnHeader = (props: {
                                         const newHeader = e.target.value;
 
                                         props.setEditorState((prevEditorState => {
-                                            console.log("undefined 2")
                                             if (prevEditorState === undefined) return undefined;
                                             return {
                                                 ...prevEditorState,
@@ -346,7 +344,6 @@ const ColumnHeader = (props: {
                                 const newHeader = e.target.value;
 
                                 props.setEditorState((prevEditorState => {
-                                    console.log("undefined 3")
                                     if (prevEditorState === undefined) return undefined;
                                     return {
                                         ...prevEditorState,

--- a/mitosheet/src/components/endo/ColumnHeader.tsx
+++ b/mitosheet/src/components/endo/ColumnHeader.tsx
@@ -89,6 +89,7 @@ const ColumnHeader = (props: {
     }
 
     const closeColumnHeaderEditor = () => {
+        console.log("closing column header editor")
         props.setEditorState(undefined);
         // We then focus on the grid, as we are no longer focused on the editor
         setTimeout(() => focusGrid(props.containerRef.current), 100);
@@ -222,6 +223,7 @@ const ColumnHeader = (props: {
                                         const newHeader = e.target.value;
 
                                         props.setEditorState((prevEditorState => {
+                                            console.log("undefined 2")
                                             if (prevEditorState === undefined) return undefined;
                                             return {
                                                 ...prevEditorState,
@@ -344,6 +346,7 @@ const ColumnHeader = (props: {
                                 const newHeader = e.target.value;
 
                                 props.setEditorState((prevEditorState => {
+                                    console.log("undefined 3")
                                     if (prevEditorState === undefined) return undefined;
                                     return {
                                         ...prevEditorState,

--- a/mitosheet/src/components/endo/ColumnHeaderDropdown.tsx
+++ b/mitosheet/src/components/endo/ColumnHeaderDropdown.tsx
@@ -137,7 +137,7 @@ export default function ColumnHeaderDropdown(props: {
             <DropdownItem 
                 title='Set Column Formula'
                 onClick={() => {
-                    const {startingColumnFormula, arrowKeysScrollInFormula} = getStartingFormula(props.sheetData, rowIndex, columnIndex, 'set_column_formula');
+                    const {startingColumnFormula, arrowKeysScrollInFormula} = getStartingFormula(props.sheetData, undefined, rowIndex, columnIndex, 'set_column_formula');
 
                     props.setEditorState({
                         rowIndex: 0,

--- a/mitosheet/src/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/components/endo/EndoGrid.tsx
@@ -497,13 +497,12 @@ function EndoGrid(props: {
             return;
         }
 
-        const {startingColumnFormula, arrowKeysScrollInFormula} = getStartingFormula(sheetData, rowIndex, columnIndex, 'set_column_formula');
-        const formula = props.editorState?.formula || startingColumnFormula
+        const {startingColumnFormula, arrowKeysScrollInFormula} = getStartingFormula(sheetData, props.editorState, rowIndex, columnIndex, 'set_column_formula');
 
         setEditorState({
             rowIndex: rowIndex,
             columnIndex: columnIndex,
-            formula: formula,
+            formula: startingColumnFormula,
             arrowKeysScrollInFormula: arrowKeysScrollInFormula,
             editorLocation: 'cell',
             editingMode: 'set_column_formula'
@@ -565,7 +564,7 @@ function EndoGrid(props: {
                 setGridState((gridState) => {
                     const lastSelection = gridState.selections[gridState.selections.length - 1]
 
-                    const {startingColumnFormula, arrowKeysScrollInFormula} = getStartingFormula(sheetData, lastSelection.startingRowIndex, lastSelection.startingColumnIndex, 'set_column_formula', e);
+                    const {startingColumnFormula, arrowKeysScrollInFormula} = getStartingFormula(sheetData, undefined, lastSelection.startingRowIndex, lastSelection.startingColumnIndex, 'set_column_formula', e);
                     
                     setEditorState({
                         rowIndex: lastSelection.startingRowIndex,

--- a/mitosheet/src/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/components/endo/EndoGrid.tsx
@@ -201,6 +201,7 @@ function EndoGrid(props: {
 
 
     const onMouseDown = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+
         if (editorState !== undefined) {
             // EDITING MODE
 
@@ -497,11 +498,12 @@ function EndoGrid(props: {
         }
 
         const {startingColumnFormula, arrowKeysScrollInFormula} = getStartingFormula(sheetData, rowIndex, columnIndex, 'set_column_formula');
+        const formula = props.editorState?.formula || startingColumnFormula
 
         setEditorState({
             rowIndex: rowIndex,
             columnIndex: columnIndex,
-            formula: startingColumnFormula,
+            formula: formula,
             arrowKeysScrollInFormula: arrowKeysScrollInFormula,
             editorLocation: 'cell',
             editingMode: 'set_column_formula'

--- a/mitosheet/src/components/endo/FormulaBar.tsx
+++ b/mitosheet/src/components/endo/FormulaBar.tsx
@@ -39,19 +39,23 @@ const FormulaBar = (props: {
     const cellEditingCellData = props.editorState === undefined ? undefined : getCellDataFromCellIndexes(props.sheetData, props.editorState.rowIndex, props.editorState.columnIndex);
     const formulaBarColumnHeader = props.editorState === undefined ? columnHeader : cellEditingCellData?.columnHeader;
 
-    let formulaBarValue = '' 
-    if (props.editorState === undefined) {
-        // If the formula bar is a cell, display the cell value. If it is a column header, display the column header
-        if (rowIndex == -1 && columnHeader !== undefined) {
-            formulaBarValue = getDisplayColumnHeader(columnHeader)
+    const getFormulaBarValue = (): string => {
+        if (props.editorState === undefined) {
+            // If the formula bar is a cell, display the cell value. If it is a column header, display the column header
+            if (rowIndex == -1 && columnHeader !== undefined) {
+                return getDisplayColumnHeader(columnHeader)
+            } else {
+                return originalFormulaBarValue;
+            }
         } else {
-            formulaBarValue = originalFormulaBarValue;
+            // If we're editing, display the formula
+            const fullFormula = getFullFormula(props.editorState.formula, formulaBarColumnHeader || '', props.editorState.pendingSelectedColumns);
+            console.log('Full Formula: ', fullFormula)
+            return fullFormula
         }
-    } else {
-        // If we're editing, display the formula
-        formulaBarValue = getFullFormula(props.editorState.formula, formulaBarColumnHeader || '', props.editorState.pendingSelectedColumns);
     }
 
+    const formulaBarValue = getFormulaBarValue()
     const currentSheetView = calculateCurrentSheetView(props.gridState);
 
     return(

--- a/mitosheet/src/components/endo/FormulaBar.tsx
+++ b/mitosheet/src/components/endo/FormulaBar.tsx
@@ -39,23 +39,19 @@ const FormulaBar = (props: {
     const cellEditingCellData = props.editorState === undefined ? undefined : getCellDataFromCellIndexes(props.sheetData, props.editorState.rowIndex, props.editorState.columnIndex);
     const formulaBarColumnHeader = props.editorState === undefined ? columnHeader : cellEditingCellData?.columnHeader;
 
-    const getFormulaBarValue = (): string => {
-        if (props.editorState === undefined) {
-            // If the formula bar is a cell, display the cell value. If it is a column header, display the column header
-            if (rowIndex == -1 && columnHeader !== undefined) {
-                return getDisplayColumnHeader(columnHeader)
-            } else {
-                return originalFormulaBarValue;
-            }
+    let formulaBarValue = ''
+    if (props.editorState === undefined) {
+        // If the formula bar is a cell, display the cell value. If it is a column header, display the column header
+        if (rowIndex == -1 && columnHeader !== undefined) {
+            formulaBarValue =  getDisplayColumnHeader(columnHeader)
         } else {
-            // If we're editing, display the formula
-            const fullFormula = getFullFormula(props.editorState.formula, formulaBarColumnHeader || '', props.editorState.pendingSelectedColumns);
-            console.log('Full Formula: ', fullFormula)
-            return fullFormula
+            formulaBarValue =  originalFormulaBarValue;
         }
+    } else {
+        // If we're editing, display the formula
+        formulaBarValue = getFullFormula(props.editorState.formula, formulaBarColumnHeader || '', props.editorState.pendingSelectedColumns);
     }
 
-    const formulaBarValue = getFormulaBarValue()
     const currentSheetView = calculateCurrentSheetView(props.gridState);
 
     return(

--- a/mitosheet/src/components/endo/celleditor/CellEditor.tsx
+++ b/mitosheet/src/components/endo/celleditor/CellEditor.tsx
@@ -97,24 +97,17 @@ const CellEditor = (props: {
     }, [props.editorState.pendingSelectedColumns]);
 
     useEffect(() => {
-        const openCellEditor = (editorState: EditorState | undefined): void => {
-            props.setEditorState(prevEditingState => {
-                if (prevEditingState === undefined) {
-                    return prevEditingState;
-                } 
-                
-                // If there is already a formula in the cell editor state, then use that (ie: if you edit the floating cell editor
-                // and switch to the formula bar). Otherwise get the starting formula. 
-                const startingColumnFormula = editorState?.formula || getStartingFormula(props.sheetData, props.editorState.rowIndex, props.editorState.columnIndex, props.editorState.editingMode).startingColumnFormula
-                return {
-                    ...prevEditingState,
-                    formula: startingColumnFormula
-                }
-            })
-        }
-
-        openCellEditor(props.editorState)
-        
+        props.setEditorState(prevEditingState => {
+            if (prevEditingState === undefined) {
+                return prevEditingState;
+            } 
+            
+            const startingColumnFormula = getStartingFormula(props.sheetData, prevEditingState, props.editorState.rowIndex, props.editorState.columnIndex, props.editorState.editingMode).startingColumnFormula
+            return {
+                ...prevEditingState,
+                formula: startingColumnFormula
+            }
+        })
     }, [props.editorState.editingMode])
 
     if (columnID === undefined || columnHeader === undefined) {

--- a/mitosheet/src/components/endo/celleditor/CellEditor.tsx
+++ b/mitosheet/src/components/endo/celleditor/CellEditor.tsx
@@ -97,16 +97,28 @@ const CellEditor = (props: {
     }, [props.editorState.pendingSelectedColumns]);
 
     useEffect(() => {
-        const {startingColumnFormula} = getStartingFormula(props.sheetData, props.editorState.rowIndex, props.editorState.columnIndex, props.editorState.editingMode);
-        props.setEditorState(prevEditingState => {
-            if (prevEditingState === undefined) {
-                return prevEditingState;
-            }
-            return {
-                ...prevEditingState,
-                formula: startingColumnFormula
-            }
-        })
+        console.log("Swtich editing mode")
+
+        const openCellEditor = (editorState: EditorState | undefined): void => {
+            props.setEditorState(prevEditingState => {
+                console.log("Prev Editing State: ", prevEditingState)
+                if (prevEditingState === undefined) {
+                    return prevEditingState;
+                } 
+                
+                // If there is already a formula in the cell editor state, then use that (ie: if you edit the floating cell editor
+                // and switch to the formula bar). Otherwise get the starting formula. 
+                const startingColumnFormula = editorState?.formula || getStartingFormula(props.sheetData, props.editorState.rowIndex, props.editorState.columnIndex, props.editorState.editingMode).startingColumnFormula
+                console.log("starting column formula: ", startingColumnFormula)
+                return {
+                    ...prevEditingState,
+                    formula: startingColumnFormula
+                }
+            })
+        }
+
+        openCellEditor(props.editorState)
+        
     }, [props.editorState.editingMode])
 
     if (columnID === undefined || columnHeader === undefined) {
@@ -139,6 +151,7 @@ const CellEditor = (props: {
                 }]
             }
         })
+        console.log("reseting editor state")
         props.setEditorState(undefined);
         
         ensureCellVisible(
@@ -479,6 +492,7 @@ const CellEditor = (props: {
                             arrowKeysScrollInFormula = props.editorState.arrowKeysScrollInFormula !== undefined && !endsInResetCharacter && !isEmpty; 
                         }
                         
+                        console.log('on change: ', e.target.value)
                         props.setEditorState({
                             ...props.editorState,
                             formula: e.target.value,
@@ -501,6 +515,7 @@ const CellEditor = (props: {
                             className='mr-5px'
                             value={props.editorState.editingMode === 'set_column_formula' ? true : false}
                             onChange={() => {
+                                console.log("on change undefined")
                                 props.setEditorState(prevEditorState => {
                                     if (prevEditorState === undefined) {
                                         return undefined
@@ -556,6 +571,7 @@ const CellEditor = (props: {
                                 <div 
                                     onMouseEnter={() => setSavedSelectedSuggestionIndex(idx)}
                                     onClick={() => {
+                                        console.log('on click')
                                         // Take a suggestion if you click on it
                                         takeSuggestion(idx);
                                         // Make sure we're focused

--- a/mitosheet/src/components/endo/celleditor/CellEditor.tsx
+++ b/mitosheet/src/components/endo/celleditor/CellEditor.tsx
@@ -97,11 +97,8 @@ const CellEditor = (props: {
     }, [props.editorState.pendingSelectedColumns]);
 
     useEffect(() => {
-        console.log("Swtich editing mode")
-
         const openCellEditor = (editorState: EditorState | undefined): void => {
             props.setEditorState(prevEditingState => {
-                console.log("Prev Editing State: ", prevEditingState)
                 if (prevEditingState === undefined) {
                     return prevEditingState;
                 } 
@@ -109,7 +106,6 @@ const CellEditor = (props: {
                 // If there is already a formula in the cell editor state, then use that (ie: if you edit the floating cell editor
                 // and switch to the formula bar). Otherwise get the starting formula. 
                 const startingColumnFormula = editorState?.formula || getStartingFormula(props.sheetData, props.editorState.rowIndex, props.editorState.columnIndex, props.editorState.editingMode).startingColumnFormula
-                console.log("starting column formula: ", startingColumnFormula)
                 return {
                     ...prevEditingState,
                     formula: startingColumnFormula
@@ -151,7 +147,6 @@ const CellEditor = (props: {
                 }]
             }
         })
-        console.log("reseting editor state")
         props.setEditorState(undefined);
         
         ensureCellVisible(
@@ -492,7 +487,6 @@ const CellEditor = (props: {
                             arrowKeysScrollInFormula = props.editorState.arrowKeysScrollInFormula !== undefined && !endsInResetCharacter && !isEmpty; 
                         }
                         
-                        console.log('on change: ', e.target.value)
                         props.setEditorState({
                             ...props.editorState,
                             formula: e.target.value,
@@ -515,7 +509,6 @@ const CellEditor = (props: {
                             className='mr-5px'
                             value={props.editorState.editingMode === 'set_column_formula' ? true : false}
                             onChange={() => {
-                                console.log("on change undefined")
                                 props.setEditorState(prevEditorState => {
                                     if (prevEditorState === undefined) {
                                         return undefined
@@ -571,7 +564,6 @@ const CellEditor = (props: {
                                 <div 
                                     onMouseEnter={() => setSavedSelectedSuggestionIndex(idx)}
                                     onClick={() => {
-                                        console.log('on click')
                                         // Take a suggestion if you click on it
                                         takeSuggestion(idx);
                                         // Make sure we're focused

--- a/mitosheet/src/components/endo/celleditor/cellEditorUtils.tsx
+++ b/mitosheet/src/components/endo/celleditor/cellEditorUtils.tsx
@@ -82,11 +82,20 @@ const KEYS_TO_ENTER_CELL_EDITING_MODE_EMPTY = [
  */
 export const getStartingFormula = (
     sheetData: SheetData | undefined, 
+    editorState: EditorState | undefined,
     rowIndex: number, 
     columnIndex: number, 
     editingMode: 'set_column_formula' | 'set_cell_value',
     e?: KeyboardEvent
 ): {startingColumnFormula: string, arrowKeysScrollInFormula: boolean} => {
+    // Preserve the formula if setting the same column's formula and you're just switching cell editors.
+    // ie: from the floating cell editor to the formula bar.
+    if (editorState !== undefined && editorState.columnIndex === columnIndex) {
+        return {
+            startingColumnFormula: editorState.formula,
+            arrowKeysScrollInFormula: true
+        }
+    }
   
     const {columnFormula, cellValue, columnHeader} = getCellDataFromCellIndexes(sheetData, rowIndex, columnIndex);
 

--- a/mitosheet/src/components/endo/celleditor/cellEditorUtils.tsx
+++ b/mitosheet/src/components/endo/celleditor/cellEditorUtils.tsx
@@ -1,7 +1,7 @@
 // Utilities for the cell editor
 
 import { FunctionDocumentationObject, functionDocumentationObjects } from "../../../data/function_documentation";
-import { ColumnHeader, ColumnID, SheetData } from "../../../types";
+import { ColumnHeader, ColumnID, EditorState, SheetData } from "../../../types";
 import { getDisplayColumnHeader, isPrimitiveColumnHeader, rowIndexToColumnHeaderLevel } from "../../../utils/columnHeaders";
 import { getCellDataFromCellIndexes } from "../utils";
 

--- a/mitosheet/src/components/endo/celleditor/cellEditorUtils.tsx
+++ b/mitosheet/src/components/endo/celleditor/cellEditorUtils.tsx
@@ -80,7 +80,13 @@ const KEYS_TO_ENTER_CELL_EDITING_MODE_EMPTY = [
  * @param e - optionally, if cell editing mode is being entered into by a keypress, pass the event here
  * @returns the formula or value that the cell editor should default to
  */
-export const getStartingFormula = (sheetData: SheetData | undefined, rowIndex: number, columnIndex: number, editingMode: 'set_column_formula' | 'set_cell_value', e?: KeyboardEvent): {startingColumnFormula: string, arrowKeysScrollInFormula: boolean} => {
+export const getStartingFormula = (
+    sheetData: SheetData | undefined, 
+    rowIndex: number, 
+    columnIndex: number, 
+    editingMode: 'set_column_formula' | 'set_cell_value',
+    e?: KeyboardEvent
+): {startingColumnFormula: string, arrowKeysScrollInFormula: boolean} => {
   
     const {columnFormula, cellValue, columnHeader} = getCellDataFromCellIndexes(sheetData, rowIndex, columnIndex);
 

--- a/mitosheet/src/utils/actions.tsx
+++ b/mitosheet/src/utils/actions.tsx
@@ -38,7 +38,7 @@ export const createActions = (
     const startingRowIndex = gridState.selections[gridState.selections.length - 1].startingRowIndex;
     const startingColumnIndex = gridState.selections[gridState.selections.length - 1].startingColumnIndex;
     const {columnID} = getCellDataFromCellIndexes(sheetData, startingRowIndex, startingColumnIndex);
-    const {startingColumnFormula, arrowKeysScrollInFormula} = getStartingFormula(sheetData, startingRowIndex, startingColumnIndex, 'set_column_formula');
+    const {startingColumnFormula, arrowKeysScrollInFormula} = getStartingFormula(sheetData, undefined, startingRowIndex, startingColumnIndex, 'set_column_formula');
     const startingColumnID = columnID;
     const lastStepSummary = analysisData.stepSummaryList[analysisData.stepSummaryList.length - 1];
 


### PR DESCRIPTION
# Description

When using the in grid cell editor, you can now switch to the formula bar cell editor and the formula is preserved instead of being deleted. 

# Testing

Try switching cell editors

# Documentation

None. 