### PR TITLE
Add a hint that a file is password protected to stop confusion

### DIFF
--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -27847,13 +27847,13 @@ ${finalCode}`;
   var import_react59 = __toESM(require_react());
   var MAX_DISPLAYED = 1e4;
   var MultiToggleBoxMessage = (props) => {
-    const emptyMessage = props._emptyMessage !== void 0 ? props._emptyMessage : "No items to display.";
+    const _emptyMessage = props.emptyMessage !== void 0 ? props.emptyMessage : "No items to display.";
     if (props.loading) {
       return /* @__PURE__ */ import_react59.default.createElement(Row_default, { justify: "center" }, /* @__PURE__ */ import_react59.default.createElement("p", { className: "text-body-1 text-align-center-important" }, "Loading items", /* @__PURE__ */ import_react59.default.createElement(LoadingDots_default, null)));
     } else if (props.maxDisplayed || props.isSubset) {
       return /* @__PURE__ */ import_react59.default.createElement(Row_default, { justify: "center" }, /* @__PURE__ */ import_react59.default.createElement("p", { className: "text-body-1 text-align-center-important" }, "There are too many items to display. Search to filter down to the items you care about."));
     } else if (props.numDisplayed === 0) {
-      return /* @__PURE__ */ import_react59.default.createElement(Row_default, { justify: "center" }, /* @__PURE__ */ import_react59.default.createElement("p", { className: "text-body-1 text-align-center-important" }, emptyMessage));
+      return /* @__PURE__ */ import_react59.default.createElement(Row_default, { justify: "center" }, /* @__PURE__ */ import_react59.default.createElement("p", { className: "text-body-1 text-align-center-important" }, _emptyMessage));
     } else if (props.message !== void 0) {
       return /* @__PURE__ */ import_react59.default.createElement(Row_default, { justify: "center" }, /* @__PURE__ */ import_react59.default.createElement("p", { className: "text-body-1 text-align-center-important" }, props.message));
     }
@@ -27945,7 +27945,7 @@ ${finalCode}`;
           loading: props.loading,
           isSubset: props.isSubset,
           message: props.message,
-          _emptyMessage: props.emptyMessage,
+          emptyMessage: props.emptyMessage,
           maxDisplayed,
           numDisplayed
         }

--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -27847,14 +27847,15 @@ ${finalCode}`;
   var import_react59 = __toESM(require_react());
   var MAX_DISPLAYED = 1e4;
   var MultiToggleBoxMessage = (props) => {
+    const emptyMessage = props._emptyMessage !== void 0 ? props._emptyMessage : "No items to display.";
     if (props.loading) {
-      return /* @__PURE__ */ import_react59.default.createElement(Row_default, { justify: "center" }, /* @__PURE__ */ import_react59.default.createElement("p", { className: "text-body-1 text-align-center" }, "Loading items", /* @__PURE__ */ import_react59.default.createElement(LoadingDots_default, null)));
+      return /* @__PURE__ */ import_react59.default.createElement(Row_default, { justify: "center" }, /* @__PURE__ */ import_react59.default.createElement("p", { className: "text-body-1 text-align-center-important" }, "Loading items", /* @__PURE__ */ import_react59.default.createElement(LoadingDots_default, null)));
     } else if (props.maxDisplayed || props.isSubset) {
-      return /* @__PURE__ */ import_react59.default.createElement(Row_default, { justify: "center" }, /* @__PURE__ */ import_react59.default.createElement("p", { className: "text-body-1 text-align-center" }, "There are too many items to display. Search to filter down to the items you care about."));
+      return /* @__PURE__ */ import_react59.default.createElement(Row_default, { justify: "center" }, /* @__PURE__ */ import_react59.default.createElement("p", { className: "text-body-1 text-align-center-important" }, "There are too many items to display. Search to filter down to the items you care about."));
     } else if (props.numDisplayed === 0) {
-      return /* @__PURE__ */ import_react59.default.createElement(Row_default, { justify: "center" }, /* @__PURE__ */ import_react59.default.createElement("p", { className: "text-body-1" }, "No items to display."));
+      return /* @__PURE__ */ import_react59.default.createElement(Row_default, { justify: "center" }, /* @__PURE__ */ import_react59.default.createElement("p", { className: "text-body-1 text-align-center-important" }, emptyMessage));
     } else if (props.message !== void 0) {
-      return /* @__PURE__ */ import_react59.default.createElement(Row_default, { justify: "center" }, /* @__PURE__ */ import_react59.default.createElement("p", { className: "text-body-1 text-align-center" }, props.message));
+      return /* @__PURE__ */ import_react59.default.createElement(Row_default, { justify: "center" }, /* @__PURE__ */ import_react59.default.createElement("p", { className: "text-body-1 text-align-center-important" }, props.message));
     }
     return /* @__PURE__ */ import_react59.default.createElement(import_react59.default.Fragment, null);
   };
@@ -27944,6 +27945,7 @@ ${finalCode}`;
           loading: props.loading,
           isSubset: props.isSubset,
           message: props.message,
+          _emptyMessage: props.emptyMessage,
           maxDisplayed,
           numDisplayed
         }
@@ -34688,6 +34690,7 @@ ${finalCode}`;
         loading,
         searchable: true,
         height: "medium",
+        emptyMessage: "There are no sheets to choose from. Either the workbook is empty or password protected.",
         toggleAllIndexes: (indexesToToggle) => {
           props.setParams((prevParams) => {
             const newSheetNames = [...prevParams.sheet_names];

--- a/mitosheet/src/components/elements/MultiToggleBox.tsx
+++ b/mitosheet/src/components/elements/MultiToggleBox.tsx
@@ -18,8 +18,8 @@ import { Height, Width } from './sizes.d';
 const MAX_DISPLAYED = 10000;
 
 
-const MultiToggleBoxMessage = (props: {loading?: boolean, maxDisplayed: boolean, numDisplayed: number, isSubset?: boolean, _emptyMessage?: string, message?: string;}): JSX.Element => {
-    const emptyMessage = props._emptyMessage !== undefined ? props. _emptyMessage : "No items to display."
+const MultiToggleBoxMessage = (props: {loading?: boolean, maxDisplayed: boolean, numDisplayed: number, isSubset?: boolean, emptyMessage?: string, message?: string;}): JSX.Element => {
+    const _emptyMessage = props.emptyMessage !== undefined ? props. emptyMessage : "No items to display."
     if (props.loading) {
         return (
             <Row justify='center'>
@@ -40,7 +40,7 @@ const MultiToggleBoxMessage = (props: {loading?: boolean, maxDisplayed: boolean,
         return (
             <Row justify='center'>
                 <p className='text-body-1 text-align-center-important'> 
-                    {emptyMessage}
+                    {_emptyMessage}
                 </p>
             </Row>
         )
@@ -248,7 +248,7 @@ const MultiToggleBox = (props: {
                     loading={props.loading}
                     isSubset={props.isSubset}
                     message={props.message}
-                    _emptyMessage={props.emptyMessage}
+                    emptyMessage={props.emptyMessage}
                     maxDisplayed={maxDisplayed}
                     numDisplayed={numDisplayed}
                 />}

--- a/mitosheet/src/components/elements/MultiToggleBox.tsx
+++ b/mitosheet/src/components/elements/MultiToggleBox.tsx
@@ -18,11 +18,12 @@ import { Height, Width } from './sizes.d';
 const MAX_DISPLAYED = 10000;
 
 
-const MultiToggleBoxMessage = (props: {loading?: boolean, maxDisplayed: boolean, numDisplayed: number, isSubset?: boolean, message?: string;}): JSX.Element => {
+const MultiToggleBoxMessage = (props: {loading?: boolean, maxDisplayed: boolean, numDisplayed: number, isSubset?: boolean, _emptyMessage?: string, message?: string;}): JSX.Element => {
+    const emptyMessage = props._emptyMessage !== undefined ? props. _emptyMessage : "No items to display."
     if (props.loading) {
         return (
             <Row justify='center'>
-                <p className='text-body-1 text-align-center'> 
+                <p className='text-body-1 text-align-center-important'> 
                     Loading items<LoadingDots/>
                 </p>
             </Row>
@@ -30,7 +31,7 @@ const MultiToggleBoxMessage = (props: {loading?: boolean, maxDisplayed: boolean,
     } else if (props.maxDisplayed || props.isSubset) {
         return (
             <Row justify='center'>
-                <p className='text-body-1 text-align-center'> 
+                <p className='text-body-1 text-align-center-important'> 
                     There are too many items to display. Search to filter down to the items you care about.
                 </p>
             </Row>
@@ -38,15 +39,15 @@ const MultiToggleBoxMessage = (props: {loading?: boolean, maxDisplayed: boolean,
     } else if (props.numDisplayed === 0) {
         return (
             <Row justify='center'>
-                <p className='text-body-1'> 
-                    No items to display.
+                <p className='text-body-1 text-align-center-important'> 
+                    {emptyMessage}
                 </p>
             </Row>
         )
     } else if (props.message !== undefined) {
         return (
             <Row justify='center'>
-                <p className='text-body-1 text-align-center'> 
+                <p className='text-body-1 text-align-center-important'> 
                     {props.message}
                 </p>
             </Row>
@@ -129,6 +130,11 @@ const MultiToggleBox = (props: {
         * message at the top of the box
     */
     message?: string;
+
+    /** 
+        * @param [emptyMessage] - Display this message if there are no items in the MultiToggleBox.
+    */
+    emptyMessage?: string;
 
     /** 
         * @param [disabled] - Optionally make none of the buttons clickable here
@@ -242,6 +248,7 @@ const MultiToggleBox = (props: {
                     loading={props.loading}
                     isSubset={props.isSubset}
                     message={props.message}
+                    _emptyMessage={props.emptyMessage}
                     maxDisplayed={maxDisplayed}
                     numDisplayed={numDisplayed}
                 />}

--- a/mitosheet/src/components/import/XLSXImportConfigScreen.tsx
+++ b/mitosheet/src/components/import/XLSXImportConfigScreen.tsx
@@ -142,6 +142,7 @@ function XLSXImportConfigScreen(props: XLSXImportConfigScreenProps): JSX.Element
                             loading={loading}
                             searchable
                             height='medium'
+                            emptyMessage='There are no sheets to choose from. Either the workbook is empty or password protected.'
                             toggleAllIndexes={(indexesToToggle) => {
                                 props.setParams(prevParams => {
                                     const newSheetNames = [...prevParams.sheet_names];


### PR DESCRIPTION
# Description

When an Excel file is password protected, no sheets are displayed in the multi toggle box. This has causes confusion to our users. Now if there are no sheets returned, we just let them know that it might be because the file is password protected. 80/20

Supporting password protected files is not straight forward in pandas, so if we want to actually support these files, we'll need to look for new import methods. 

# Testing

Create a password protected Excel file and watch for the message. 

# Documentation

Note if any new documentation needs to addressed or reviewed.