### PR TITLE
mitosheet: add code snippets toolbar button

### DIFF
--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -30997,7 +30997,7 @@ ${finalCode}`;
       },
       ["CodeSnippets" /* CODESNIPPETS */]: {
         type: "CodeSnippets" /* CODESNIPPETS */,
-        shortTitle: "Code Snippets",
+        shortTitle: "Snippets",
         longTitle: "Code Snippets",
         actionFunction: () => {
           setEditorState(void 0);
@@ -38360,7 +38360,7 @@ fig.write_html("${props.graphTabName}.html")`
   // src/components/icons/CodeSnippetIcon.tsx
   var import_react166 = __toESM(require_react());
   var CodeSnippetIcon = () => {
-    return /* @__PURE__ */ import_react166.default.createElement("svg", { width: "20", height: "20", viewBox: "0 0 13 14", fill: "none", xmlns: "http://www.w3.org/2000/svg" }, /* @__PURE__ */ import_react166.default.createElement("line", { y1: "1", x2: "13", y2: "1", stroke: "#494650" }), /* @__PURE__ */ import_react166.default.createElement("line", { y1: "5", x2: "13", y2: "5", stroke: "#494650" }), /* @__PURE__ */ import_react166.default.createElement("line", { y1: "9", x2: "13", y2: "9", stroke: "#494650" }), /* @__PURE__ */ import_react166.default.createElement("line", { y1: "13", x2: "13", y2: "13", stroke: "#494650" }));
+    return /* @__PURE__ */ import_react166.default.createElement("svg", { width: "20", height: "20", viewBox: "0 0 13 14", fill: "none", xmlns: "http://www.w3.org/2000/svg" }, /* @__PURE__ */ import_react166.default.createElement("line", { y1: "1", x2: "13", y2: "1", stroke: "#494650" }), /* @__PURE__ */ import_react166.default.createElement("line", { y1: "5", x2: "13", y2: "5", stroke: "#494650" }), /* @__PURE__ */ import_react166.default.createElement("line", { y1: "9", x2: "13", y2: "9", stroke: "#494650" }));
   };
   var CodeSnippetIcon_default = CodeSnippetIcon;
 
@@ -40357,6 +40357,9 @@ fig.write_html("${props.graphTabName}.html")`
       case "AI_TRANSFORMATION" /* AI_TRANSFORMATION */: {
         return /* @__PURE__ */ import_react210.default.createElement(AIIcon_default, null);
       }
+      case "CODE_SNIPPETS" /* CODE_SNIPPETS */: {
+        return /* @__PURE__ */ import_react210.default.createElement(CodeSnippetIcon_default, null);
+      }
       case "CATCH UP" /* CATCH_UP */: {
         return /* @__PURE__ */ import_react210.default.createElement(CatchUpIcon_default, null);
       }
@@ -40713,6 +40716,7 @@ fig.write_html("${props.graphTabName}.html")`
 
   // src/components/toolbar/Toolbar.tsx
   var Toolbar = (props) => {
+    var _a;
     const importDropdownItems = [
       /* @__PURE__ */ import_react222.default.createElement(DropdownItem_default, { title: "Import Files", key: "Import Files", onClick: () => {
         props.setUIState((prevUIState) => {
@@ -41024,6 +41028,14 @@ fig.write_html("${props.graphTabName}.html")`
         action: props.actions["AI_Transformation" /* AI_TRANSFORMATION */],
         setEditorState: props.setEditorState,
         disabledTooltip: props.actions["AI_Transformation" /* AI_TRANSFORMATION */].isDisabled()
+      }
+    ), ((_a = props.userProfile.mitoConfig.MITO_CONFIG_CODE_SNIPPETS) == null ? void 0 : _a.MITO_CONFIG_CODE_SNIPPETS_URL) !== void 0 && /* @__PURE__ */ import_react222.default.createElement(
+      ToolbarButton_default,
+      {
+        toolbarButtonType: "CODE_SNIPPETS" /* CODE_SNIPPETS */,
+        action: props.actions["CodeSnippets" /* CODESNIPPETS */],
+        setEditorState: props.setEditorState,
+        disabledTooltip: props.actions["CodeSnippets" /* CODESNIPPETS */].isDisabled()
       }
     )), /* @__PURE__ */ import_react222.default.createElement("div", { className: "toolbar-bottom-right-half" }, props.currStepIdx !== props.lastStepIndex && /* @__PURE__ */ import_react222.default.createElement(
       ToolbarButton_default,

--- a/mitosheet/src/components/icons/CodeSnippetIcon.tsx
+++ b/mitosheet/src/components/icons/CodeSnippetIcon.tsx
@@ -9,9 +9,7 @@ const CodeSnippetIcon = (): JSX.Element => {
             <line y1="1" x2="13" y2="1" stroke="#494650"/>
             <line y1="5" x2="13" y2="5" stroke="#494650"/>
             <line y1="9" x2="13" y2="9" stroke="#494650"/>
-            <line y1="13" x2="13" y2="13" stroke="#494650"/>
         </svg>
-
     )
 }
 

--- a/mitosheet/src/components/toolbar/Toolbar.tsx
+++ b/mitosheet/src/components/toolbar/Toolbar.tsx
@@ -362,6 +362,14 @@ const Toolbar = (
                             disabledTooltip={props.actions[ActionEnum.AI_TRANSFORMATION].isDisabled()}
                         />
                     }
+                    {props.userProfile.mitoConfig.MITO_CONFIG_CODE_SNIPPETS?.MITO_CONFIG_CODE_SNIPPETS_URL !== undefined && 
+                        <ToolbarButton
+                            toolbarButtonType={ToolbarButtonType.CODE_SNIPPETS}
+                            action={props.actions[ActionEnum.CODESNIPPETS]}
+                            setEditorState={props.setEditorState}
+                            disabledTooltip={props.actions[ActionEnum.CODESNIPPETS].isDisabled()}
+                        />
+                    }
                 </div>
                 <div className='toolbar-bottom-right-half'>
                     {/* 

--- a/mitosheet/src/components/toolbar/utils.tsx
+++ b/mitosheet/src/components/toolbar/utils.tsx
@@ -20,6 +20,7 @@ import { Action, UserProfile } from '../../types';
 import MoreIcon from '../icons/MoreIcon';
 import LessIcon from '../icons/LessIcon';
 import AIIcon from '../icons/AIIcon';
+import CodeSnippetIcon from '../icons/CodeSnippetIcon';
 
 /* 
     Each toolbar button icon has both a light and dark option. 
@@ -56,7 +57,7 @@ export enum ToolbarButtonType {
     PIVOT = "PIVOT",
     GRAPH = "GRAPH",
     AI_TRANSFORMATION = "AI_TRANSFORMATION",
-
+    CODE_SNIPPETS = 'CODE_SNIPPETS',
 
     CATCH_UP = "CATCH UP",
     STEPS = "STEPS",
@@ -88,6 +89,7 @@ export const getToolbarItemIcon = (toolbarButtonType: ToolbarButtonType): JSX.El
         case ToolbarButtonType.PIVOT: {return <PivotIcon />}
         case ToolbarButtonType.GRAPH: {return <GraphIcon />}
         case ToolbarButtonType.AI_TRANSFORMATION: {return <AIIcon />}
+        case ToolbarButtonType.CODE_SNIPPETS: {return <CodeSnippetIcon />}
 
         case ToolbarButtonType.CATCH_UP: {return <CatchUpIcon />}
         case ToolbarButtonType.STEPS: {return <StepsIcon />}

--- a/mitosheet/src/utils/actions.tsx
+++ b/mitosheet/src/utils/actions.tsx
@@ -1284,7 +1284,7 @@ export const createActions = (
         },
         [ActionEnum.CODESNIPPETS]: {
             type: ActionEnum.CODESNIPPETS,
-            shortTitle: 'Code Snippets',
+            shortTitle: 'Snippets',
             longTitle: 'Code Snippets',
             actionFunction: () => {
                 // We turn off editing mode, if it is on


### PR DESCRIPTION
# Description

Add toolbar button for code snippets if there is a custom code snippets url set. 

# Testing

1. Set a custom code snippets url, see the code snippets button.
2. Remove the code snippets url, don't see the code snippets button. 

# Documentation

No. 