### PR TITLE
mitosheet: have dataframe renames optimize

### DIFF
--- a/mitosheet/mitosheet/code_chunks/snowflake_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/snowflake_import_code_chunk.py
@@ -2,15 +2,15 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+from copy import copy
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
-from typing import List, Optional, Tuple, Dict
-from copy import copy
+from typing import Dict, List, Optional, Tuple
+
 from mitosheet.code_chunks.code_chunk import CodeChunk
-from mitosheet.code_chunks.step_performers.dataframe_steps.dataframe_rename_code_chunk import DataframeRenameCodeChunk
 from mitosheet.state import State
-from mitosheet.transpiler.transpile_utils import TAB, param_dict_to_code
-from mitosheet.types import ColumnHeader, SnowflakeCredentials, SnowflakeQueryParams, SnowflakeTableLocationAndWarehouse
+from mitosheet.transpiler.transpile_utils import param_dict_to_code
+
 
 class SnowflakeImportCodeChunk(CodeChunk):
 
@@ -20,12 +20,10 @@ class SnowflakeImportCodeChunk(CodeChunk):
         post_state: State, 
         connection_params_dict: Dict[str, str], 
         sql_queries: List[str],
-        df_names: List[str]
     ):
         super().__init__(prev_state, post_state)
         self.connection_params_dict = connection_params_dict
         self.sql_queries = sql_queries
-        self.df_names = df_names
 
     def get_display_name(self) -> str:
         return 'Import from Snowflake'
@@ -43,8 +41,10 @@ class SnowflakeImportCodeChunk(CodeChunk):
             'cur = con.cursor()',
         ]
 
+        df_names = self.post_state.df_names[len(self.prev_state.df_names):]
+
         df_creation_code = ['']
-        for sql_query, df_name in zip(self.sql_queries, self.df_names):
+        for sql_query, df_name in zip(self.sql_queries, df_names):
             df_creation_code.append(f'cur.execute(\'{sql_query}\')')
             df_creation_code.append(f'{df_name} = cur.fetch_pandas_all()')
             df_creation_code.append('')
@@ -56,7 +56,7 @@ class SnowflakeImportCodeChunk(CodeChunk):
         return all_code, ['import snowflake.connector']
 
     def get_created_sheet_indexes(self) -> List[int]:
-        return [i for i in range(len(self.post_state.dfs) - len(self.df_names), len(self.post_state.dfs))]
+        return [i for i in range(len(self.post_state.dfs) - len(self.sql_queries), len(self.post_state.dfs))]
 
 
     def _combine_right_with_snowflake_import_code_chunk(self, other_code_chunk: "SnowflakeImportCodeChunk") -> Optional["SnowflakeImportCodeChunk"]:
@@ -65,16 +65,12 @@ class SnowflakeImportCodeChunk(CodeChunk):
         
         all_sql_queries = copy(self.sql_queries) # Make sure to copy this so we don't get weird bugs w/ duplication
         all_sql_queries.extend(other_code_chunk.sql_queries)
-
-        all_df_names = copy(self.df_names)
-        all_df_names.extend(other_code_chunk.df_names)
         
         return SnowflakeImportCodeChunk(
             self.prev_state,
             other_code_chunk.post_state,
             self.connection_params_dict,
             all_sql_queries,
-            all_df_names
         )        
 
     def combine_right(self, other_code_chunk: CodeChunk) -> Optional[CodeChunk]:

--- a/mitosheet/mitosheet/code_chunks/step_performers/dataframe_steps/dataframe_rename_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/dataframe_steps/dataframe_rename_code_chunk.py
@@ -3,9 +3,17 @@
 
 # Copyright (c) Saga Inc.
 # Distributed under the terms of the GPL License.
-from typing import Any, Dict, List, Optional, Tuple
+from copy import deepcopy
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
+from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import SimpleImportCodeChunk
+from mitosheet.code_chunks.step_performers.import_steps.excel_import_code_chunk import ExcelImportCodeChunk
+from mitosheet.code_chunks.step_performers.import_steps.excel_range_import_code_chunk import ExcelRangeImportCodeChunk
+from mitosheet.code_chunks.snowflake_import_code_chunk import SnowflakeImportCodeChunk
+from mitosheet.code_chunks.step_performers.pivot_code_chunk import PivotCodeChunk
+from mitosheet.code_chunks.step_performers.merge_code_chunk import MergeCodeChunk
+from mitosheet.code_chunks.step_performers.dataframe_steps.dataframe_duplicate_code_chunk import DataframeDuplicateCodeChunk
 from mitosheet.state import State
 
 
@@ -31,3 +39,92 @@ class DataframeRenameCodeChunk(CodeChunk):
 
     def get_edited_sheet_indexes(self) -> List[int]:
         return [self.sheet_index]
+
+    def _combine_left_with_dataframe_rename(self, dataframe_rename_code_chunk: "DataframeRenameCodeChunk") -> Optional["DataframeRenameCodeChunk"]:
+        if self.sheet_index != dataframe_rename_code_chunk.sheet_index:
+            return None
+        
+        return DataframeRenameCodeChunk(
+            dataframe_rename_code_chunk.prev_state,
+            self.post_state,
+            dataframe_rename_code_chunk.sheet_index,
+            dataframe_rename_code_chunk.old_dataframe_name,
+            self.new_dataframe_name
+        )
+
+    def _combine_left_with_pivot_code_chunk(self, pivot_code_chunk: PivotCodeChunk) -> Optional[CodeChunk]:
+        destination_sheet_index = pivot_code_chunk.destination_sheet_index
+        if destination_sheet_index is None:
+            destination_sheet_index = len(pivot_code_chunk.post_state.dfs) - 1
+
+        if destination_sheet_index != self.sheet_index:
+            return None
+
+        return PivotCodeChunk(
+            pivot_code_chunk.prev_state,
+            self.post_state,
+            pivot_code_chunk.sheet_index,
+            pivot_code_chunk.destination_sheet_index,
+            pivot_code_chunk.pivot_rows_column_ids_with_transforms,
+            pivot_code_chunk.pivot_columns_column_ids_with_transforms,
+            pivot_code_chunk.pivot_filters_ids,
+            pivot_code_chunk.values_column_ids_map,
+            pivot_code_chunk.flatten_column_headers,
+            pivot_code_chunk.was_series,
+        )
+
+    def _combine_left_with_merge_code_chunk(self, merge_code_chunk: MergeCodeChunk) -> Optional[CodeChunk]:
+        destination_sheet_index = len(merge_code_chunk.post_state.dfs) - 1
+        if destination_sheet_index != self.sheet_index:
+            return None
+
+        return MergeCodeChunk(
+            merge_code_chunk.prev_state,
+            self.post_state,
+            merge_code_chunk.how,
+            merge_code_chunk.sheet_index_one,
+            merge_code_chunk.sheet_index_two,
+            merge_code_chunk.merge_key_column_ids,
+            merge_code_chunk.selected_column_ids_one,
+            merge_code_chunk.selected_column_ids_two,
+        )
+
+    def _combine_left_with_import_code_chunk(
+            self, 
+            import_code_chunk: Union[SimpleImportCodeChunk, ExcelImportCodeChunk, ExcelRangeImportCodeChunk, SnowflakeImportCodeChunk]
+        ) -> Optional[CodeChunk]:
+        created_sheet_indexes = import_code_chunk.get_created_sheet_indexes()
+        if created_sheet_indexes is None or self.sheet_index not in created_sheet_indexes:
+            return None
+
+        new_import_chunk = deepcopy(import_code_chunk)
+        new_import_chunk.post_state = self.post_state
+        return new_import_chunk
+
+    def _combine_left_with_dataframe_duplicate(
+        self, 
+        dataframe_duplicate_code_chunk: DataframeDuplicateCodeChunk
+    ) -> Optional[CodeChunk]:
+        if self.sheet_index != len(dataframe_duplicate_code_chunk.post_state.dfs) - 1:
+            return None
+        
+        return DataframeDuplicateCodeChunk(
+            dataframe_duplicate_code_chunk.prev_state,
+            self.post_state,
+            dataframe_duplicate_code_chunk.sheet_index
+        )
+
+    def combine_left(self, other_code_chunk: "CodeChunk") -> Optional["CodeChunk"]:
+        if isinstance(other_code_chunk, DataframeRenameCodeChunk):
+            return self._combine_left_with_dataframe_rename(other_code_chunk)
+        elif isinstance(other_code_chunk, PivotCodeChunk):
+            return self._combine_left_with_pivot_code_chunk(other_code_chunk)
+        elif isinstance(other_code_chunk, MergeCodeChunk):
+            return self._combine_left_with_merge_code_chunk(other_code_chunk)
+        elif isinstance(other_code_chunk, SimpleImportCodeChunk) or isinstance(other_code_chunk, ExcelImportCodeChunk) \
+            or isinstance(other_code_chunk, ExcelRangeImportCodeChunk) or isinstance(other_code_chunk, SnowflakeImportCodeChunk):
+            return self._combine_left_with_import_code_chunk(other_code_chunk)
+        elif isinstance(other_code_chunk, DataframeDuplicateCodeChunk):
+            return self._combine_left_with_dataframe_duplicate(other_code_chunk)
+
+        return None

--- a/mitosheet/mitosheet/code_chunks/step_performers/import_steps/excel_range_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/import_steps/excel_range_import_code_chunk.py
@@ -6,33 +6,32 @@
 # Distributed under the terms of the GPL License.
 from copy import copy
 from typing import Dict, List, Optional, Tuple
-from collections import OrderedDict
 
 from mitosheet.code_chunks.code_chunk import CodeChunk
 from mitosheet.excel_utils import (get_column_from_column_index,
                                    get_col_and_row_indexes_from_range)
 from mitosheet.state import State
-from mitosheet.code_chunks.step_performers.dataframe_steps.dataframe_rename_code_chunk import DataframeRenameCodeChunk
 
 
 class ExcelRangeImportCodeChunk(CodeChunk):
 
-    def __init__(self, prev_state: State, post_state: State, file_path: str, sheet_name: str, sheet_index_to_df_name_and_range: Dict[int, Tuple[str, str]]):
+    def __init__(self, prev_state: State, post_state: State, file_path: str, sheet_name: str, sheet_index_to_df_range: Dict[int, str]):
         super().__init__(prev_state, post_state)
         self.file_path = file_path
         self.sheet_name = sheet_name
-        self.sheet_index_to_df_name_and_range = sheet_index_to_df_name_and_range
+        self.sheet_index_to_df_range = sheet_index_to_df_range
 
     def get_display_name(self) -> str:
         return 'Excel Range Import'
     
     def get_description_comment(self) -> str:
         
-        return f"Imported {len(self.sheet_index_to_df_name_and_range)} dataframes from {self.sheet_name} in {self.file_path}"
+        return f"Imported {len(self.sheet_index_to_df_range)} dataframes from {self.sheet_name} in {self.file_path}"
 
     def get_code(self) -> Tuple[List[str], List[str]]:
         code = []
-        for df_name, _range in self.sheet_index_to_df_name_and_range.values():
+        for sheet_index, _range in self.sheet_index_to_df_range.items():
+            df_name = self.post_state.df_names[sheet_index]
             ((start_col_index, start_row_index), (end_col_index, end_row_index)) = get_col_and_row_indexes_from_range(_range)
             nrows = end_row_index - start_row_index
             usecols = get_column_from_column_index(start_col_index) + ':' + get_column_from_column_index(end_col_index)
@@ -44,45 +43,26 @@ class ExcelRangeImportCodeChunk(CodeChunk):
         return code, ['import pandas as pd']
 
     def get_created_sheet_indexes(self) -> Optional[List[int]]:
-        return list(self.sheet_index_to_df_name_and_range.keys())
-
-    def _combine_right_with_dataframe_rename_code_chunk(self, dataframe_rename_code_chunk: DataframeRenameCodeChunk) -> Optional[CodeChunk]:
-        sheet_index = dataframe_rename_code_chunk.sheet_index
-        new_dataframe_name = dataframe_rename_code_chunk.new_dataframe_name
-
-        if sheet_index in self.sheet_index_to_df_name_and_range:
-            new_sheet_index_to_df_name_and_range = copy(self.sheet_index_to_df_name_and_range)
-            new_sheet_index_to_df_name_and_range[sheet_index] = (new_dataframe_name, self.sheet_index_to_df_name_and_range[sheet_index][1])
-            return ExcelRangeImportCodeChunk(
-                self.prev_state,
-                dataframe_rename_code_chunk.post_state,
-                self.file_path,
-                self.sheet_name,
-                new_sheet_index_to_df_name_and_range
-            )
-
-        return None
+        return list(self.sheet_index_to_df_range.keys())
 
     def _combine_right_with_excel_range_import_code_chunk(self, excel_range_import_code_chunk: "ExcelRangeImportCodeChunk") -> Optional[CodeChunk]:
         if excel_range_import_code_chunk.file_path == self.file_path and excel_range_import_code_chunk.sheet_name == self.sheet_name:
-            new_sheet_index_to_df_name_and_range = copy(self.sheet_index_to_df_name_and_range)
-            new_sheet_index_to_df_name_and_range.update(excel_range_import_code_chunk.sheet_index_to_df_name_and_range)
+            new_sheet_index_to_df_range = copy(self.sheet_index_to_df_range)
+            new_sheet_index_to_df_range.update(excel_range_import_code_chunk.sheet_index_to_df_range)
 
             return ExcelRangeImportCodeChunk(
                 self.prev_state,
                 excel_range_import_code_chunk.post_state,
                 self.file_path,
                 self.sheet_name,
-                new_sheet_index_to_df_name_and_range
+                new_sheet_index_to_df_range
             )
 
         return None
 
 
     def combine_right(self, other_code_chunk: "CodeChunk") -> Optional["CodeChunk"]:
-        if isinstance(other_code_chunk, DataframeRenameCodeChunk):
-            return self._combine_right_with_dataframe_rename_code_chunk(other_code_chunk)
-        elif isinstance(other_code_chunk, ExcelRangeImportCodeChunk):
+        if isinstance(other_code_chunk, ExcelRangeImportCodeChunk):
             return self._combine_right_with_excel_range_import_code_chunk(other_code_chunk)
 
         return None

--- a/mitosheet/mitosheet/code_chunks/step_performers/pivot_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/pivot_code_chunk.py
@@ -79,8 +79,6 @@ def build_args_code(
 
 class PivotCodeChunk(CodeChunk):
 
-    
-
     def __init__(
         self, 
         prev_state: State, 

--- a/mitosheet/mitosheet/step_performers/import_steps/excel_range_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/excel_range_import.py
@@ -48,7 +48,7 @@ class ExcelRangeImportStepPerformer(StepPerformer):
 
         pandas_start_time = perf_counter()
 
-        sheet_index_to_df_name_and_range: Dict[int, Tuple[str, str]] = {}
+        sheet_index_to_df_range: Dict[int, str] = {}
         for range_import in range_imports:
             _range: Optional[str]
             if range_import['type'] == EXCEL_RANGE_IMPORT_TYPE_RANGE:
@@ -71,13 +71,13 @@ class ExcelRangeImportStepPerformer(StepPerformer):
                 df_name=final_df_name
             )
 
-            sheet_index_to_df_name_and_range[len(post_state.dfs) - 1] = (final_df_name, _range)
+            sheet_index_to_df_range[len(post_state.dfs) - 1] = _range
 
         pandas_processing_time = perf_counter() - pandas_start_time
 
         return post_state, {
             'pandas_processing_time': pandas_processing_time,
-            'sheet_index_to_df_name_and_range': sheet_index_to_df_name_and_range,
+            'new_sheet_index_to_df_range': sheet_index_to_df_range,
             'result': {
                 # TODO: fill in the result, when we make the frontend
             }
@@ -97,7 +97,7 @@ class ExcelRangeImportStepPerformer(StepPerformer):
                 post_state, 
                 get_param(params, 'file_path'),
                 get_param(params, 'sheet_name'),
-                (execution_data if execution_data is not None else dict()).get('sheet_index_to_df_name_and_range', {})
+                (execution_data if execution_data is not None else dict()).get('new_sheet_index_to_df_range', {})
             )
         ]
 

--- a/mitosheet/mitosheet/step_performers/import_steps/snowflake_import.py
+++ b/mitosheet/mitosheet/step_performers/import_steps/snowflake_import.py
@@ -84,7 +84,7 @@ class SnowflakeImportStepPerformer(StepPerformer):
             df, 
             DATAFRAME_SOURCE_IMPORTED, 
             df_name=new_df_name,
-        )   
+        )
 
         pandas_processing_time = perf_counter() - pandas_start_time
 
@@ -92,7 +92,6 @@ class SnowflakeImportStepPerformer(StepPerformer):
             'pandas_processing_time': pandas_processing_time,
             'connection_params_dict': connection_params_dict,
             'sql_query': sql_query,
-            'df_name': post_state.df_names[-1],
             'result': {
                 # TODO: fill in the result
             }
@@ -112,7 +111,6 @@ class SnowflakeImportStepPerformer(StepPerformer):
                 post_state, 
                 get_param(execution_data if execution_data is not None else {}, 'connection_params_dict'),
                 [get_param(execution_data if execution_data is not None else {}, 'sql_query')],
-                [get_param(execution_data if execution_data is not None else {}, 'df_name')],
             )
         ]
 

--- a/mitosheet/mitosheet/tests/step_performers/dataframe_steps/test_dataframe_rename.py
+++ b/mitosheet/mitosheet/tests/step_performers/dataframe_steps/test_dataframe_rename.py
@@ -7,11 +7,14 @@
 Contains tests for dataframe_rename
 """
 
+import os
 import pytest
 import pandas as pd
+from mitosheet.api.get_validate_snowflake_credentials import get_validate_snowflake_credentials
+from mitosheet.tests.step_performers.import_steps.test_snowflake_import import TEST_SNOWFLAKE_CREDENTIALS, TEST_SNOWFLAKE_TABLE_LOC_AND_WAREHOUSE
 
 from mitosheet.tests.test_utils import create_mito_wrapper_dfs
-from mitosheet.transpiler.transpile import transpile
+from mitosheet.tests.decorators import pandas_post_1_only, python_post_3_6_only, requires_snowflake_dependencies_and_credentials
 
 
 def test_can_rename_single_dataframe():
@@ -22,6 +25,26 @@ def test_can_rename_single_dataframe():
 
     assert mito.df_names == ['df100']
 
+def test_rename_dataframe_twice_optimizes():
+    df = pd.DataFrame({'A': [123]})
+    mito = create_mito_wrapper_dfs(df)
+
+    mito.rename_dataframe(0, 'df100')
+    mito.rename_dataframe(0, 'df101')
+
+    assert mito.df_names == ['df101']
+    assert len(mito.optimized_code_chunks) == 1
+
+def test_rename_two_different_dataframes_no_optimizes():
+    df = pd.DataFrame({'A': [123]})
+    df1 = pd.DataFrame({'A': [123]})
+    mito = create_mito_wrapper_dfs(df, df1)
+
+    mito.rename_dataframe(0, 'df100')
+    mito.rename_dataframe(1, 'df101')
+
+    assert mito.df_names == ['df100', 'df101']
+    assert len(mito.optimized_code_chunks) == 2
 
 def test_can_rename_multiple_dataframes():
     df1 = pd.DataFrame({'A': [123]})
@@ -90,3 +113,199 @@ def test_rename_not_optimized_after_different_dataframe_delete():
     mito.delete_dataframe(1)
 
     assert len(mito.optimized_code_chunks) >= 3
+
+def test_pivot_then_rename_same_df_optimizes():
+    df = pd.DataFrame({'A': [123]})
+    mito = create_mito_wrapper_dfs(df)
+    mito.pivot_sheet(0, ['A'], [], {'A': ['count']})
+    mito.rename_dataframe(1, 'abc')
+
+    assert mito.df_names[1] == 'abc'
+    assert mito.dfs[1].equals(pd.DataFrame({'A': [123], 'A count': [1]}))
+    assert len(mito.optimized_code_chunks) == 1
+    
+def test_pivot_then_edit_then_rename_same_df_optimizes():
+    df = pd.DataFrame({'A': [123]})
+    mito = create_mito_wrapper_dfs(df)
+    mito.pivot_sheet(0, ['A'], [], {'A': ['count']})
+    mito.pivot_sheet(0, ['A'], [], {'A': ['sum']}, destination_sheet_index=1)
+    mito.rename_dataframe(1, 'abc')
+
+    assert mito.df_names[1] == 'abc'
+    assert mito.dfs[1].equals(pd.DataFrame({'A': [123], 'A sum': [123]}))
+    assert len(mito.optimized_code_chunks) == 1
+
+def test_pivot_then_rename_different_df_not_optimizes():
+    df = pd.DataFrame({'A': [123]})
+    df1 = pd.DataFrame({'A': [123]})
+    mito = create_mito_wrapper_dfs(df, df1)
+    mito.pivot_sheet(0, ['A'], [], {'A': ['count']})
+    mito.rename_dataframe(1, 'abc')
+
+    assert mito.df_names[1] == 'abc'
+    assert mito.dfs[1].equals(df1)
+    assert mito.dfs[2].equals(pd.DataFrame({'A': [123], 'A count': [1]}))
+    assert len(mito.optimized_code_chunks) == 2
+
+def test_merge_then_rename_same_df_optimizes():
+    df = pd.DataFrame({'A': [123]})
+    df1 = pd.DataFrame({'A': [123]})
+    mito = create_mito_wrapper_dfs(df, df1)
+    mito.merge_sheets('left', 0, 1, [('A', 'A')], ['A'], ['A'])
+    mito.rename_dataframe(2, 'abc')
+
+    assert mito.df_names[2] == 'abc'
+    assert mito.dfs[0].equals(df)
+    assert mito.dfs[1].equals(df1)
+    assert mito.dfs[2].equals(pd.DataFrame({'A': [123]}))
+    assert len(mito.optimized_code_chunks) == 1
+
+def test_merge_then_rename_diff_df_not_optimizes():
+    df = pd.DataFrame({'A': [123]})
+    df1 = pd.DataFrame({'A': [123]})
+    mito = create_mito_wrapper_dfs(df, df1)
+    mito.merge_sheets('left', 0, 1, [('A', 'A')], ['A'], ['A'])
+    mito.rename_dataframe(1, 'abc')
+
+    assert mito.df_names[1] == 'abc'
+    assert mito.dfs[0].equals(df)
+    assert mito.dfs[1].equals(df1)
+    assert mito.dfs[2].equals(pd.DataFrame({'A': [123]}))
+    assert len(mito.optimized_code_chunks) == 2
+
+TEST_CSV_FILE = 'tmp.csv'
+TEST_XLSX_FILE = 'tmp.xlsx'
+
+def test_simple_import_then_rename_same_df_optimizes():
+    df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})
+    df.to_csv(TEST_CSV_FILE, index=False)
+
+    mito = create_mito_wrapper_dfs()
+    mito.simple_import([TEST_CSV_FILE])
+    mito.rename_dataframe(0, 'abc')
+
+    assert mito.df_names[0] == 'abc'
+    assert mito.dfs[0].equals(df)
+    assert len(mito.optimized_code_chunks) == 1
+
+    # Remove the test file
+    os.remove(TEST_CSV_FILE)
+
+
+def test_simple_import_then_rename_diff_df_not_optimizes():
+    df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})
+    df.to_csv(TEST_CSV_FILE, index=False)
+
+    mito = create_mito_wrapper_dfs(df)
+    mito.simple_import([TEST_CSV_FILE])
+    mito.rename_dataframe(0, 'abc')
+
+    assert mito.df_names[0] == 'abc'
+    assert mito.dfs[0].equals(df)
+    assert mito.dfs[1].equals(df)
+    assert len(mito.optimized_code_chunks) == 2
+
+    # Remove the test file
+    os.remove(TEST_CSV_FILE)
+
+@pandas_post_1_only
+@python_post_3_6_only
+def test_excel_import_then_rename_same_df_optimizes():
+    df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})
+    df.to_excel(TEST_XLSX_FILE, index=False)
+
+    mito = create_mito_wrapper_dfs()
+    mito.excel_import(TEST_XLSX_FILE, ['Sheet1'], True, 0)
+    mito.rename_dataframe(0, 'abc')
+
+    assert mito.df_names[0] == 'abc'
+    print(mito.dfs[0])
+    assert mito.dfs[0].equals(df)
+    assert len(mito.optimized_code_chunks) == 1
+
+    # Remove the test file
+    os.remove(TEST_XLSX_FILE)
+
+
+@pandas_post_1_only
+@python_post_3_6_only
+def test_excel_import_then_rename_diff_df_not_optimizes():
+    df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})
+    df.to_excel(TEST_XLSX_FILE, index=False)
+
+    mito = create_mito_wrapper_dfs(df)
+    mito.excel_import(TEST_XLSX_FILE, ['Sheet1'], True, 0)
+    mito.rename_dataframe(0, 'abc')
+
+    assert mito.df_names[0] == 'abc'
+    assert mito.dfs[0].equals(df)
+    assert mito.dfs[1].equals(df)
+    assert len(mito.optimized_code_chunks) == 2
+
+    # Remove the test file
+    os.remove(TEST_XLSX_FILE)
+
+@pandas_post_1_only
+@python_post_3_6_only
+def test_excel_range_import_then_rename_same_df_optimizes():
+    df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})
+    mito = create_mito_wrapper_dfs()
+    df.to_excel(TEST_XLSX_FILE, sheet_name='Sheet1', index=False)
+
+    mito.excel_range_import(TEST_XLSX_FILE, 'Sheet1', [{'type': 'range', 'df_name': 'df2', 'value': 'A1:B4'}])
+    mito.rename_dataframe(0, 'abc')
+
+    assert mito.df_names[0] == 'abc'
+    assert mito.dfs[0].equals(df)
+    assert len(mito.optimized_code_chunks) == 1
+
+    os.remove(TEST_XLSX_FILE)
+
+@pandas_post_1_only
+@python_post_3_6_only
+def test_excel_range_import_then_rename_diff_df_not_optimizes():
+    df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})
+    mito = create_mito_wrapper_dfs(df)
+    df.to_excel(TEST_XLSX_FILE, sheet_name='Sheet1', index=False)
+
+    mito.excel_range_import(TEST_XLSX_FILE, 'Sheet1', [{'type': 'range', 'df_name': 'df2', 'value': 'A1:B4'}])
+    mito.rename_dataframe(0, 'abc')
+
+    assert mito.df_names[0] == 'abc'
+    assert mito.dfs[0].equals(df)
+    assert mito.dfs[1].equals(df)
+    assert len(mito.optimized_code_chunks) == 2
+
+    os.remove(TEST_XLSX_FILE)
+
+@requires_snowflake_dependencies_and_credentials
+@python_post_3_6_only
+def test_snowflake_import_then_rename_same_df_optimizes():
+    mito = create_mito_wrapper_dfs()
+    get_validate_snowflake_credentials(TEST_SNOWFLAKE_CREDENTIALS, mito.mito_backend.steps_manager)
+
+    query_params = {'columns': ['COLUMNA', 'COLUMNB'], 'limit': 2}
+
+    mito.snowflake_import(TEST_SNOWFLAKE_TABLE_LOC_AND_WAREHOUSE, query_params)
+    mito.rename_dataframe(0, 'abc')
+
+    assert mito.df_names[0] == 'abc'
+    assert mito.dfs[0].equals(pd.DataFrame({'COLUMNA': ['Aaron', 'Nate'], 'COLUMNB': ["DR", "Rush"]}))
+    assert len(mito.optimized_code_chunks) == 1
+
+@requires_snowflake_dependencies_and_credentials
+@python_post_3_6_only
+def test_snowflake_import_then_rename_diff_df_not_optimizes():
+    df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})
+    mito = create_mito_wrapper_dfs(df)
+    get_validate_snowflake_credentials(TEST_SNOWFLAKE_CREDENTIALS, mito.mito_backend.steps_manager)
+
+    query_params = {'columns': ['COLUMNA', 'COLUMNB'], 'limit': 2}
+
+    mito.snowflake_import(TEST_SNOWFLAKE_TABLE_LOC_AND_WAREHOUSE, query_params)
+    mito.rename_dataframe(0, 'abc')
+
+    assert mito.df_names[0] == 'abc'
+    assert mito.dfs[0].equals(df)
+    assert mito.dfs[1].equals(pd.DataFrame({'COLUMNA': ['Aaron', 'Nate'], 'COLUMNB': ["DR", "Rush"]}))
+    assert len(mito.optimized_code_chunks) == 2

--- a/mitosheet/mitosheet/tests/step_performers/dataframe_steps/test_dataframe_rename.py
+++ b/mitosheet/mitosheet/tests/step_performers/dataframe_steps/test_dataframe_rename.py
@@ -14,7 +14,7 @@ from mitosheet.api.get_validate_snowflake_credentials import get_validate_snowfl
 from mitosheet.tests.step_performers.import_steps.test_snowflake_import import TEST_SNOWFLAKE_CREDENTIALS, TEST_SNOWFLAKE_TABLE_LOC_AND_WAREHOUSE
 
 from mitosheet.tests.test_utils import create_mito_wrapper_dfs
-from mitosheet.tests.decorators import pandas_post_1_only, python_post_3_6_only, requires_snowflake_dependencies_and_credentials
+from mitosheet.tests.decorators import pandas_post_1_only, python_post_3_6_only, requires_snowflake_dependencies_and_credentials, pandas_post_1_2_only
 
 
 def test_can_rename_single_dataframe():
@@ -245,7 +245,7 @@ def test_excel_import_then_rename_diff_df_not_optimizes():
     # Remove the test file
     os.remove(TEST_XLSX_FILE)
 
-@pandas_post_1_only
+@pandas_post_1_2_only
 @python_post_3_6_only
 def test_excel_range_import_then_rename_same_df_optimizes():
     df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})
@@ -261,7 +261,7 @@ def test_excel_range_import_then_rename_same_df_optimizes():
 
     os.remove(TEST_XLSX_FILE)
 
-@pandas_post_1_only
+@pandas_post_1_2_only
 @python_post_3_6_only
 def test_excel_range_import_then_rename_diff_df_not_optimizes():
     df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})

--- a/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_range_import.py
+++ b/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_range_import.py
@@ -234,24 +234,6 @@ def test_excel_range_upper_left_detection_finds_first_match():
 
 @pandas_post_1_2_only
 @python_post_3_6_only
-def test_excel_range_import_followed_by_rename_optimizes():
-    mito = create_mito_wrapper_dfs(TEST_DF_1)
-    TEST_DF_2.to_excel(TEST_FILE_PATH, sheet_name=TEST_SHEET_NAME, index=False)
-
-    mito.excel_range_import(TEST_FILE_PATH, TEST_SHEET_NAME, [{'type': 'range', 'df_name': 'df2', 'value': 'A1:B2'}])
-    mito.rename_dataframe(1, 'new_df2')
-
-    assert len(mito.dfs) == 2
-    assert TEST_DF_1.equals(mito.dfs[0])
-    assert TEST_DF_2.equals(mito.dfs[1])
-
-    assert mito.df_names[-1] == 'new_df2'
-    assert len(mito.optimized_code_chunks) == 1
-
-    os.remove(TEST_FILE_PATH)
-
-@pandas_post_1_2_only
-@python_post_3_6_only
 def test_excel_range_import_followed_by_rename_other_does_not_optimize():
     mito = create_mito_wrapper_dfs(TEST_DF_1)
     TEST_DF_2.to_excel(TEST_FILE_PATH, sheet_name=TEST_SHEET_NAME, index=False)

--- a/mitosheet/mitosheet/tests/step_performers/import_steps/test_snowflake_import.py
+++ b/mitosheet/mitosheet/tests/step_performers/import_steps/test_snowflake_import.py
@@ -11,6 +11,7 @@ import json
 import pandas as pd
 import pytest
 import os
+from mitosheet.types import SnowflakeCredentials
 from mitosheet.utils import get_new_id
 from mitosheet.api.get_available_snowflake_options_and_defaults import get_available_snowflake_options_and_defaults
 from mitosheet.api.get_validate_snowflake_credentials import get_validate_snowflake_credentials
@@ -22,11 +23,11 @@ PYTEST_SNOWFLAKE_USERNAME = os.getenv('PYTEST_SNOWFLAKE_USERNAME')
 PYTEST_SNOWFLAKE_PASSWORD = os.getenv('PYTEST_SNOWFLAKE_PASSWORD')
 PYTEST_SNOWFLAKE_ACCOUNT = os.getenv('PYTEST_SNOWFLAKE_ACCOUNT')
 
-TEST_SNOWFLAKE_CREDENTIALS = {
+TEST_SNOWFLAKE_CREDENTIALS: SnowflakeCredentials = {
     'type': 'username/password', 
-    'username': PYTEST_SNOWFLAKE_USERNAME, 
-    'password': PYTEST_SNOWFLAKE_PASSWORD, 
-    'account': PYTEST_SNOWFLAKE_ACCOUNT
+    'username': PYTEST_SNOWFLAKE_USERNAME or '', 
+    'password': PYTEST_SNOWFLAKE_PASSWORD or '', 
+    'account': PYTEST_SNOWFLAKE_ACCOUNT or ''
 }
 
 TEST_SNOWFLAKE_TABLE_LOC_AND_WAREHOUSE = {


### PR DESCRIPTION
# Description

Optimizes dataframe renames in a bunch of the most common cases. Very nice! Closes https://github.com/mito-ds/monorepo/issues/617
 
# Testing

Do things, then rename.

# Documentation

No.