### PR TITLE
Break out imports

### DIFF
--- a/.github/workflows/lint-mitosheet-typescript.yml
+++ b/.github/workflows/lint-mitosheet-typescript.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'mitosheet/**'
   pull_request:
-    branches: [ dev ]
     paths:
       - 'mitosheet/**'
 

--- a/.github/workflows/test-mitoinstaller.yml
+++ b/.github/workflows/test-mitoinstaller.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'mitoinstaller/**'
   pull_request:
-    branches: [ dev ]
     paths:
       - 'mitoinstaller/**'
 

--- a/.github/workflows/test-mitosheet-frontend.yml
+++ b/.github/workflows/test-mitosheet-frontend.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'mitosheet/**'
   pull_request:
-    branches: [ dev ]
     paths:
       - 'mitosheet/**'
       - 'tests/**'

--- a/.github/workflows/test-mitosheet-mypy.yml
+++ b/.github/workflows/test-mitosheet-mypy.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'mitosheet/**'
   pull_request:
-    branches: [ dev ]
     paths:
       - 'mitosheet/**'
 

--- a/.github/workflows/test-mitosheet-python.yml
+++ b/.github/workflows/test-mitosheet-python.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'mitosheet/**'
   pull_request:
-    branches: [ dev ]
     paths:
       - 'mitosheet/**'
 

--- a/mitosheet/mitosheet/code_chunks/add_column_set_formula_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/add_column_set_formula_code_chunk.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 
 from copy import copy
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.code_chunks.no_op_code_chunk import NoOpCodeChunk
@@ -35,7 +35,7 @@ class AddColumnSetFormulaCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f'Added column {column_header_to_transpiled_code(self.column_header)}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         column_headers = self.post_state.dfs[self.sheet_index].keys().tolist()
 
         python_code, _, _ = parse_formula(
@@ -50,7 +50,7 @@ class AddColumnSetFormulaCodeChunk(CodeChunk):
         column_header_index = self.column_header_index
         return [
             f'{self.df_name}.insert({column_header_index}, {transpiled_column_header}, {python_code})'
-        ]
+        ], []
 
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]

--- a/mitosheet/mitosheet/code_chunks/code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/code_chunk.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 if TYPE_CHECKING:
     from mitosheet.state import State
@@ -42,7 +42,7 @@ class CodeChunk:
         """Returns a detailed comment explaing what happened in this CodeChunk"""
         raise NotImplementedError('Implement in subclass')
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         """Returns a the list of code strings that this code chunk executes"""
         raise NotImplementedError('Implement in subclass')
 

--- a/mitosheet/mitosheet/code_chunks/delete_row_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/delete_row_code_chunk.py
@@ -5,7 +5,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 from copy import copy
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
 from mitosheet.transpiler.transpile_utils import column_header_list_to_transpiled_code
@@ -25,9 +25,8 @@ class DeleteRowCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f'Deleted {len(self.labels)} row{"" if len(self.labels) == 1 else "s"} in {self.df_name}'
         
-    def get_code(self) -> List[str]:
-        return [f'{self.df_name}.drop(labels={column_header_list_to_transpiled_code(self.labels)}, inplace=True)']
-
+    def get_code(self) -> Tuple[List[str], List[str]]:
+        return [f'{self.df_name}.drop(labels={column_header_list_to_transpiled_code(self.labels)}, inplace=True)'], []
     
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]

--- a/mitosheet/mitosheet/code_chunks/empty_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/empty_code_chunk.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 
 from copy import deepcopy
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
 
@@ -31,8 +31,8 @@ class EmptyCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return self.description_comment
 
-    def get_code(self) -> List[str]:
-        return []
+    def get_code(self) -> Tuple[List[str], List[str]]:
+        return [], []
 
     def combine_right(self, other_code_chunk: CodeChunk) -> Optional[CodeChunk]:
         # We just return the other code chunk, while also updating the prev_state. To avoid

--- a/mitosheet/mitosheet/code_chunks/melt_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/melt_code_chunk.py
@@ -4,7 +4,7 @@
 
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
 from mitosheet.transpiler.transpile_utils import column_header_list_to_transpiled_code
@@ -28,7 +28,7 @@ class MeltCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f"Unpivoted {self.df_name} into {self.new_df_name}"
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         id_vars = self.prev_state.column_ids.get_column_headers_by_ids(self.sheet_index, self.id_var_column_ids)
         value_vars = self.prev_state.column_ids.get_column_headers_by_ids(self.sheet_index, self.value_var_column_ids)
 
@@ -38,7 +38,7 @@ class MeltCodeChunk(CodeChunk):
         if self.include_value_vars:
             param_string += f', value_vars={column_header_list_to_transpiled_code(value_vars)}'
 
-        return [f'{self.new_df_name} = {self.df_name}.melt({param_string})']
+        return [f'{self.new_df_name} = {self.df_name}.melt({param_string})'], []
     
     def get_created_sheet_indexes(self) -> List[int]:
         return [len(self.post_state.dfs) - 1]

--- a/mitosheet/mitosheet/code_chunks/no_op_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/no_op_code_chunk.py
@@ -4,7 +4,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from mitosheet.code_chunks.code_chunk import CodeChunk
 
 
@@ -17,8 +17,8 @@ class NoOpCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return "No comment"
 
-    def get_code(self) -> List[str]:
-        return []
+    def get_code(self) -> Tuple[List[str], List[str]]:
+        return [], []
 
     def combine_right(self, other_code_chunk: CodeChunk) -> Optional[CodeChunk]:
         # The empty code chunk always overwrites itself with the right code chunk

--- a/mitosheet/mitosheet/code_chunks/one_hot_encoding_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/one_hot_encoding_code_chunk.py
@@ -4,7 +4,7 @@
 
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
 from mitosheet.transpiler.transpile_utils import column_header_list_to_transpiled_code, column_header_to_transpiled_code
@@ -25,7 +25,7 @@ class OneHotEncodingCodeChunk(CodeChunk):
         column_header = self.post_state.column_ids.get_column_header_by_id(self.sheet_index, self.column_id)
         return f'One-hot Encoded {column_header}'
         
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         column_header = self.post_state.column_ids.get_column_header_by_id(self.sheet_index, self.column_id)
         df_name = self.post_state.df_names[self.sheet_index]
         column_index = self.post_state.dfs[self.sheet_index].columns.tolist().index(column_header)
@@ -37,10 +37,9 @@ class OneHotEncodingCodeChunk(CodeChunk):
         reorder_columns_line = f'{df_name} = {df_name}[{df_name}.columns[:{column_index + 1}].tolist() + {new_transpiled_column_headers} + {df_name}.columns[{column_index + 1}:-{len(self.new_column_headers)}].tolist()]'
 
         return [
-            'import pandas as pd',
             encode_line,
             reorder_columns_line   
-        ]
+        ], ['import pandas as pd']
 
     
     def get_edited_sheet_indexes(self) -> List[int]:

--- a/mitosheet/mitosheet/code_chunks/postprocessing/set_dataframe_format_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/postprocessing/set_dataframe_format_code_chunk.py
@@ -282,9 +282,6 @@ def get_dataframe_format_code(state: State, sheet_index: int) -> Optional[str]:
         if line is None:
             continue
         dataframe_format_string += f"\\\n{TAB}{line}"
-
-    if 'np.where' in dataframe_format_string:
-        dataframe_format_string = 'import numpy as np\n' + dataframe_format_string
     
     return dataframe_format_string
 
@@ -306,5 +303,6 @@ class SetDataframeFormatCodeChunk(CodeChunk):
             dataframe_format_code = get_dataframe_format_code(self.post_state, sheet_index)
             if dataframe_format_code is not None:
                 code.append(dataframe_format_code)
-        
-        return code, []
+
+        # Make sure to import numpy if we use it
+        return code, ['import numpy as np'] if any([True for format_code in code if 'np.where' in format_code]) else []

--- a/mitosheet/mitosheet/code_chunks/postprocessing/set_dataframe_format_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/postprocessing/set_dataframe_format_code_chunk.py
@@ -300,11 +300,11 @@ class SetDataframeFormatCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f'Formatted dataframes. View these styling objects to see the formatted dataframe'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         code = []
         for sheet_index in range(len(self.post_state.df_formats)):
             dataframe_format_code = get_dataframe_format_code(self.post_state, sheet_index)
             if dataframe_format_code is not None:
                 code.append(dataframe_format_code)
         
-        return code
+        return code, []

--- a/mitosheet/mitosheet/code_chunks/promote_row_to_header_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/promote_row_to_header_code_chunk.py
@@ -4,7 +4,7 @@
 
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
 from mitosheet.transpiler.transpile_utils import column_header_to_transpiled_code
@@ -27,12 +27,12 @@ class PromoteRowToHeaderCodeChunk(CodeChunk):
 
         return f"Promoted row {self.index} to header in {self.df_name}"
         
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         transpiled_index = column_header_to_transpiled_code(self.index)
         return [
             f"{self.df_name}.columns = {self.df_name}.loc[{transpiled_index}]",
             f"{self.df_name}.drop(labels=[{transpiled_index}], inplace=True)",
-        ]
+        ], []
     
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]

--- a/mitosheet/mitosheet/code_chunks/step_performers/bulk_old_rename/bulk_old_rename_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/bulk_old_rename/bulk_old_rename_code_chunk.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 
 import json
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
@@ -24,7 +24,7 @@ class BulkOldRenameCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f'Renamed headers for compatibility with previous Mito versions'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
 
         code = []
         for sheet_index, df_name in enumerate(self.post_state.df_names):
@@ -39,4 +39,4 @@ class BulkOldRenameCodeChunk(CodeChunk):
         if len(code) > 0:
             code.insert(0, '# Rename headers to make them work with Mito')
 
-        return code
+        return code, []

--- a/mitosheet/mitosheet/code_chunks/step_performers/column_steps/add_column_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/column_steps/add_column_code_chunk.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 
 from copy import copy
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from mitosheet.code_chunks.add_column_set_formula_code_chunk import \
     AddColumnSetFormulaCodeChunk
@@ -40,11 +40,11 @@ class AddColumnCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f'Added column {self.column_header}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         transpiled_column_header = column_header_to_transpiled_code(self.column_header)
         return [
             f'{self.df_name}.insert({self.column_header_index}, {transpiled_column_header}, 0)'
-        ]
+        ], []
 
     
     def get_edited_sheet_indexes(self) -> List[int]:

--- a/mitosheet/mitosheet/code_chunks/step_performers/column_steps/change_column_dtype_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/column_steps/change_column_dtype_code_chunk.py
@@ -4,7 +4,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.types import ColumnID
 from mitosheet.state import State
@@ -154,7 +154,7 @@ class ChangeColumnDtypeCodeChunk(CodeChunk):
         column_headers = self.post_state.column_ids.get_column_headers_by_ids(self.sheet_index, self.changed_column_ids)
         return f'Changed {", ".join([str(ch) for ch in column_headers])} to dtype {self.new_dtype}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
 
         # Note: we can't actually group all the headers together in one conversion, and not every dtype can be converted
         # to the target dtype in the same way. Even if they have the same old_dtype, this still might not work in the case
@@ -169,11 +169,8 @@ class ChangeColumnDtypeCodeChunk(CodeChunk):
             if conversion_code is not None:
                 code.append(conversion_code)
         
-        # If we have pandas included, then add pandas to the transpiled code
-        if any('pd.to_datetime' in line for line in code):
-            code.insert(0, 'import pandas as pd')
-
-        return code
+        # If we have pandas included, then add pandas as an import
+        return code, ['import pandas as pd'] if any('pd.to_datetime' in line for line in code) else []
 
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]

--- a/mitosheet/mitosheet/code_chunks/step_performers/column_steps/delete_column_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/column_steps/delete_column_code_chunk.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 
 from copy import copy
-from typing import List, Optional, TYPE_CHECKING, Any, Dict
+from typing import List, Optional, TYPE_CHECKING, Any, Dict, Tuple
 from mitosheet.state import State
 
 from mitosheet.types import ColumnID, ColumnHeader
@@ -38,13 +38,13 @@ class DeleteColumnsCodeChunk(CodeChunk):
         column_headers = self.prev_state.column_ids.get_column_headers_by_ids(self.sheet_index, self.column_ids)
         return f'Deleted columns {", ".join([str(ch) for ch in column_headers])}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
 
         column_headers_list_string = column_header_list_to_transpiled_code(
             [self.prev_state.column_ids.get_column_header_by_id(self.sheet_index, column_id) for column_id in self.column_ids]
         )
 
-        return [f'{self.df_name}.drop({column_headers_list_string}, axis=1, inplace=True)']
+        return [f'{self.df_name}.drop({column_headers_list_string}, axis=1, inplace=True)'], []
 
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]

--- a/mitosheet/mitosheet/code_chunks/step_performers/column_steps/rename_columns_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/column_steps/rename_columns_code_chunk.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 
 from copy import copy
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.code_chunks.step_performers.column_steps.delete_column_code_chunk import DeleteColumnsCodeChunk
@@ -28,7 +28,7 @@ class RenameColumnsCodeChunk(CodeChunk):
         new_column_headers = self.column_ids_to_new_column_headers.values()
         return f'Renamed columns {", ".join(new_column_headers)}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
 
         old_column_header_to_new_column_header_map: Dict[ColumnHeader, ColumnHeader] = dict()
         df_name = self.post_state.df_names[self.sheet_index]
@@ -37,7 +37,7 @@ class RenameColumnsCodeChunk(CodeChunk):
 
         rename_dict = column_header_map_to_string(old_column_header_to_new_column_header_map)
         rename_string = f'{df_name}.rename(columns={rename_dict}, inplace=True)'
-        return [rename_string]
+        return [rename_string], []
 
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]

--- a/mitosheet/mitosheet/code_chunks/step_performers/column_steps/reorder_column_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/column_steps/reorder_column_code_chunk.py
@@ -4,7 +4,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
 from mitosheet.transpiler.transpile_utils import \
@@ -29,7 +29,7 @@ class ReorderColumnCodeChunk(CodeChunk):
         column_header = self.post_state.column_ids.get_column_header_by_id(self.sheet_index, self.column_id)
         return f'Reordered column {column_header}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         from mitosheet.step_performers.column_steps.reorder_column import get_valid_index
 
         column_header = self.prev_state.column_ids.get_column_header_by_id(self.sheet_index, self.column_id)
@@ -46,7 +46,7 @@ class ReorderColumnCodeChunk(CodeChunk):
         # Apply reorder line
         apply_reorder_line = f'{self.df_name} = {self.df_name}[{self.df_name}_columns]'
 
-        return [columns_list_line, insert_line, apply_reorder_line]
+        return [columns_list_line, insert_line, apply_reorder_line], []
 
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]

--- a/mitosheet/mitosheet/code_chunks/step_performers/column_steps/set_column_formula_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/column_steps/set_column_formula_code_chunk.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.code_chunks.code_chunk_utils import get_right_combine_with_column_delete_code_chunk
@@ -32,7 +32,7 @@ class SetColumnFormulaCodeChunk(CodeChunk):
         column_header = self.post_state.column_ids.get_column_header_by_id(self.sheet_index, self.column_id)
         return f'Set formula of {column_header}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         column_header = self.post_state.column_ids.get_column_header_by_id(self.sheet_index, self.column_id)
         python_code, _, _ = parse_formula(
             self.new_formula, 
@@ -43,7 +43,7 @@ class SetColumnFormulaCodeChunk(CodeChunk):
 
         return [
             python_code
-        ]
+        ], []
 
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]

--- a/mitosheet/mitosheet/code_chunks/step_performers/column_steps/split_text_to_columns_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/column_steps/split_text_to_columns_code_chunk.py
@@ -4,7 +4,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.sheet_functions.types.utils import is_datetime_dtype, is_string_dtype, is_timedelta_dtype
 from mitosheet.state import State
@@ -54,7 +54,7 @@ class SplitTextToColumnsCodeChunk(CodeChunk):
         delimiters_string = (', ').join(map(lambda x: f'"{x}"', self.delimiters))
         return f'Split {column_header} on {delimiters_string}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         delimiter_string = repr('|'.join(self.delimiters))
         
         column_header = self.prev_state.column_ids.get_column_header_by_id(self.sheet_index, self.column_id)
@@ -81,7 +81,7 @@ class SplitTextToColumnsCodeChunk(CodeChunk):
         # Reorder columns 
         reorder_columns_line = f'{self.df_name} = {self.df_name}[{self.df_name}.columns[:{column_idx + 1}].tolist() + {new_transpiled_column_headers} + {self.df_name}.columns[{column_idx + 1}:-{len(self.new_column_headers)}].tolist()]'
 
-        return [split_column_line, reorder_columns_line]
+        return [split_column_line, reorder_columns_line], []
 
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]

--- a/mitosheet/mitosheet/code_chunks/step_performers/concat_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/concat_code_chunk.py
@@ -4,7 +4,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
@@ -27,14 +27,14 @@ class ConcatCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f'Concatenated {len(self.sheet_indexes)} into dataframes into {self.new_df_name}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
 
         if len(self.df_names_to_concat) == 0:
-            return [f'{self.new_df_name} = pd.DataFrame()']
+            return [f'{self.new_df_name} = pd.DataFrame()'], ['import pandas as pd']
         else:
             return [
                 f"{self.new_df_name} = pd.concat([{', '.join(self.df_names_to_concat)}], join=\'{self.join}\', ignore_index={self.ignore_index})"
-            ]
+            ], ['import pandas as pd']
 
     def get_created_sheet_indexes(self) -> List[int]:
         return [len(self.post_state.dfs) - 1]

--- a/mitosheet/mitosheet/code_chunks/step_performers/dataframe_steps/dataframe_delete_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/dataframe_steps/dataframe_delete_code_chunk.py
@@ -4,7 +4,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 from copy import copy, deepcopy
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.code_chunks.no_op_code_chunk import NoOpCodeChunk
@@ -24,11 +24,11 @@ class DataframeDeleteCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f'Deleted {", ".join(self.old_dataframe_names)}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         # NOTE: We do not actually delete the dataframes, as it serves no purpose, but 
         # makes things confusing if you're importing dataframes from outside the sheet
         # However, we still use this code chunk as it optimizes out other code chunks
-        return []
+        return [], []
 
     def _combine_right_dataframe_delete(self, other_code_chunk: "DataframeDeleteCodeChunk") -> CodeChunk:
         first_sheet_indexes = deepcopy(self.sheet_indexes)

--- a/mitosheet/mitosheet/code_chunks/step_performers/dataframe_steps/dataframe_duplicate_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/dataframe_steps/dataframe_duplicate_code_chunk.py
@@ -4,7 +4,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
@@ -25,8 +25,8 @@ class DataframeDuplicateCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f'Duplicated {self.old_df_name}'
 
-    def get_code(self) -> List[str]:
-        return [f'{self.new_df_name} = {self.old_df_name}.copy(deep=True)']
+    def get_code(self) -> Tuple[List[str], List[str]]:
+        return [f'{self.new_df_name} = {self.old_df_name}.copy(deep=True)'], []
 
     def get_created_sheet_indexes(self) -> List[int]:
         return [len(self.post_state.dfs) - 1]

--- a/mitosheet/mitosheet/code_chunks/step_performers/dataframe_steps/dataframe_rename_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/dataframe_steps/dataframe_rename_code_chunk.py
@@ -3,7 +3,7 @@
 
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
@@ -23,11 +23,11 @@ class DataframeRenameCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f'Renamed {self.old_dataframe_name} to {self.new_dataframe_name}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         if self.old_dataframe_name == self.new_dataframe_name:
-            return []
+            return [], []
 
-        return [f'{self.post_state.df_names[self.sheet_index]} = {self.old_dataframe_name}']
+        return [f'{self.post_state.df_names[self.sheet_index]} = {self.old_dataframe_name}'], []
 
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]

--- a/mitosheet/mitosheet/code_chunks/step_performers/drop_duplicates_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/drop_duplicates_code_chunk.py
@@ -3,7 +3,7 @@
 
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
 
@@ -27,7 +27,7 @@ class DropDuplicatesCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f'Dropped duplicates in {self.df_name}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         column_headers = [
             self.prev_state.column_ids.get_column_header_by_id(self.sheet_index, column_id)
             for column_id in self.column_ids
@@ -36,7 +36,7 @@ class DropDuplicatesCodeChunk(CodeChunk):
         # If the subset is none, then we don't actually do the drop, as there are no
         # duplicates between 0 columns
         if len(column_headers) == 0:
-            return []
+            return [], []
         
         # We leave subset and keep empty if they are not used
         param_string = ''
@@ -47,7 +47,7 @@ class DropDuplicatesCodeChunk(CodeChunk):
 
         return [
             f'{self.df_name} = {self.df_name}.drop_duplicates({param_string})'
-        ]
+        ], []
     
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]

--- a/mitosheet/mitosheet/code_chunks/step_performers/filter_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/filter_code_chunk.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.sheet_functions.types.utils import is_datetime_dtype
@@ -397,18 +397,18 @@ class FilterCodeChunk(CodeChunk):
         column_header = self.post_state.column_ids.get_column_header_by_id(self.sheet_index, self.column_id)
         return f'Filtered {column_header}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
 
         entire_filter_string = get_entire_filter_string(
             self.post_state, self.sheet_index, self.operator, self.filters, self.column_id
         )
 
         if entire_filter_string is None:
-            return []
+            return [], []
         else:
             return [
                 f"{self.df_name} = {self.df_name}[{entire_filter_string}]",
-            ]
+            ], []
 
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]

--- a/mitosheet/mitosheet/code_chunks/step_performers/import_steps/dataframe_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/import_steps/dataframe_import_code_chunk.py
@@ -4,7 +4,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
 
@@ -27,5 +27,5 @@ class DataframeImportCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return self.description_comment
 
-    def get_code(self) -> List[str]:
-        return []
+    def get_code(self) -> Tuple[List[str], List[str]]:
+        return [], []

--- a/mitosheet/mitosheet/code_chunks/step_performers/import_steps/excel_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/import_steps/excel_import_code_chunk.py
@@ -4,7 +4,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL
@@ -29,7 +29,7 @@ class ExcelImportCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f'Imported {", ".join(self.sheet_names)} from {self.file_name}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         read_excel_params = build_read_excel_params(
             self.sheet_names,
             self.has_headers,
@@ -51,9 +51,8 @@ class ExcelImportCodeChunk(CodeChunk):
             )
 
         return [
-            'import pandas as pd',
             read_excel_line
-        ] + df_definitions
+        ] + df_definitions, ['import pandas as pd']
 
     def get_created_sheet_indexes(self) -> List[int]:
         return [i for i in range(len(self.post_state.dfs) - len(self.sheet_names), len(self.post_state.dfs))]

--- a/mitosheet/mitosheet/code_chunks/step_performers/import_steps/simple_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/import_steps/simple_import_code_chunk.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 import pandas as pd
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
@@ -72,9 +72,9 @@ class SimpleImportCodeChunk(CodeChunk):
         base_names = [os.path.basename(path) for path in self.file_names]
         return f'Imported {", ".join(base_names)}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
 
-        code = ['import pandas as pd']
+        code = []
 
         index = 0
         for file_name, df_name in zip(self.file_names, self.post_state.df_names[len(self.post_state.df_names) - len(self.file_names):]):
@@ -91,7 +91,7 @@ class SimpleImportCodeChunk(CodeChunk):
             
             index += 1
 
-        return code
+        return code, ['import pandas as pd']
 
     def get_created_sheet_indexes(self) -> List[int]:
         return [i for i in range(len(self.post_state.dfs) - len(self.file_names), len(self.post_state.dfs))]

--- a/mitosheet/mitosheet/code_chunks/step_performers/merge_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/merge_code_chunk.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
@@ -40,7 +40,7 @@ class MergeCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f'Merged {self.df_one_name} and {self.df_two_name} into {self.df_new_name}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         merge_keys_one: List[ColumnHeader] = self.prev_state.column_ids.get_column_headers_by_ids(self.sheet_index_one, list(map(lambda x: x[0], self.merge_key_column_ids)))
         merge_keys_two: List[ColumnHeader] = self.prev_state.column_ids.get_column_headers_by_ids(self.sheet_index_two, list(map(lambda x: x[1], self.merge_key_column_ids)))
 
@@ -48,7 +48,7 @@ class MergeCodeChunk(CodeChunk):
         selected_column_headers_two: List[ColumnHeader] = self.prev_state.column_ids.get_column_headers_by_ids(self.sheet_index_two, self.selected_column_ids_two)
 
         if len(merge_keys_one) == 0 and len(merge_keys_two) == 0:
-            return [f'{self.df_new_name} = pd.DataFrame()']
+            return [f'{self.df_new_name} = pd.DataFrame()'], ['import pandas as pd']
 
         # Now, we build the merge code 
         merge_code = []
@@ -111,7 +111,7 @@ class MergeCodeChunk(CodeChunk):
             )
 
         # And then return it
-        return merge_code
+        return merge_code, []
 
     def get_created_sheet_indexes(self) -> List[int]:
         return [len(self.post_state.dfs) - 1]

--- a/mitosheet/mitosheet/code_chunks/step_performers/pivot_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/pivot_code_chunk.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GPL License.
 
 from copy import deepcopy
-from typing import Any, Collection, Dict, List, Optional
+from typing import Any, Collection, Dict, List, Optional, Tuple
 
 import pandas as pd
 
@@ -120,7 +120,7 @@ class PivotCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f'Pivoted {self.old_df_name} into {self.new_df_name}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
     
         # Get just the column headers in a list, for convenience
         pivot_rows = [self.prev_state.column_ids.get_column_header_by_id(self.sheet_index, cit['column_id']) for cit in self.pivot_rows_column_ids_with_transforms]
@@ -146,7 +146,7 @@ class PivotCodeChunk(CodeChunk):
 
         # If there are no keys or values to aggregate on we return an empty dataframe. 
         if len(pivot_rows_with_transforms) == 0 and len(pivot_columns_with_transforms) == 0 or len(values) == 0:
-            return [f'{self.new_df_name} = pd.DataFrame(data={{}})']
+            return [f'{self.new_df_name} = pd.DataFrame(data={{}})'], ['import pandas as pd']
 
         transpiled_code = []
 
@@ -183,7 +183,7 @@ class PivotCodeChunk(CodeChunk):
         # Finially, reset the column name, and the indexes!
         transpiled_code.append(f'{self.new_df_name} = pivot_table.reset_index()')
 
-        return transpiled_code
+        return transpiled_code, [] # TODO: we might actually need pd to be defined!
 
     def _combine_right_with_pivot_code_chunk(self, pivot_code_chunk: "PivotCodeChunk") -> Optional["CodeChunk"]:
         """

--- a/mitosheet/mitosheet/code_chunks/step_performers/pivot_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/pivot_code_chunk.py
@@ -159,11 +159,13 @@ class PivotCodeChunk(CodeChunk):
             full_filter_string = combine_filter_strings('And', filter_strings)
             transpiled_code.append(f'tmp_df = {self.old_df_name}[{full_filter_string}]')
             old_df_name = 'tmp_df' # update the old_df name, for the step below
+        else:
+            old_df_name = self.old_df_name
 
         # Drop any columns we don't need, to avoid issues where pandas freaks out
         # and says there is a non-1-dimensional grouper
         column_headers_list = column_header_list_to_transpiled_code(list(set(pivot_rows + pivot_columns + list(values.keys()))))
-        transpiled_code.append(f'tmp_df = {self.old_df_name}[{column_headers_list}].copy()')
+        transpiled_code.append(f'tmp_df = {old_df_name}[{column_headers_list}].copy()')
 
         # Create any new temporary columns that are formed by the pivot transforms
         transpiled_code = transpiled_code + get_code_for_transform_columns('tmp_df', pivot_rows_with_transforms) + get_code_for_transform_columns('tmp_df', pivot_columns_with_transforms)

--- a/mitosheet/mitosheet/code_chunks/step_performers/set_cell_value_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/set_cell_value_code_chunk.py
@@ -3,7 +3,7 @@
 
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.code_chunks.code_chunk_utils import get_right_combine_with_column_delete_code_chunk
@@ -39,13 +39,13 @@ class SetCellValueCodeChunk(CodeChunk):
         column_header = self.post_state.column_ids.get_column_header_by_id(self.sheet_index, self.column_id)
         return f'Set a cell value in {column_header}'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
 
         code: List[str] = []
 
         # If nothings changed, we don't write any code
         if self.old_value == self.new_value:
-            return code
+            return code, []
 
         column_header = self.post_state.column_ids.get_column_header_by_id(self.sheet_index, self.column_id)
         transpiled_column_header = column_header_to_transpiled_code(column_header)
@@ -66,7 +66,7 @@ class SetCellValueCodeChunk(CodeChunk):
         else:
             code.append(f'{self.df_name}.at[{self.row_index}, {transpiled_column_header}] = \"{self.type_corrected_new_value}\"')
 
-        return code
+        return code, [] # TODO: we might need pandas here as well!
 
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]

--- a/mitosheet/mitosheet/code_chunks/step_performers/sort_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/sort_code_chunk.py
@@ -4,7 +4,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
@@ -28,13 +28,13 @@ class SortCodeChunk(CodeChunk):
         column_header = self.post_state.column_ids.get_column_header_by_id(self.sheet_index, self.column_id)
         return f'Sorted {column_header} in {self.sort_direction} order'
 
-    def get_code(self) -> List[str]:
+    def get_code(self) -> Tuple[List[str], List[str]]:
         from mitosheet.step_performers.sort import SORT_DIRECTION_ASCENDING
 
         # If there is no sort applied in this step, then bail with no code
         from mitosheet.step_performers.sort import SORT_DIRECTION_NONE
         if self.sort_direction == SORT_DIRECTION_NONE:
-            return []
+            return [], []
 
         column_header = self.post_state.column_ids.get_column_header_by_id(self.sheet_index, self.column_id)
         transpiled_column_header = column_header_to_transpiled_code(column_header)
@@ -43,7 +43,7 @@ class SortCodeChunk(CodeChunk):
         
         return [
             f'{self.df_name} = {self.df_name}.sort_values(by={transpiled_column_header}, ascending={self.sort_direction == SORT_DIRECTION_ASCENDING}, na_position=\'{na_position_string}\')', 
-        ]
+        ], []
     
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]

--- a/mitosheet/mitosheet/code_chunks/transpose_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/transpose_code_chunk.py
@@ -4,7 +4,7 @@
 
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.state import State
 from mitosheet.types import ColumnID
@@ -24,8 +24,8 @@ class TransposeCodeChunk(CodeChunk):
     def get_description_comment(self) -> str:
         return f"Transposed {self.df_name} into {self.transposed_df_name}"
 
-    def get_code(self) -> List[str]:
-        return [f'{self.transposed_df_name} = {self.df_name}.T']
+    def get_code(self) -> Tuple[List[str], List[str]]:
+        return [f'{self.transposed_df_name} = {self.df_name}.T'], []
 
     def get_created_sheet_indexes(self) -> List[int]:
         return [len(self.post_state.dfs) - 1]

--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -22571,6 +22571,7 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
     if (code.length == 0) {
       return "";
     }
+    console.log("Code", code);
     let finalCode = "";
     const isCommentLine = (codeLine) => {
       return codeLine.startsWith("#") && codeLine.indexOf("\n") === -1;
@@ -22585,10 +22586,10 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
     }
     if (telemetryEnabled) {
       return `from mitosheet import *; register_analysis("${analysisName}");
-    ${finalCode}`;
+${finalCode}`;
     } else {
       return `from mitosheet import *; # Analysis Name:${analysisName};
-    ${finalCode}`;
+${finalCode}`;
     }
   }
   function getLastNonEmptyLine(codeText) {

--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -22571,7 +22571,6 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
     if (code.length == 0) {
       return "";
     }
-    console.log("Code", code);
     let finalCode = "";
     const isCommentLine = (codeLine) => {
       return codeLine.startsWith("#") && codeLine.indexOf("\n") === -1;

--- a/mitosheet/mitosheet/tests/step_performers/test_set_dataframe_format.py
+++ b/mitosheet/mitosheet/tests/step_performers/test_set_dataframe_format.py
@@ -133,6 +133,9 @@ def test_set_dataframe_format(df_format, included_formatting_code):
                     one_found = True
             assert one_found
         else:
+            if code == 'import numpy as np':
+                assert code in mito.transpiled_code[-2]
+                continue
             assert code in mito.transpiled_code[-1]
 
 
@@ -213,4 +216,7 @@ def test_set_dataframe_format_different_indexes(df_format, included_formatting_c
                     one_found = True
             assert one_found
         else:
+            if code == 'import numpy as np':
+                assert code in mito.transpiled_code[-2]
+                continue
             assert code in mito.transpiled_code[-1]

--- a/mitosheet/mitosheet/tests/test_transpile.py
+++ b/mitosheet/mitosheet/tests/test_transpile.py
@@ -229,3 +229,19 @@ def test_transpile_merge_then_sort():
         'df3 = df1.merge(temp_df, left_on=[\'Name\'], right_on=[\'Name\'], how=\'left\', suffixes=[\'_df1\', \'_df2\'])',
         'df3 = df3.sort_values(by=\'Number\', ascending=True, na_position=\'first\')',
     ]
+
+def test_transpile_multiple_pandas_imports_combined(tmp_path):
+    tmp_file = str(tmp_path / 'txt.csv')
+    df1 = pd.DataFrame(data={'Name': ["Aaron", "Nate"], 'Number': [123, 1]})
+    df1.to_csv(tmp_file, index=False)
+    mito = create_mito_wrapper_dfs(df1)
+    mito.simple_import([tmp_file])
+    mito.add_column(0, 'A', -1)
+    mito.simple_import([tmp_file])
+    mito.add_column(1, 'A', -1)
+    mito.simple_import([tmp_file])
+
+    assert len(mito.optimized_code_chunks) == 5
+    assert 'import pandas as pd' in mito.transpiled_code
+    assert len([c for c in mito.transpiled_code if c == 'import pandas as pd']) == 1
+

--- a/mitosheet/mitosheet/tests/test_utils.py
+++ b/mitosheet/mitosheet/tests/test_utils.py
@@ -91,6 +91,7 @@ def check_dataframes_equal(test_wrapper):
         print(get_recent_traceback())
         print("\nCode:")
         print(code)
+        raise
 
     # We then check that the sheet data json that is saved by the widget, which 
     # notably uses caching, does not get incorrectly cached and is written correctly

--- a/mitosheet/mitosheet/transpiler/transpile.py
+++ b/mitosheet/mitosheet/transpiler/transpile.py
@@ -9,6 +9,7 @@ container and generates transpiled Python code.
 """
 
 from typing import Any, Dict, List
+from mitosheet.array_utils import deduplicate_array
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.code_chunks.code_chunk_utils import get_code_chunks
 from mitosheet.code_chunks.postprocessing import POSTPROCESSING_CODE_CHUNKS
@@ -32,6 +33,7 @@ def transpile(
     describe functions. 
     """
 
+    imports_code = []
     code = []
 
     # First, we transpile all the preprocessing steps
@@ -53,7 +55,7 @@ def transpile(
 
     for code_chunk in all_code_chunks:
         comment = '# ' + code_chunk.get_description_comment()
-        gotten_code = code_chunk.get_code()
+        (gotten_code, code_chunk_imports) = code_chunk.get_code()
 
         # Make sure to not generate comments or code for steps with no code 
         if len(gotten_code) > 0:
@@ -61,9 +63,15 @@ def transpile(
                 gotten_code.insert(0, comment)
             code.extend(gotten_code)
 
+        imports_code.extend(code_chunk_imports)
+
     # If we have a historical step checked out, then we add a comment letting
     # the user know this is the case
     if steps_manager.curr_step_idx != len(steps_manager.steps_including_skipped) - 1:
         code.append(IN_PREVIOUS_STEP_COMMENT)
 
-    return code
+    # We then deduplicate the imports, keeping the same order as originally. We then 
+    # put them at the start of the code!
+    final_imports_code = deduplicate_array(imports_code)
+
+    return final_imports_code + code

--- a/mitosheet/src/utils/code.tsx
+++ b/mitosheet/src/utils/code.tsx
@@ -10,8 +10,6 @@ export function getCodeString(
         return '';
     }
 
-    console.log("Code", code);
-
     let finalCode = '';
 
     // When joining code, we do not add blank line between comments

--- a/mitosheet/src/utils/code.tsx
+++ b/mitosheet/src/utils/code.tsx
@@ -10,6 +10,8 @@ export function getCodeString(
         return '';
     }
 
+    console.log("Code", code);
+
     let finalCode = '';
 
     // When joining code, we do not add blank line between comments
@@ -33,10 +35,10 @@ export function getCodeString(
     // simply not calling a func w/ the analysis name
     if (telemetryEnabled) {
         return `from mitosheet import *; register_analysis("${analysisName}");
-    ${finalCode}`
+${finalCode}`
     } else {
         return `from mitosheet import *; # Analysis Name:${analysisName};
-    ${finalCode}`
+${finalCode}`
     }
 }
 


### PR DESCRIPTION
# Description

This PR breaks out imports, and deduplicates them. This is a very low-hanging bar (it was quite easy) to great effect -- scripts def feel much nicer now when you are importing multiple things!

We can iterate on this to improve how we're polluting the global namespace (which would be super worthwhile). See here: https://github.com/mito-ds/monorepo/issues/582

# Testing

Generate some code!

# Documentation

Nope.