### PR TITLE
mitosheet: filter out temp windows files

### DIFF
--- a/mitosheet/mitosheet/api/get_path_contents.py
+++ b/mitosheet/mitosheet/api/get_path_contents.py
@@ -128,8 +128,10 @@ def get_path_contents(params: Dict[str, Any]) -> str:
     # to see (as they would otherwise). 
     # Linux, Max == starts with "."
     # Windows == "$"
+    # We also filter out files that start with:
+    # ~$ is used to prefix hidden temporary files that are created when a document is opened in Windows
     dirnames = [d for d in dirnames if (not d.startswith('.') and not d.startswith('$'))]
-    filenames = [f for f in filenames if (not f.startswith('.') and not f.startswith('$'))]
+    filenames = [f for f in filenames if (not f.startswith('.') and not f.startswith('$') and not f.startswith('~$'))]
 
     return json.dumps({
         'path': path,


### PR DESCRIPTION
# Description

Hides temporary files that start with `~$`

# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.