### PR TITLE
mitosheet: add toggle all to export taskpane

### DIFF
--- a/mitosheet/src/components/taskpanes/Download/ExcelDownloadConfigSection.tsx
+++ b/mitosheet/src/components/taskpanes/Download/ExcelDownloadConfigSection.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import MitoAPI from "../../../jupyter/api";
 import ExcelFormatSection from "../../../pro/download/ExcelFormatSection";
 import { ExcelExportState, SheetData, UIState, UserProfile } from "../../../types";
-import { toggleInArray } from "../../../utils/arrays";
+import { addIfAbsent, removeIfPresent, toggleInArray } from "../../../utils/arrays";
 import MultiToggleBox from "../../elements/MultiToggleBox";
 import MultiToggleItem from "../../elements/MultiToggleItem";
 import Row from "../../layout/Row";
@@ -26,6 +26,25 @@ const ExcelDownloadConfigSection = (props: {
             <MultiToggleBox
                 width='block'
                 height='small'
+                toggleAllIndexes={(indexesToToggle, newToggle) => {
+                    props.setUIState(prevUiState => {
+                        // We make the assumption that the order of the sheets in the MultiToggleBox
+                        // is the same as the order in the sheet. 
+                        const newSelectedSheetIndexes = [...props.exportState.sheetIndexes]
+                        indexesToToggle.forEach(sheetIndex => {
+                            if (newToggle) {
+                                addIfAbsent(newSelectedSheetIndexes, sheetIndex)
+                            } else {
+                                removeIfPresent(newSelectedSheetIndexes, sheetIndex)
+                            }
+                        })
+                        newSelectedSheetIndexes.sort() // Make sure these are in the right order;
+                        return {
+                            ...prevUiState,
+                            exportConfiguration: {exportType: 'excel', sheetIndexes: newSelectedSheetIndexes}
+                        }
+                    })
+                }}
             >
                 {props.dfNames.map((dfName, index) => {
                     return (


### PR DESCRIPTION
# Description

Adds a toggle all to the excel export taskpane

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.