### PR TITLE
Add cla infrastructure

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,4 +1,0 @@
-{
-  "contributors": ["naterush", "aarondr77"],
-  "message": "Hiya! It looks like you haven't signed the Mito CLA yet, which helps us manage contributions from the community. A Mito team member will follow up and help you get set up with the CLA ASAP!"
-}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ jobs:
           path-to-document: 'https://github.com/mito-ds/monorepo/blob/main/LICENSE' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'main'
-          allowlist: ["naterush"]
+          allowlist: ["naterush", "aarondr77"]
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,14 +21,3 @@ jobs:
           # branch should not be protected
           branch: 'main'
           allowlist: ["naterush", "aarondr77"]
-
-          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
-          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
-          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
-          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ jobs:
           path-to-document: 'https://github.com/mito-ds/monorepo/blob/main/LICENSE' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'main'
-          allowlist: ["naterush", "aarondr77"]
+          allowlist: ["naterush"]
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,34 @@
+name: "CLA Assistant"
+on:
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        # Beta Release
+        uses: contributor-assistant/github-action@v2.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/mito-ds/monorepo/blob/main/LICENSE' # e.g. a CLA or a DCO document
+          # branch should not be protected
+          branch: 'main'
+          allowlist: ["naterush", "aarondr77"]
+
+          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
+          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/CLA.md
+++ b/CLA.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Mito. This page describes the est
 
 In order to clarify the intellectual property license granted with contributions from any person or entity, Mito must have a Contributor License Agreement (CLA) on file that has been signed by each Contributor, indicating agreement to certain license terms. This license is not only for the protection of the contributors themselves, but also for the protection of the project and its users; it does not change your rights to use your own Contributions for any other purpose.
 
-All past and future contributors of non-trivial amounts of code (more than just a line or two) to Mito are required to sign the CLA. If somebody is unable to sign the document, their contribution will not be accepted or will be removed from Audacity.
+All past and future contributors of non-trivial amounts of code (more than just a line or two) to Mito are required to sign the CLA. If somebody is unable to sign the document, their contribution will not be accepted or will be removed from Mito.
 
 ### You and Mito agree:
 

--- a/CLA.md
+++ b/CLA.md
@@ -1,6 +1,6 @@
 # Contributor License Agreement
 
-Thank you for your interest in contributing to Mito. This page describes the established guidelines for contributions of code, patches and artwork to Mito.
+Thank you for your interest in contributing to Mito. This page describes the established guidelines for contributions of code, patches, documentation, notebooks, and artwork to Mito.
 
 In order to clarify the intellectual property license granted with contributions from any person or entity, Mito must have a Contributor License Agreement (CLA) on file that has been signed by each Contributor, indicating agreement to certain license terms. This license is not only for the protection of the contributors themselves, but also for the protection of the project and its users; it does not change your rights to use your own Contributions for any other purpose.
 

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,19 @@
+# Contributor License Agreement
+
+Thank you for your interest in contributing to Mito. This page describes the established guidelines for contributions of code, patches and artwork to Mito.
+
+In order to clarify the intellectual property license granted with contributions from any person or entity, Mito must have a Contributor License Agreement (CLA) on file that has been signed by each Contributor, indicating agreement to certain license terms. This license is not only for the protection of the contributors themselves, but also for the protection of the project and its users; it does not change your rights to use your own Contributions for any other purpose.
+
+All past and future contributors of non-trivial amounts of code (more than just a line or two) to Mito are required to sign the CLA. If somebody is unable to sign the document, their contribution will not be accepted or will be removed from Audacity.
+
+### You and Mito agree:
+
+    You grant Saga Inc. (“Company”) the ability to use the Contributions in any way. You hereby grant to Company, a perpetual, non-exclusive, worldwide, fully paid-up, royalty free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your Contribution and such derivative works.
+
+    You are able to grant Company these rights. You represent that You are legally entitled to grant the above license. If Your employer has rights to intellectual property that You create, You represent that You have received permission to make the Contributions on behalf of that employer, or that Your employer has waived such rights for the Contributions.
+
+    The Contributions are your original work. You represent that the Contributions are Your original works of authorship, and to Your knowledge, no other person claims, or has the right to claim, any right in any invention or patent related to the Contributions. You also represent that You are not legally obligated, whether by entering into an agreement or otherwise, in any way that conflicts with the terms of this license. For example, if you have signed an agreement requiring you to assign the intellectual property rights in the Contributions to an employer or customer, that would conflict with the terms of this license.
+
+    Company determines the code that is in the Company project. You understand that the decision to include the Contribution in any project or source repository is entirely that of Company, and this agreement does not guarantee that the Contributions will be included in any product.
+
+    No Implied Warranties. Company  acknowledges that, except as explicitly described in this Agreement, the Contribution is provided on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,4 +53,4 @@ We also thank the maintainers of [SerenityOS](https://github.com/SerenityOS/sere
 
 ## Contributor Agreement
 
-**Coming soon**
+Read our Contribute Liscence Agreement [here](https://github.com/mito-ds/monorepo/blob/main/CLA.md)


### PR DESCRIPTION
# Description

Sets up the the CLA assistant following the instructions [here](https://github.com/marketplace/actions/cla-assistant-lite)

# Testing

Will test once we merge into dev

# Documentation

Note if any new documentation needs to addressed or reviewed.