### PR TITLE
mitoinstaller: don't fail on notebook installer

### DIFF
--- a/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
+++ b/mitoinstaller/mitoinstaller/installer_steps/mitosheet_installer_steps.py
@@ -66,8 +66,11 @@ def install_step_mitosheet_install_mitosheet():
 
 
 def install_step_mitosheet_activate_notebook_extension():
-    run_command([sys.executable, "-m", 'jupyter', 'nbextension', 'install', '--py', '--user', 'mitosheet'])
-    run_command([sys.executable, "-m", 'jupyter', 'nbextension', 'enable', '--py', '--user', 'mitosheet'])
+    try:
+        run_command([sys.executable, "-m", 'jupyter', 'nbextension', 'install', '--py', '--user', 'mitosheet'])
+        run_command([sys.executable, "-m", 'jupyter', 'nbextension', 'enable', '--py', '--user', 'mitosheet'])
+    except:
+        print("Unable to activate extension for Classic Notebook. Mito will still work in JupyterLab")
 
     
 MITOSHEET_INSTALLER_STEPS = [


### PR DESCRIPTION
# Description

This is an optional step for most of our users, so let's not fail on it. See investigation of other issues here: https://www.notion.so/trymito/2-6-23-4d92e602e0674eac98ca8fcfd9d86c97

# Testing

Add an raise Exception in the steps you want to fail, and make sure the installer still terminates.

# Documentation

No.