### PR TITLE
mitoinstaller: create option for turning off automatic jupyter launch

### DIFF
--- a/mitoinstaller/mitoinstaller/commands.py
+++ b/mitoinstaller/mitoinstaller/commands.py
@@ -114,6 +114,9 @@ def install_pip_packages(*packages: str, test_pypi: bool=False, user_install: bo
     if '--no-cache-dir' in sys.argv:
         sys_call.append('--no-cache-dir')
 
+    if '--turn-off-jupyter-launch' in sys.argv:
+        sys_call.append('--turn-off-jupyter-launch')
+
     for package in packages:
         sys_call.append(package)
     sys_call.append('--upgrade')

--- a/mitoinstaller/mitoinstaller/commands.py
+++ b/mitoinstaller/mitoinstaller/commands.py
@@ -114,9 +114,6 @@ def install_pip_packages(*packages: str, test_pypi: bool=False, user_install: bo
     if '--no-cache-dir' in sys.argv:
         sys_call.append('--no-cache-dir')
 
-    if '--turn-off-jupyter-launch' in sys.argv:
-        sys_call.append('--turn-off-jupyter-launch')
-
     for package in packages:
         sys_call.append(package)
     sys_call.append('--upgrade')

--- a/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
@@ -25,6 +25,10 @@ def replace_process_with_jupyter():
     """
     if is_running_test():
         return
+
+    if ('--turn-off-jupyter-launch' in sys.argv):
+        return 
+        
     # Get the prefered jupyter to launch, which we saved before
     prefered_jupyter = get_prefered_jupyter_env_variable()
 

--- a/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
@@ -27,8 +27,9 @@ def replace_process_with_jupyter():
         return
 
     if ('--turn-off-jupyter-launch' in sys.argv):
+        print("Not starting Jupyter due to --turn-off-jupyter-launch")
         return 
-        
+
     # Get the prefered jupyter to launch, which we saved before
     prefered_jupyter = get_prefered_jupyter_env_variable()
 

--- a/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
@@ -7,7 +7,6 @@ import time
 
 import analytics
 from mitoinstaller.create_startup_file import create_startup_file
-from mitoinstaller.experiments.experiment_utils import is_variant_a
 from mitoinstaller.installer_steps.installer_step import InstallerStep
 from mitoinstaller.jupyter_utils import get_prefered_jupyter_env_variable
 from mitoinstaller.starter_notebook import (MITO_STARTER_NOTEBOOK_PATH,

--- a/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/final_installer_steps.py
@@ -25,8 +25,8 @@ def replace_process_with_jupyter():
     if is_running_test():
         return
 
-    if ('--turn-off-jupyter-launch' in sys.argv):
-        print("Not starting Jupyter due to --turn-off-jupyter-launch")
+    if ('--no-jupyter-launch' in sys.argv):
+        print("Not starting Jupyter due to --no-jupyter-launch")
         return 
 
     # Get the prefered jupyter to launch, which we saved before

--- a/mitoinstaller/tests/test_launch_jupyter.py
+++ b/mitoinstaller/tests/test_launch_jupyter.py
@@ -1,14 +1,30 @@
 
-from mitoinstaller.jupyter_utils import get_prefered_jupyter_env_variable
+from mitoinstaller.jupyter_utils import get_prefered_jupyter_env_variable, is_jupyter_lab_running, is_jupyter_notebook_running
 from tests.conftest import VirtualEnvironment
 
 def test_detects_notebook_as_prefered(venv: VirtualEnvironment):
     venv.run_python_module_command(['pip', 'install', 'notebook'])
     venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])
     out = venv.run_python_script('from mitoinstaller.jupyter_utils import get_prefered_jupyter_env_variable, set_prefered_jupyter_env_variable; set_prefered_jupyter_env_variable(); print(get_prefered_jupyter_env_variable())')
+    
     assert out.strip() == 'notebook'
 
 def test_defaults_to_lab(venv: VirtualEnvironment):
     venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])
     out = venv.run_python_script('from mitoinstaller.jupyter_utils import get_prefered_jupyter_env_variable, set_prefered_jupyter_env_variable; set_prefered_jupyter_env_variable(); print(get_prefered_jupyter_env_variable())')
     assert out.strip() == 'lab'
+
+def test_does_not_launch_jupyter(venv: VirtualEnvironment):
+    # Note that this test only ensures that adding the param '--turn-off-jupyter-launch' does not 
+    # completely break the installation, but it does not test that it prevents jupyter from launching
+    venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])    
+    venv.run_python_module_command(['mitoinstaller', 'install', '--turn-off-jupyter-launch'])
+
+    mitosheet_version = venv.get_package_version('mitosheet')
+    jlab_version = venv.get_package_version('jupyterlab')
+
+    assert mitosheet_version is not None 
+    assert jlab_version is not None
+
+
+

--- a/mitoinstaller/tests/test_launch_jupyter.py
+++ b/mitoinstaller/tests/test_launch_jupyter.py
@@ -14,10 +14,10 @@ def test_defaults_to_lab(venv: VirtualEnvironment):
     assert out.strip() == 'lab'
 
 def test_does_not_launch_jupyter(venv: VirtualEnvironment):
-    # Note that this test only ensures that adding the param '--turn-off-jupyter-launch' does not 
+    # Note that this test only ensures that adding the param '--no-jupyter-launch' does not 
     # completely break the installation, but it does not test that it prevents jupyter from launching
     venv.run_python_module_command(['pip', 'install', '-r', 'requirements.txt'])    
-    venv.run_python_module_command(['mitoinstaller', 'install', '--turn-off-jupyter-launch'])
+    venv.run_python_module_command(['mitoinstaller', 'install', '--no-jupyter-launch'])
 
     mitosheet_version = venv.get_package_version('mitosheet')
     jlab_version = venv.get_package_version('jupyterlab')

--- a/mitoinstaller/tests/test_launch_jupyter.py
+++ b/mitoinstaller/tests/test_launch_jupyter.py
@@ -1,5 +1,4 @@
 
-from mitoinstaller.jupyter_utils import get_prefered_jupyter_env_variable, is_jupyter_lab_running, is_jupyter_notebook_running
 from tests.conftest import VirtualEnvironment
 
 def test_detects_notebook_as_prefered(venv: VirtualEnvironment):


### PR DESCRIPTION
# Description

Creates an optional argument to the installer that prevents the installer from automatically launching Jupyter at the end of the process, as this is breaking some users's startup scripts. https://github.com/mito-ds/monorepo/issues/578

# Testing

Run installer locally with `python3 -m mitoinstaller install --turn-off-jupyter-launch` and make sure Jupyter does not start

@naterush is there an easy way to actually test this functionality. My test leaves room to be desired. 

# Documentation

Yes. We could add documentation for this and --user options