### PR TITLE
mitosheet: fix pytests for new numpy release

### DIFF
--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -22973,7 +22973,7 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
   var useKeyboardShortcuts = (mitoContainerRef, actions, setGridState) => {
     useDebouncedEffect(() => {
       const checkKeyboardShortCut = (e) => {
-        var _a, _b;
+        var _a, _b, _c;
         if (!Object.keys(KEYBOARD_SHORTCUTS).includes(e.key) || !e.ctrlKey && !e.metaKey) {
           return;
         }
@@ -22991,6 +22991,10 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
           return;
         }
         if (((_b = document.activeElement) == null ? void 0 : _b.tagName.toLowerCase()) === "input") {
+          return;
+        }
+        const selectedText = (_c = window.getSelection()) == null ? void 0 : _c.toString();
+        if (e.key === "c" && selectedText !== void 0 && selectedText !== "") {
           return;
         }
         e.stopImmediatePropagation();

--- a/mitosheet/mitosheet/tests/step_performers/test_filter.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_filter.py
@@ -71,7 +71,7 @@ FILTER_TESTS = [
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
         FC_NUMBER_EXACTLY,
         10,
-        pd.DataFrame(columns=["A"], dtype="int"),
+        pd.DataFrame(columns=["A"]),
     ),
     (
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
@@ -83,7 +83,7 @@ FILTER_TESTS = [
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
         FC_NUMBER_GREATER,
         10,
-        pd.DataFrame(columns=["A"], dtype="int"),
+        pd.DataFrame(columns=["A"]),
     ),
     (
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
@@ -101,7 +101,7 @@ FILTER_TESTS = [
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
         FC_NUMBER_GREATER_THAN_OR_EQUAL,
         10,
-        pd.DataFrame(columns=["A"], dtype="int"),
+        pd.DataFrame(columns=["A"]),
     ),
     (
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
@@ -119,7 +119,7 @@ FILTER_TESTS = [
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
         FC_NUMBER_LESS,
         0,
-        pd.DataFrame(columns=["A"], dtype="int"),
+        pd.DataFrame(columns=["A"]),
     ),
     (
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
@@ -137,7 +137,7 @@ FILTER_TESTS = [
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
         FC_NUMBER_LESS_THAN_OR_EQUAL,
         0,
-        pd.DataFrame(columns=["A"], dtype="int"),
+        pd.DataFrame(columns=["A"]),
     ),
     (
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),

--- a/mitosheet/mitosheet/tests/step_performers/test_filter.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_filter.py
@@ -71,7 +71,7 @@ FILTER_TESTS = [
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
         FC_NUMBER_EXACTLY,
         10,
-        pd.DataFrame(columns=["A"]),
+        pd.DataFrame(columns=["A"], dtype="float"),
     ),
     (
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
@@ -83,7 +83,7 @@ FILTER_TESTS = [
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
         FC_NUMBER_GREATER,
         10,
-        pd.DataFrame(columns=["A"]),
+        pd.DataFrame(columns=["A"], dtype="float"),
     ),
     (
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
@@ -101,7 +101,7 @@ FILTER_TESTS = [
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
         FC_NUMBER_GREATER_THAN_OR_EQUAL,
         10,
-        pd.DataFrame(columns=["A"]),
+        pd.DataFrame(columns=["A"], dtype="float"),
     ),
     (
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
@@ -119,7 +119,7 @@ FILTER_TESTS = [
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
         FC_NUMBER_LESS,
         0,
-        pd.DataFrame(columns=["A"]),
+        pd.DataFrame(columns=["A"], dtype="float"),
     ),
     (
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
@@ -137,7 +137,7 @@ FILTER_TESTS = [
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),
         FC_NUMBER_LESS_THAN_OR_EQUAL,
         0,
-        pd.DataFrame(columns=["A"]),
+        pd.DataFrame(columns=["A"], dtype="float"),
     ),
     (
         pd.DataFrame(data={"A": [1, 2, 3, 4, 5, 6]}),


### PR DESCRIPTION
# Description

There was a new numpy release, `numpy 1.24.0` that broke a few filter tests. This PR fixes them. Specifically, I believe that it broke because of this PR https://github.com/numpy/numpy/pull/22357 where some dtypes got checked at runtime. 

However, according to the release notes [here](https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations), "This release supports Python versions 3.8-3.11." so we have to take special care to handle earlier versions of numpy by setting the dtype to float. 

# Testing

- On dev, install numpy 1.24.0 and see that's don't pass
- On dev, install numpy 1.23.5 and see that tests do pass
- On this branch, see that tests pass on both versions of numpy. 

# Documentation

No. 