### PR TITLE
mitosheet: don't remove excel range imports on clear

### DIFF
--- a/mitosheet/mitosheet/steps_manager.py
+++ b/mitosheet/mitosheet/steps_manager.py
@@ -16,6 +16,7 @@ from mitosheet.data_in_mito import DataTypeInMito, get_data_type_in_mito
 from mitosheet.enterprise.mito_config import MitoConfig
 from mitosheet.experiments.experiment_utils import get_current_experiment
 from mitosheet.step_performers.import_steps.dataframe_import import DataframeImportStepPerformer
+from mitosheet.step_performers.import_steps.excel_range_import import ExcelRangeImportStepPerformer
 from mitosheet.telemetry.telemetry_utils import log
 from mitosheet.preprocessing import PREPROCESS_STEP_PERFORMERS
 from mitosheet.saved_analyses.save_utils import get_analysis_exists
@@ -574,6 +575,7 @@ class StepsManager:
                 or step.step_type == ExcelImportStepPerformer.step_type()
                 or step.step_type == DataframeImportStepPerformer.step_type()
                 or step.step_type == SnowflakeImportStepPerformer.step_type()
+                or step.step_type == ExcelRangeImportStepPerformer.step_type()
             )
         ]
 

--- a/mitosheet/mitosheet/tests/updates/test_clear.py
+++ b/mitosheet/mitosheet/tests/updates/test_clear.py
@@ -12,6 +12,9 @@ from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk
 from mitosheet.tests.test_utils import create_mito_wrapper_dfs
 from mitosheet.tests.decorators import pandas_post_1_only, python_post_3_6_only
 
+TEST_DF_1 = pd.DataFrame({'header 1': [1], 'header 2': [2]})
+TEST_FILE_PATH = "test_file.xlsx"
+TEST_SHEET_NAME = 'sheet1'
 
 def test_clear_undoes_mulitple_steps_on_passed_dataframes():
     df1 = pd.DataFrame(data={'A': [1, 2, 3, 4, 5, 6]})
@@ -140,3 +143,18 @@ def test_clear_resets_excel_imports():
 
     # Remove the test file
     os.remove('test.xlsx')
+
+
+def test_does_not_undo_excel_range_import():
+    mito = create_mito_wrapper_dfs()
+
+    TEST_DF_1.to_excel(TEST_FILE_PATH, sheet_name=TEST_SHEET_NAME, index=False)
+    mito.excel_range_import(TEST_FILE_PATH, TEST_SHEET_NAME, [{'type': 'range', 'df_name': 'df1', 'value': 'A1:B2'}])
+
+    assert len(mito.dfs) == 1
+    assert TEST_DF_1.equals(mito.dfs[0])
+
+    mito.clear()
+
+    assert TEST_DF_1.equals(mito.dfs[0])
+

--- a/mitosheet/mitosheet/tests/updates/test_clear.py
+++ b/mitosheet/mitosheet/tests/updates/test_clear.py
@@ -10,7 +10,7 @@ import pytest
 from mitosheet.code_chunks.step_performers.import_steps.simple_import_code_chunk import DEFAULT_DECIMAL
 
 from mitosheet.tests.test_utils import create_mito_wrapper_dfs
-from mitosheet.tests.decorators import pandas_post_1_only, python_post_3_6_only
+from mitosheet.tests.decorators import pandas_post_1_only, python_post_3_6_only, pandas_post_1_2_only
 
 TEST_DF_1 = pd.DataFrame({'header 1': [1], 'header 2': [2]})
 TEST_FILE_PATH = "test_file.xlsx"
@@ -144,7 +144,8 @@ def test_clear_resets_excel_imports():
     # Remove the test file
     os.remove('test.xlsx')
 
-
+@pandas_post_1_2_only
+@python_post_3_6_only
 def test_does_not_undo_excel_range_import():
     mito = create_mito_wrapper_dfs()
 


### PR DESCRIPTION
# Description

Don't clear Excel range imports on Clear. 

# Testing

See test 

# Documentation

Note if any new documentation needs to addressed or reviewed.