### PR TITLE
mitosheet: add env for turning off tours

### DIFF
--- a/mitosheet/mitosheet/enterprise/mito_config.py
+++ b/mitosheet/mitosheet/enterprise/mito_config.py
@@ -16,6 +16,7 @@ MITO_CONFIG_SUPPORT_EMAIL = 'MITO_CONFIG_SUPPORT_EMAIL'
 MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL = 'MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL' 
 MITO_CONFIG_CODE_SNIPPETS_VERSION  = 'MITO_CONFIG_CODE_SNIPPETS_VERSION' 
 MITO_CONFIG_CODE_SNIPPETS_URL = 'MITO_CONFIG_CODE_SNIPPETS_URL'
+MITO_CONFIG_DISPLAY_TOURS = 'MITO_CONFIG_DISPLAY_TOURS'
 
 # Note: The below keys can change since they are not set by the user.
 MITO_CONFIG_CODE_SNIPPETS = 'MITO_CONFIG_CODE_SNIPPETS'
@@ -39,7 +40,8 @@ def upgrade_mec_1_to_2(mec: Dict[str, Any]) -> Dict[str, Any]:
         'MITO_CONFIG_SUPPORT_EMAIL': 'support@mito.com',
         'MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL': None,
         'MITO_CONFIG_CODE_SNIPPETS_VERSION': None,
-        'MITO_CONFIG_CODE_SNIPPETS_URL': None
+        'MITO_CONFIG_CODE_SNIPPETS_URL': None,
+        'MITO_CONFIG_DISPLAY_TOURS': None
     }
     """
     return {
@@ -47,7 +49,8 @@ def upgrade_mec_1_to_2(mec: Dict[str, Any]) -> Dict[str, Any]:
         MITO_CONFIG_SUPPORT_EMAIL: mec[MITO_CONFIG_SUPPORT_EMAIL],
         MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL: None,
         MITO_CONFIG_CODE_SNIPPETS_VERSION: None,
-        MITO_CONFIG_CODE_SNIPPETS_URL: None
+        MITO_CONFIG_CODE_SNIPPETS_URL: None,
+        MITO_CONFIG_DISPLAY_TOURS: None
     }
 
 """
@@ -86,7 +89,8 @@ MEC_VERSION_KEYS = {
         MITO_CONFIG_SUPPORT_EMAIL, 
         MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL, 
         MITO_CONFIG_CODE_SNIPPETS_VERSION,
-        MITO_CONFIG_CODE_SNIPPETS_URL
+        MITO_CONFIG_CODE_SNIPPETS_URL, 
+        MITO_CONFIG_DISPLAY_TOURS
     ]
 }
 
@@ -130,6 +134,11 @@ class MitoConfig:
         if self.mec is None or self.mec[MITO_CONFIG_SUPPORT_EMAIL] is None:
             return DEFAULT_MITO_CONFIG_SUPPORT_EMAIL
         return self.mec[MITO_CONFIG_SUPPORT_EMAIL]
+
+    def get_display_tours(self) -> bool:
+        if self.mec is None or self.mec[MITO_CONFIG_DISPLAY_TOURS] is None:
+            return True
+        return False if self.mec[MITO_CONFIG_DISPLAY_TOURS] == 'False' else True
 
     def _get_code_snippets_version(self) -> Optional[str]:
         if self.mec is None or self.mec[MITO_CONFIG_CODE_SNIPPETS_VERSION] is None:
@@ -179,6 +188,7 @@ class MitoConfig:
         return {
             MITO_CONFIG_VERSION: self.get_version(),
             MITO_CONFIG_SUPPORT_EMAIL: self.get_support_email(),
+            MITO_CONFIG_DISPLAY_TOURS: self.get_display_tours(),
             MITO_CONFIG_CODE_SNIPPETS: self.get_code_snippets()
         }
 

--- a/mitosheet/mitosheet/enterprise/mito_config.py
+++ b/mitosheet/mitosheet/enterprise/mito_config.py
@@ -144,7 +144,6 @@ class MitoConfig:
             return False
 
         disable_tours = is_env_variable_set_to_true(self.mec[MITO_CONFIG_DISABLE_TOURS])
-        print(disable_tours)
         return True if disable_tours else False
 
     def _get_code_snippets_version(self) -> Optional[str]:

--- a/mitosheet/mitosheet/enterprise/mito_config.py
+++ b/mitosheet/mitosheet/enterprise/mito_config.py
@@ -4,7 +4,7 @@
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the The Mito Enterprise license.
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 import os
 from mitosheet.telemetry.telemetry_utils import log
 from mitosheet.types import CodeSnippetEnvVars
@@ -16,7 +16,7 @@ MITO_CONFIG_SUPPORT_EMAIL = 'MITO_CONFIG_SUPPORT_EMAIL'
 MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL = 'MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL' 
 MITO_CONFIG_CODE_SNIPPETS_VERSION  = 'MITO_CONFIG_CODE_SNIPPETS_VERSION' 
 MITO_CONFIG_CODE_SNIPPETS_URL = 'MITO_CONFIG_CODE_SNIPPETS_URL'
-MITO_CONFIG_DISPLAY_TOURS = 'MITO_CONFIG_DISPLAY_TOURS'
+MITO_CONFIG_DISABLE_TOURS = 'MITO_CONFIG_DISABLE_TOURS'
 
 # Note: The below keys can change since they are not set by the user.
 MITO_CONFIG_CODE_SNIPPETS = 'MITO_CONFIG_CODE_SNIPPETS'
@@ -41,7 +41,7 @@ def upgrade_mec_1_to_2(mec: Dict[str, Any]) -> Dict[str, Any]:
         'MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL': None,
         'MITO_CONFIG_CODE_SNIPPETS_VERSION': None,
         'MITO_CONFIG_CODE_SNIPPETS_URL': None,
-        'MITO_CONFIG_DISPLAY_TOURS': None
+        'MITO_CONFIG_DISABLE_TOURS': None
     }
     """
     return {
@@ -50,7 +50,7 @@ def upgrade_mec_1_to_2(mec: Dict[str, Any]) -> Dict[str, Any]:
         MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL: None,
         MITO_CONFIG_CODE_SNIPPETS_VERSION: None,
         MITO_CONFIG_CODE_SNIPPETS_URL: None,
-        MITO_CONFIG_DISPLAY_TOURS: None
+        MITO_CONFIG_DISABLE_TOURS: None
     }
 
 """
@@ -79,6 +79,10 @@ def upgrade_mito_enterprise_configuration(mec: Optional[Dict[str, Any]]) -> Opti
 
     return _mec
 
+def is_env_variable_set_to_true(env_variable: Union[str, int, bool]) -> bool: 
+    truth_values = ['True', 'true', True, 1, '1', 't', 'T']
+    return env_variable in truth_values
+
 # Since Mito needs to look up individual environment variables, we need to 
 # know the names of the variables associated with each mito config version. 
 # To do so we store them as a list here. 
@@ -90,7 +94,7 @@ MEC_VERSION_KEYS = {
         MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL, 
         MITO_CONFIG_CODE_SNIPPETS_VERSION,
         MITO_CONFIG_CODE_SNIPPETS_URL, 
-        MITO_CONFIG_DISPLAY_TOURS
+        MITO_CONFIG_DISABLE_TOURS
     ]
 }
 
@@ -135,10 +139,13 @@ class MitoConfig:
             return DEFAULT_MITO_CONFIG_SUPPORT_EMAIL
         return self.mec[MITO_CONFIG_SUPPORT_EMAIL]
 
-    def get_display_tours(self) -> bool:
-        if self.mec is None or self.mec[MITO_CONFIG_DISPLAY_TOURS] is None:
-            return True
-        return False if self.mec[MITO_CONFIG_DISPLAY_TOURS] == 'False' else True
+    def get_disable_tours(self) -> bool:
+        if self.mec is None or self.mec[MITO_CONFIG_DISABLE_TOURS] is None:
+            return False
+
+        disable_tours = is_env_variable_set_to_true(self.mec[MITO_CONFIG_DISABLE_TOURS])
+        print(disable_tours)
+        return True if disable_tours else False
 
     def _get_code_snippets_version(self) -> Optional[str]:
         if self.mec is None or self.mec[MITO_CONFIG_CODE_SNIPPETS_VERSION] is None:
@@ -188,7 +195,7 @@ class MitoConfig:
         return {
             MITO_CONFIG_VERSION: self.get_version(),
             MITO_CONFIG_SUPPORT_EMAIL: self.get_support_email(),
-            MITO_CONFIG_DISPLAY_TOURS: self.get_display_tours(),
+            MITO_CONFIG_DISABLE_TOURS: self.get_disable_tours(),
             MITO_CONFIG_CODE_SNIPPETS: self.get_code_snippets()
         }
 

--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -40588,7 +40588,7 @@ fig.write_html("${props.graphTabName}.html")`
       if (analysisData2.dataTypeInTool === "none" /* NONE */ || analysisData2.dataTypeInTool === "tutorial" /* TUTORIAL */) {
         return /* @__PURE__ */ import_react215.default.createElement(import_react215.default.Fragment, null);
       }
-      if (!userProfile2.mitoConfig.MITO_CONFIG_DISPLAY_TOURS) {
+      if (userProfile2.mitoConfig.MITO_CONFIG_DISABLE_TOURS) {
         return /* @__PURE__ */ import_react215.default.createElement(import_react215.default.Fragment, null);
       }
       const toursToDisplay = [];

--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -40588,6 +40588,9 @@ fig.write_html("${props.graphTabName}.html")`
       if (analysisData2.dataTypeInTool === "none" /* NONE */ || analysisData2.dataTypeInTool === "tutorial" /* TUTORIAL */) {
         return /* @__PURE__ */ import_react215.default.createElement(import_react215.default.Fragment, null);
       }
+      if (!userProfile2.mitoConfig.MITO_CONFIG_DISPLAY_TOURS) {
+        return /* @__PURE__ */ import_react215.default.createElement(import_react215.default.Fragment, null);
+      }
       const toursToDisplay = [];
       if (!userProfile2.receivedTours.includes("Intro" /* INTRO */)) {
         toursToDisplay.push("Intro" /* INTRO */);

--- a/mitosheet/mitosheet/tests/test_mito_config.py
+++ b/mitosheet/mitosheet/tests/test_mito_config.py
@@ -13,7 +13,7 @@ from mitosheet.enterprise.mito_config import (
     MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL, 
     MITO_CONFIG_CODE_SNIPPETS_URL, 
     MITO_CONFIG_CODE_SNIPPETS_VERSION,
-    MITO_CONFIG_DISPLAY_TOURS, 
+    MITO_CONFIG_DISABLE_TOURS, 
     MITO_CONFIG_SUPPORT_EMAIL, 
     MITO_CONFIG_VERSION, 
     MITO_CONFIG_SUPPORT_EMAIL, 
@@ -54,7 +54,7 @@ def test_none_works():
     assert mito_config_dict == {
         MITO_CONFIG_VERSION: '2',
         MITO_CONFIG_SUPPORT_EMAIL: DEFAULT_MITO_CONFIG_SUPPORT_EMAIL,
-        MITO_CONFIG_DISPLAY_TOURS: True,
+        MITO_CONFIG_DISABLE_TOURS: False,
         MITO_CONFIG_CODE_SNIPPETS: None
     }
 
@@ -72,7 +72,7 @@ def test_version_2_works():
     os.environ[MITO_CONFIG_SUPPORT_EMAIL] = "aaron@sagacollab.com"
     os.environ[MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL] = "jake@sagacollab.com"
     os.environ[MITO_CONFIG_CODE_SNIPPETS_URL] = "url"
-    os.environ[MITO_CONFIG_DISPLAY_TOURS] = "False"
+    os.environ[MITO_CONFIG_DISABLE_TOURS] = "True"
     os.environ[MITO_CONFIG_CODE_SNIPPETS_VERSION] = "1"
 
     # Test reading environment variables works properly
@@ -80,7 +80,7 @@ def test_version_2_works():
     assert mito_config.get_mito_config() == {
         MITO_CONFIG_VERSION: '2',
         MITO_CONFIG_SUPPORT_EMAIL: 'aaron@sagacollab.com',
-        MITO_CONFIG_DISPLAY_TOURS: False,
+        MITO_CONFIG_DISABLE_TOURS: True,
         MITO_CONFIG_CODE_SNIPPETS: {
             MITO_CONFIG_CODE_SNIPPETS_VERSION : '1',
             MITO_CONFIG_CODE_SNIPPETS_URL: 'url',
@@ -101,7 +101,7 @@ def test_mito_config_update_version_1_to_2():
     assert mito_config.get_mito_config() == {
         MITO_CONFIG_VERSION: '2',
         MITO_CONFIG_SUPPORT_EMAIL: 'aaron@sagacollab.com',
-        MITO_CONFIG_DISPLAY_TOURS: True,
+        MITO_CONFIG_DISABLE_TOURS: False,
         MITO_CONFIG_CODE_SNIPPETS: None
     }    
 

--- a/mitosheet/mitosheet/tests/test_mito_config.py
+++ b/mitosheet/mitosheet/tests/test_mito_config.py
@@ -12,7 +12,8 @@ from mitosheet.enterprise.mito_config import (
     MITO_CONFIG_CODE_SNIPPETS, 
     MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL, 
     MITO_CONFIG_CODE_SNIPPETS_URL, 
-    MITO_CONFIG_CODE_SNIPPETS_VERSION, 
+    MITO_CONFIG_CODE_SNIPPETS_VERSION,
+    MITO_CONFIG_DISPLAY_TOURS, 
     MITO_CONFIG_SUPPORT_EMAIL, 
     MITO_CONFIG_VERSION, 
     MITO_CONFIG_SUPPORT_EMAIL, 
@@ -53,6 +54,7 @@ def test_none_works():
     assert mito_config_dict == {
         MITO_CONFIG_VERSION: '2',
         MITO_CONFIG_SUPPORT_EMAIL: DEFAULT_MITO_CONFIG_SUPPORT_EMAIL,
+        MITO_CONFIG_DISPLAY_TOURS: True,
         MITO_CONFIG_CODE_SNIPPETS: None
     }
 
@@ -70,6 +72,7 @@ def test_version_2_works():
     os.environ[MITO_CONFIG_SUPPORT_EMAIL] = "aaron@sagacollab.com"
     os.environ[MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL] = "jake@sagacollab.com"
     os.environ[MITO_CONFIG_CODE_SNIPPETS_URL] = "url"
+    os.environ[MITO_CONFIG_DISPLAY_TOURS] = "False"
     os.environ[MITO_CONFIG_CODE_SNIPPETS_VERSION] = "1"
 
     # Test reading environment variables works properly
@@ -77,6 +80,7 @@ def test_version_2_works():
     assert mito_config.get_mito_config() == {
         MITO_CONFIG_VERSION: '2',
         MITO_CONFIG_SUPPORT_EMAIL: 'aaron@sagacollab.com',
+        MITO_CONFIG_DISPLAY_TOURS: False,
         MITO_CONFIG_CODE_SNIPPETS: {
             MITO_CONFIG_CODE_SNIPPETS_VERSION : '1',
             MITO_CONFIG_CODE_SNIPPETS_URL: 'url',
@@ -97,6 +101,7 @@ def test_mito_config_update_version_1_to_2():
     assert mito_config.get_mito_config() == {
         MITO_CONFIG_VERSION: '2',
         MITO_CONFIG_SUPPORT_EMAIL: 'aaron@sagacollab.com',
+        MITO_CONFIG_DISPLAY_TOURS: True,
         MITO_CONFIG_CODE_SNIPPETS: None
     }    
 

--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -786,7 +786,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
         }
 
         // If the user has turned off tours via the enviornment variable, don't display the tour
-        if (!userProfile.mitoConfig.MITO_CONFIG_DISPLAY_TOURS) {
+        if (userProfile.mitoConfig.MITO_CONFIG_DISABLE_TOURS) {
             return <></>;
         }
 

--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -785,6 +785,11 @@ export const Mito = (props: MitoProps): JSX.Element => {
             return <></>;
         }
 
+        // If the user has turned off tours via the enviornment variable, don't display the tour
+        if (!userProfile.mitoConfig.MITO_CONFIG_DISPLAY_TOURS) {
+            return <></>;
+        }
+
         const toursToDisplay: TourName[] = []
 
         // We display the INTRO to users if they have not received it

--- a/mitosheet/src/types.tsx
+++ b/mitosheet/src/types.tsx
@@ -661,6 +661,7 @@ export enum MitoEnterpriseConfigKey {
     CODE_SNIPPETS_SUPPORT_EMAIL = 'MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL',
     CODE_SNIPPETS_VERSION = 'MITO_CONFIG_CODE_SNIPPETS_VERSION',
     CODE_SNIPPETS_URL = 'MITO_CONFIG_CODE_SNIPPETS_URL',
+    DISPLAY_TOURS = 'MITO_CONFIG_DISPLAY_TOURS'
 }
 
 
@@ -732,11 +733,13 @@ export interface UserProfile {
     mitoConfig: {
         [MitoEnterpriseConfigKey.MEC_VERSION]: number | undefined | null
         [MitoEnterpriseConfigKey.SUPPORT_EMAIL]: string
+        [MitoEnterpriseConfigKey.DISPLAY_TOURS]: boolean,
         [MitoEnterpriseConfigKey.CODE_SNIPPETS]: {
             [MitoEnterpriseConfigKey.CODE_SNIPPETS_VERSION]: string,
             [MitoEnterpriseConfigKey.CODE_SNIPPETS_URL]: string
             [MitoEnterpriseConfigKey.CODE_SNIPPETS_SUPPORT_EMAIL]: string | undefined | null
         } | null | undefined
+
     };
 }
 

--- a/mitosheet/src/types.tsx
+++ b/mitosheet/src/types.tsx
@@ -661,7 +661,7 @@ export enum MitoEnterpriseConfigKey {
     CODE_SNIPPETS_SUPPORT_EMAIL = 'MITO_CONFIG_CODE_SNIPPETS_SUPPORT_EMAIL',
     CODE_SNIPPETS_VERSION = 'MITO_CONFIG_CODE_SNIPPETS_VERSION',
     CODE_SNIPPETS_URL = 'MITO_CONFIG_CODE_SNIPPETS_URL',
-    DISPLAY_TOURS = 'MITO_CONFIG_DISPLAY_TOURS'
+    DISABLE_TOURS = 'MITO_CONFIG_DISABLE_TOURS'
 }
 
 
@@ -733,7 +733,7 @@ export interface UserProfile {
     mitoConfig: {
         [MitoEnterpriseConfigKey.MEC_VERSION]: number | undefined | null
         [MitoEnterpriseConfigKey.SUPPORT_EMAIL]: string
-        [MitoEnterpriseConfigKey.DISPLAY_TOURS]: boolean,
+        [MitoEnterpriseConfigKey.DISABLE_TOURS]: boolean,
         [MitoEnterpriseConfigKey.CODE_SNIPPETS]: {
             [MitoEnterpriseConfigKey.CODE_SNIPPETS_VERSION]: string,
             [MitoEnterpriseConfigKey.CODE_SNIPPETS_URL]: string


### PR DESCRIPTION
# Description

Adds an environment variable for turning off tours. Helpful for enterprise customers who run trainings and find the tour distracting during those sessions. 

Note: I did not update the Mito Config Version since we handle the default case where the Display Tours key is not set and nothing else changed. There's no benefit.  

# Testing

Set these environment variables and make sure that the intro and spreadsheet formula tours do not appear.
```
import os
os.environ['MITO_CONFIG_DISABLE_TOURS'] = 'True'
os.environ['MITO_CONFIG_VERSION'] = '2'
```

# Documentation

Note if any new documentation needs to addressed or reviewed.