### PR TITLE
mitosheet: move to chatgpt api

### DIFF
--- a/mitosheet/mitosheet/api/get_ai_completion.py
+++ b/mitosheet/mitosheet/api/get_ai_completion.py
@@ -14,7 +14,7 @@ from mitosheet.ai.prompt import get_prompt
 
 import requests
 
-URL = 'https://api.openai.com/v1/completions'
+URL = 'https://api.openai.com/v1/chat/completions'
 
 def get_ai_completion(params: Dict[str, Any], steps_manager: StepsManagerType) -> str:
         selection: Optional[Selection] = params.get('selection', None)
@@ -35,8 +35,8 @@ def get_ai_completion(params: Dict[str, Any], steps_manager: StepsManagerType) -
                 })
 
         data = {
-                "model": "code-davinci-002",
-                "prompt": prompt,
+                "model": "gpt-3.5-turbo",
+                "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": 7,
                 "temperature": .2,
                 'max_tokens': 200,
@@ -56,7 +56,7 @@ def get_ai_completion(params: Dict[str, Any], steps_manager: StepsManagerType) -
 
         if res.status_code == 200:
                 res_json = res.json()
-                completion = res_json['choices'][0]['text']
+                completion = res_json['choices'][0]['message']["content"]
                 return json.dumps({
                         'user_input': user_input,
                         'prompt_version': 'df-creation-prompt-1',


### PR DESCRIPTION
# Description

Moves to the new chatgpt api. 

# Testing

Use the AI transformation taskpane. 

# Documentation

Note if any new documentation needs to addressed or reviewed.