### PR TITLE
mitosheet: ensure backwards compatibility

### DIFF
--- a/mitosheet/mitosheet/public/README.md
+++ b/mitosheet/mitosheet/public/README.md
@@ -22,3 +22,4 @@ These don't require upgrading as they don't break or change previous analyses.
 1. Add a new folder (e.g. `v3`)
 2. Fix up all the steps so they support the new version of the public interface (and make sure to upgrade them to take this as a parameter in the step upgrader)
 3. Add code-gen on the frontend so that the new import statement are from the new public interface
+4. Make sure to add new functions to the old interfaces as well for forward compatibility on those analyses

--- a/mitosheet/mitosheet/public/v1/__init__.py
+++ b/mitosheet/mitosheet/public/v1/__init__.py
@@ -6,6 +6,7 @@ from mitosheet.public.v1.sheet_functions import *
 from mitosheet.public.v1.utils import flatten_column_header
 from mitosheet.public.v1.sheet_functions.types import to_int_series, to_boolean_series, to_float_series, to_timedelta_series, get_datetime_format
 from mitosheet.public.v1.sheet_functions.types import *
+import pandas as pd
 
 
 def register_analysis(analysis_name):
@@ -15,3 +16,7 @@ def register_analysis(analysis_name):
     """
     from mitosheet.telemetry.telemetry_utils import log
     log('ran_generated_code', {'analysis_name': analysis_name}) 
+
+
+# Forwards compatible functions
+from mitosheet.public.v2.excel_utils import get_table_range_from_upper_left_corner_value, get_read_excel_params_from_range

--- a/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_range_import.py
+++ b/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_range_import.py
@@ -168,8 +168,26 @@ def test_excel_range_import(range, input_dfs, imports, output_dfs):
 
     assert len(mito.dfs) == len(imports)
     for actual, expected in zip(mito.dfs, output_dfs):
-        print(actual)
-        print(expected)
+        assert actual.equals(expected)
+
+    os.remove(TEST_FILE_PATH)
+
+@pandas_post_1_2_only
+@python_post_3_6_only
+def test_excel_range_import_works_on_public_interface_1():
+
+    # Write an Excel file
+    with pd.ExcelWriter(TEST_FILE_PATH) as writer:
+        ((startcol, startrow), _) = get_col_and_row_indexes_from_range('A1:B2')
+        pd.DataFrame({'A': [1], "B": [2]}).to_excel(writer, sheet_name=TEST_SHEET_NAME, startrow=startrow, startcol=startcol, index=False)  
+
+    mito = create_mito_wrapper_dfs()
+    mito.mito_backend.steps_manager.public_interface_version = 1
+
+    mito.excel_range_import(TEST_FILE_PATH, TEST_SHEET_NAME, [{'type': 'upper left corner value', 'end_condition': {'type': 'first empty cell'}, 'df_name': 'dataframe_1', 'value': 'A'}])
+
+    assert len(mito.dfs) == 1
+    for actual, expected in zip(mito.dfs, [pd.DataFrame({'A': [1], "B": [2]})]):
         assert actual.equals(expected)
 
     os.remove(TEST_FILE_PATH)


### PR DESCRIPTION
# Description

This makes sure that users continuing new analyses on old versions of the public interface can access all the correct functions.

# Testing

See new test.

# Documentation

No.