### PR TITLE
mitosheet: update copying to allow users to select non endo text

### DIFF
--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -22977,6 +22977,7 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
         if (!Object.keys(KEYBOARD_SHORTCUTS).includes(e.key) || !e.ctrlKey && !e.metaKey) {
           return;
         }
+        console.log(window.getSelection());
         if (e.key === "c") {
           setGridState((prevGridState) => {
             return __spreadProps(__spreadValues({}, prevGridState), {
@@ -22991,6 +22992,10 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
           return;
         }
         if (((_b = document.activeElement) == null ? void 0 : _b.tagName.toLowerCase()) === "input") {
+          return;
+        }
+        const selection = window.getSelection();
+        if ((selection == null ? void 0 : selection.type) !== "None" || selection.anchorNode !== null || selection.focusNode !== null) {
           return;
         }
         e.stopImmediatePropagation();

--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -22977,7 +22977,6 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
         if (!Object.keys(KEYBOARD_SHORTCUTS).includes(e.key) || !e.ctrlKey && !e.metaKey) {
           return;
         }
-        console.log(window.getSelection());
         if (e.key === "c") {
           setGridState((prevGridState) => {
             return __spreadProps(__spreadValues({}, prevGridState), {
@@ -22994,8 +22993,9 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
         if (((_b = document.activeElement) == null ? void 0 : _b.tagName.toLowerCase()) === "input") {
           return;
         }
-        const selection = window.getSelection();
-        if ((selection == null ? void 0 : selection.type) !== "None" || selection.anchorNode !== null || selection.focusNode !== null) {
+        const activeElement = document == null ? void 0 : document.activeElement;
+        console.log(activeElement);
+        if ((activeElement == null ? void 0 : activeElement.id) !== "endo-grid-container") {
           return;
         }
         e.stopImmediatePropagation();
@@ -26645,6 +26645,7 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
       "div",
       {
         className: "endo-grid-container",
+        id: "endo-grid-container",
         ref: containerRef,
         tabIndex: -1,
         onMouseDown,

--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -22994,7 +22994,6 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
           return;
         }
         const activeElement = document == null ? void 0 : document.activeElement;
-        console.log(activeElement);
         if ((activeElement == null ? void 0 : activeElement.id) !== "endo-grid-container") {
           return;
         }

--- a/mitosheet/src/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/components/endo/EndoGrid.tsx
@@ -639,6 +639,7 @@ function EndoGrid(props: {
             />
             <div 
                 className='endo-grid-container' 
+                id='endo-grid-container' // This id is used by useKeyboardShortcuts to figure out when to copy data from Endo
                 ref={containerRef}
                 tabIndex={-1} 
                 onMouseDown={onMouseDown} 

--- a/mitosheet/src/hooks/useKeyboardShortcuts.tsx
+++ b/mitosheet/src/hooks/useKeyboardShortcuts.tsx
@@ -34,6 +34,8 @@ export const useKeyboardShortcuts = (mitoContainerRef: React.RefObject<HTMLDivEl
             // We have a special case here if the user is doing a copy, where we need to clear
             // the previously copied values. This should always run, even if we're not in this
             // specific mito instance, because this clears the copy anyways
+
+            console.log(window.getSelection())
             if (e.key === 'c') {
                 setGridState(prevGridState => {
                     return {
@@ -57,6 +59,14 @@ export const useKeyboardShortcuts = (mitoContainerRef: React.RefObject<HTMLDivEl
             // as in this case we don't want to overwrite this action
             if (document.activeElement?.tagName.toLowerCase() === 'input') {
                 return;
+            }
+
+            // Then if the keyboard shortcut is copy, we only overwrite the default behavior if endo data is selected.
+            // We're able to hackily determine if endo data is selected by checking if the selection type is 'None', and the anchor node and focus node
+            // are null. This is probably a result of us not crossing our t's in Endo so we might need to update this approach in the future.
+            const selection = window.getSelection()
+            if (selection?.type !== 'None' || selection.anchorNode !== null || selection.focusNode !== null) {
+                return
             }
 
             // Because JupyterLab has some other event listeners that do weird things with

--- a/mitosheet/src/hooks/useKeyboardShortcuts.tsx
+++ b/mitosheet/src/hooks/useKeyboardShortcuts.tsx
@@ -60,10 +60,7 @@ export const useKeyboardShortcuts = (mitoContainerRef: React.RefObject<HTMLDivEl
             }
 
             // Then if the keyboard shortcut is copy, we only overwrite the default behavior if endo data is selected.
-            // We're able to hackily determine if endo data is selected by checking if the selection type is 'None', and the anchor node and focus node
-            // are null. This is probably a result of us not crossing our t's in Endo so we might need to update this approach in the future.
             const activeElement = document?.activeElement
-            console.log(activeElement)
             if (activeElement?.id !== 'endo-grid-container') {
                 return
             }

--- a/mitosheet/src/hooks/useKeyboardShortcuts.tsx
+++ b/mitosheet/src/hooks/useKeyboardShortcuts.tsx
@@ -34,8 +34,6 @@ export const useKeyboardShortcuts = (mitoContainerRef: React.RefObject<HTMLDivEl
             // We have a special case here if the user is doing a copy, where we need to clear
             // the previously copied values. This should always run, even if we're not in this
             // specific mito instance, because this clears the copy anyways
-
-            console.log(window.getSelection())
             if (e.key === 'c') {
                 setGridState(prevGridState => {
                     return {
@@ -64,8 +62,9 @@ export const useKeyboardShortcuts = (mitoContainerRef: React.RefObject<HTMLDivEl
             // Then if the keyboard shortcut is copy, we only overwrite the default behavior if endo data is selected.
             // We're able to hackily determine if endo data is selected by checking if the selection type is 'None', and the anchor node and focus node
             // are null. This is probably a result of us not crossing our t's in Endo so we might need to update this approach in the future.
-            const selection = window.getSelection()
-            if (selection?.type !== 'None' || selection.anchorNode !== null || selection.focusNode !== null) {
+            const activeElement = document?.activeElement
+            console.log(activeElement)
+            if (activeElement?.id !== 'endo-grid-container') {
                 return
             }
 


### PR DESCRIPTION
# Description

Fixes our copy logic by relying on the active element so that users can copy things like:
- Summary stats data
- Values from unique values tab
- Text from the modal
- Text from the formula bar

# Testing

Copy text from Endo as well as different text from Mito and make sure it copies correctly. 

# Documentation

No