### PR TITLE
mitosheet: handle more formatting of mitosheet.sheet() call

### DIFF
--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -22661,10 +22661,12 @@ ${finalCode}`;
     return codeText.startsWith("# MITO CODE START") || codeText.startsWith("from mitosheet import *; register_analysis(") || codeText.startsWith("from mitosheet import *; # Analysis:") || codeText.startsWith("from mitosheet import *; # Analysis Name:") || startsWithPublicVersionImport;
   }
   function containsMitosheetCallWithSpecificAnalysisToReplay(codeText, analysisName) {
-    return codeText.includes("sheet(") && codeText.includes(`analysis_to_replay="${analysisName}"`);
+    const codeTextCleaned = codeText.replace(/\s/g, "");
+    return codeTextCleaned.includes("sheet(") && codeTextCleaned.includes(`analysis_to_replay="${analysisName}"`);
   }
   function containsMitosheetCallWithAnyAnalysisToReplay(codeText) {
-    return isMitosheetCallCode(codeText) && codeText.includes(`analysis_to_replay=`);
+    const codeTextCleaned = codeText.replace(/\s/g, "");
+    return isMitosheetCallCode(codeTextCleaned) && codeTextCleaned.includes(`analysis_to_replay=`);
   }
   function containsGeneratedCodeOfAnalysis(codeText, analysisName) {
     return isMitoAnalysisCode(codeText) && codeText.includes(analysisName);
@@ -22741,8 +22743,8 @@ ${finalCode}`;
     if (isMitosheetCallCode(getCellText(cell)) && containsMitosheetCallWithSpecificAnalysisToReplay(getCellText(cell), oldAnalysisName)) {
       const currentCode = getCellText(cell);
       const newCode = currentCode.replace(
-        `analysis_to_replay="${oldAnalysisName}")`,
-        `analysis_to_replay="${newAnalysisName}")`
+        RegExp(`analysis_to_replay\\s*=\\s*"${oldAnalysisName}"`),
+        `analysis_to_replay="${newAnalysisName}"`
       );
       writeToCell(cell, newCode);
       return true;

--- a/mitosheet/src/jupyter/lab/extensionUtils.tsx
+++ b/mitosheet/src/jupyter/lab/extensionUtils.tsx
@@ -168,9 +168,11 @@ export function tryOverwriteAnalysisToReplayParameter(cell: ICellModel | undefin
     if (isMitosheetCallCode(getCellText(cell)) && containsMitosheetCallWithSpecificAnalysisToReplay(getCellText(cell), oldAnalysisName)) {
         const currentCode = getCellText(cell);
 
+
+
         const newCode = currentCode.replace(
-            `analysis_to_replay="${oldAnalysisName}")`,
-            `analysis_to_replay="${newAnalysisName}")`
+            RegExp(`analysis_to_replay\\s*=\\s*"${oldAnalysisName}"`),
+            `analysis_to_replay="${newAnalysisName}"`
         )
         writeToCell(cell, newCode);
         return true;

--- a/mitosheet/src/jupyter/notebook/extensionUtils.tsx
+++ b/mitosheet/src/jupyter/notebook/extensionUtils.tsx
@@ -125,8 +125,8 @@ export function tryOverwriteAnalysisToReplayParameter(cell: CellType | undefined
         const currentCode = getCellText(cell);
 
         const newCode = currentCode.replace(
-            `analysis_to_replay="${oldAnalysisName}")`,
-            `analysis_to_replay="${newAnalysisName}")`
+            RegExp(`analysis_to_replay\\s*=\\s*"${oldAnalysisName}"`),
+            `analysis_to_replay="${newAnalysisName}"`
         )
         writeToCell(cell, newCode);
         return true;

--- a/mitosheet/src/utils/code.tsx
+++ b/mitosheet/src/utils/code.tsx
@@ -131,7 +131,9 @@ export function isMitoAnalysisCode(codeText: string): boolean {
     Returns true if the cell contains a mitosheet.sheet(analysis_to_replay={analysisName})
 */
 export function containsMitosheetCallWithSpecificAnalysisToReplay(codeText: string, analysisName: string): boolean {
-    return codeText.includes('sheet(') && codeText.includes(`analysis_to_replay="${analysisName}"`)
+    // Remove any whitespace from codeText
+    const codeTextCleaned = codeText.replace(/\s/g, '');
+    return codeTextCleaned.includes('sheet(') && codeTextCleaned.includes(`analysis_to_replay="${analysisName}"`)
 }
 
 
@@ -139,7 +141,9 @@ export function containsMitosheetCallWithSpecificAnalysisToReplay(codeText: stri
     Returns true if the cell contains a mitosheet.sheet(analysis_to_replay={analysisName})
 */
 export function containsMitosheetCallWithAnyAnalysisToReplay(codeText: string): boolean {
-    return isMitosheetCallCode(codeText) && codeText.includes(`analysis_to_replay=`)
+    // Remove any whitespace from codeText
+    const codeTextCleaned = codeText.replace(/\s/g, '');
+    return isMitosheetCallCode(codeTextCleaned) && codeTextCleaned.includes(`analysis_to_replay=`)
 }
 
 


### PR DESCRIPTION
# Description

Handles more versions of the mitosheet.sheet call. 

We used to require that it be `analysis_to_replay="${analysis_name}")`. We now support the following:
- `analysis_to_replay="${analysis_name}")`
- `analysis_to_replay = "${analysis_name}")`
- `analysis_to_replay= "${analysis_name}")`
-`analysis_to_replay = "${analysis_name}" )`


# Testing

Test creating a new mitosheet and test starting a new analysis from the failed to replay analysis due to missing import screen.  

# Documentation

No. 