### PR TITLE
mitosheet: update datetime bucket ordering and alg

### DIFF
--- a/mitosheet/src/components/endo/widthUtils.tsx
+++ b/mitosheet/src/components/endo/widthUtils.tsx
@@ -3,7 +3,6 @@ import { ColumnID, GridState, SheetData, WidthData } from "../../types";
 import { getCellDataFromCellIndexes } from "./utils";
 import { getDisplayColumnHeader } from "../../utils/columnHeaders";
 
-
 /* 
     A helper function for getting the default widthData
     based on some passed sheet data.
@@ -127,8 +126,8 @@ export const reconciliateWidthData = (prevWidthData: WidthData | undefined, oldC
     Returns a number of pixels 
 */
 export const guessFullWidthOfColumnHeaderOrContent = (sheetData: SheetData, columnIndex: number, displayColumnHeader: string): number => {
-    // Estimate the column header required width as 12px per character and 15px of spacing 
-    const displayColumnHeaderPx = displayColumnHeader.length * 12 + 15
+    // Estimate the column header required width as 10px per character and 15px of spacing 
+    const displayColumnHeaderPx = displayColumnHeader.length * 10 + 15
 
     // Estimate the data length as 8px per character in the cell with the longest data
     const dataMaxLength = Math.max(...(sheetData.data[columnIndex].columnData.map(el => String(el).length))) * 8
@@ -136,6 +135,7 @@ export const guessFullWidthOfColumnHeaderOrContent = (sheetData: SheetData, colu
     // Return the max 
     return Math.max(displayColumnHeaderPx, dataMaxLength)
 }
+
 
 /*
     Guesses the full width for all of the passed column Indexes.

--- a/mitosheet/src/components/taskpanes/PivotTable/PivotTableKeySelection.tsx
+++ b/mitosheet/src/components/taskpanes/PivotTable/PivotTableKeySelection.tsx
@@ -18,6 +18,11 @@ import PivotInvalidSelectedColumnsError from './PivotInvalidSelectedColumnsError
 const PIVOT_COLUMN_TRANSFORM_TITLES: Record<PivotColumnTransformation, string> = {
     'no-op': 'exact time',
     'year': 'year',
+    'year-quarter': 'year-quarter',
+    'year-month': 'year-month',
+    'year-month-day': 'year-month-day',
+    'year-month-day-hour': 'year-month-day-hour',
+    'year-month-day-hour-minute': 'year-month-day-hour-minute',
     'quarter': 'quarter',
     'month': 'month',
     'week': 'week',
@@ -26,11 +31,6 @@ const PIVOT_COLUMN_TRANSFORM_TITLES: Record<PivotColumnTransformation, string> =
     'hour': 'hour',
     'minute': 'minute',
     'second': 'second',
-    'year-month-day-hour-minute': 'year-month-day-hour-minute',
-    'year-month-day-hour': 'year-month-day-hour',
-    'year-month-day': 'year-month-day',
-    'year-month': 'year-month',
-    'year-quarter': 'year-quarter',
     'month-day': 'month-day',
     'day-hour': 'day-hour',
     'hour-minute': 'hour-minute'


### PR DESCRIPTION
# Description

- Changes the order of the pivot table time buckets to be more intuitive.
- Updates the algorithm to guess full width of columns <- I tried for about an hour to create divs and get the correct width from them, but it wasn't working properly and is way more complicated than this, so thought I would keep this for now. 


# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.