### PR TITLE
Dogfood 1-8-23

### DIFF
--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -21052,6 +21052,11 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
           if (props.widthOnFocus !== void 0) {
             setWidth(props.widthOnFocus);
           }
+          if (props.selectTextOnFocus) {
+            setTimeout(() => {
+              e.target.select();
+            }, 50);
+          }
         },
         onBlur: (e) => {
           if (props.onBlur !== void 0) {
@@ -34419,7 +34424,8 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
               });
             });
           }
-        }
+        },
+        selectTextOnFocus: true
       }
     ))), /* @__PURE__ */ import_react125.default.createElement(Row_default, { justify: "space-between", align: "center", title: ENCODING_TOOLTIP }, /* @__PURE__ */ import_react125.default.createElement(Col_default, null, /* @__PURE__ */ import_react125.default.createElement(LabelAndTooltip_default, { tooltip: ENCODING_TOOLTIP }, "Encoding")), /* @__PURE__ */ import_react125.default.createElement(Col_default, null, /* @__PURE__ */ import_react125.default.createElement(
       Select_default,
@@ -34470,7 +34476,8 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
               skiprows: [newSkiprowsNumber]
             });
           });
-        }
+        },
+        selectTextOnFocus: true
       }
     ))), /* @__PURE__ */ import_react125.default.createElement(Row_default, { justify: "space-between", align: "center", title: ERROR_BAD_LINES_TOOLTIP }, /* @__PURE__ */ import_react125.default.createElement(Col_default, null, /* @__PURE__ */ import_react125.default.createElement(LabelAndTooltip_default, { tooltip: ERROR_BAD_LINES_TOOLTIP }, "Skip Invalid Lines")), /* @__PURE__ */ import_react125.default.createElement(Col_default, null, /* @__PURE__ */ import_react125.default.createElement(Toggle_default, { value: !currentErrorBadLines, onChange: () => {
       props.setParams((prevParams) => {

--- a/mitosheet/src/components/elements/Input.tsx
+++ b/mitosheet/src/components/elements/Input.tsx
@@ -38,7 +38,7 @@ interface InputProps {
 
     /**
         * @param [onClick] - Function to be called with mouse is pressed 
-     */
+    */
     onClick?: (e: React.MouseEvent) => void;
 
     /**
@@ -100,6 +100,11 @@ interface InputProps {
         * @param [onEscape] - Function to be called when the escape key is pressed
     */
     onEscape?: () => void
+
+    /** 
+        * @param [selectTextOnFocus] - Select all of the text when clicked. Helpful, for example, if there is only a space in the input  
+    */
+    selectTextOnFocus?: boolean
 }
 
 /**
@@ -171,6 +176,13 @@ const Input = (props: InputProps): JSX.Element => {
                     }
                     if (props.widthOnFocus !== undefined) {
                         setWidth(props.widthOnFocus)
+                    }
+                    if (props.selectTextOnFocus) {
+                        // Select the entire text after a very short delay as to 
+                        // not compete with the onClick.
+                        setTimeout(() => {
+                            e.target.select();
+                        }, 50)
                     }
                 }}
                 onBlur={(e) => {

--- a/mitosheet/src/components/import/CSVImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/CSVImportConfigScreen.tsx
@@ -295,6 +295,7 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
                                     })
                                 }
                             }}
+                            selectTextOnFocus
                         />
                     </Col>
                 </Row>
@@ -373,6 +374,7 @@ function CSVImportConfigScreen(props: CSVImportConfigScreenProps): JSX.Element {
                                     }
                                 })
                             }}
+                            selectTextOnFocus
                         />
                     </Col>
                 </Row>


### PR DESCRIPTION
# Description

- When the inputs in the CSVConfigTaskpane are focussed on, selects all of the text to make it obvious that there is a space in the case that the delimiter Mito detects is a space. This prevents users from updating the delimiter to `[space],` instead of just `,`. 


# Testing

Please provide a list of the ways you can "access" or use the functionality. Please try and be exhaustive here, and make sure that you test everything you list.

- [ ] I have tested this on real data that is reasonable and large
- [ ] If I changed the interaction with JupyterLab, I tested that it does not break other programs (like VS Code), and tested that it works "multiple times" in the same notebook.

# Documentation

Note if any new documentation needs to addressed or reviewed.