### PR TITLE
mitosheet: fix bug with 8A as first value

### DIFF
--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -39068,7 +39068,8 @@ fig.write_html("${props.graphTabName}.html")`
               let finalRangeImport = rangeImport;
               if (finalRangeImport.type === "upper left corner value" && typeof finalRangeImport.value === "string") {
                 const parsedValue = parseFloat(finalRangeImport.value);
-                if (!isNaN(parsedValue)) {
+                const isOnlyNumber = /^[+-]?\d+(\.\d+)?$/.test(finalRangeImport.value);
+                if (!isNaN(parsedValue) && isOnlyNumber) {
                   finalRangeImport = __spreadProps(__spreadValues({}, rangeImport), {
                     value: parsedValue
                   });
@@ -39076,7 +39077,8 @@ fig.write_html("${props.graphTabName}.html")`
               }
               if (finalRangeImport.type === "upper left corner value" && finalRangeImport.end_condition.type === "bottom left corner value" && typeof finalRangeImport.end_condition.value === "string") {
                 const parsedValue = parseFloat(finalRangeImport.end_condition.value);
-                if (!isNaN(parsedValue)) {
+                const isOnlyNumber = /^[+-]?\d+(\.\d+)?$/.test(finalRangeImport.end_condition.value);
+                if (!isNaN(parsedValue) && isOnlyNumber) {
                   finalRangeImport = __spreadProps(__spreadValues({}, finalRangeImport), {
                     end_condition: __spreadProps(__spreadValues({}, finalRangeImport.end_condition), {
                       value: parsedValue
@@ -39086,7 +39088,8 @@ fig.write_html("${props.graphTabName}.html")`
               }
               if (finalRangeImport.type === "upper left corner value" && finalRangeImport.column_end_condition.type === "num columns" && typeof finalRangeImport.column_end_condition.value === "string") {
                 const parsedValue = parseInt(finalRangeImport.column_end_condition.value);
-                if (!isNaN(parsedValue)) {
+                const isOnlyNumber = /^[+-]?\d+(\.\d+)?$/.test(finalRangeImport.column_end_condition.value);
+                if (!isNaN(parsedValue) && isOnlyNumber) {
                   finalRangeImport = __spreadProps(__spreadValues({}, finalRangeImport), {
                     column_end_condition: __spreadProps(__spreadValues({}, finalRangeImport.column_end_condition), {
                       value: parsedValue

--- a/mitosheet/src/components/taskpanes/ExcelRangeImport/ExcelRangeImportTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/ExcelRangeImport/ExcelRangeImportTaskpane.tsx
@@ -489,7 +489,8 @@ const ExcelRangeImportTaskpane = (props: ExcelRangeImportTaskpaneProps): JSX.Ele
 
                                 if (finalRangeImport.type === 'upper left corner value' && typeof finalRangeImport.value === 'string') {
                                     const parsedValue = parseFloat(finalRangeImport.value);
-                                    if (!isNaN(parsedValue)) {
+                                    const isOnlyNumber = /^[+-]?\d+(\.\d+)?$/.test(finalRangeImport.value);
+                                    if (!isNaN(parsedValue) && isOnlyNumber) {
                                         finalRangeImport = {
                                             ...rangeImport,
                                             value: parsedValue
@@ -499,7 +500,8 @@ const ExcelRangeImportTaskpane = (props: ExcelRangeImportTaskpaneProps): JSX.Ele
 
                                 if (finalRangeImport.type === 'upper left corner value' && finalRangeImport.end_condition.type === 'bottom left corner value' && typeof finalRangeImport.end_condition.value === 'string') {
                                     const parsedValue = parseFloat(finalRangeImport.end_condition.value);
-                                    if (!isNaN(parsedValue)) {
+                                    const isOnlyNumber = /^[+-]?\d+(\.\d+)?$/.test(finalRangeImport.end_condition.value);
+                                    if (!isNaN(parsedValue) && isOnlyNumber) {
                                         finalRangeImport = {
                                             ...finalRangeImport,
                                             end_condition: {
@@ -512,7 +514,8 @@ const ExcelRangeImportTaskpane = (props: ExcelRangeImportTaskpaneProps): JSX.Ele
 
                                 if (finalRangeImport.type === 'upper left corner value' && finalRangeImport.column_end_condition.type === 'num columns' && typeof finalRangeImport.column_end_condition.value === 'string') {
                                     const parsedValue = parseInt(finalRangeImport.column_end_condition.value);
-                                    if (!isNaN(parsedValue)) {
+                                    const isOnlyNumber = /^[+-]?\d+(\.\d+)?$/.test(finalRangeImport.column_end_condition.value);
+                                    if (!isNaN(parsedValue)&& isOnlyNumber) {
                                         finalRangeImport = {
                                             ...finalRangeImport,
                                             column_end_condition: {


### PR DESCRIPTION
# Description

1. Create a mitosheet where upper left corner value is 8A.
2. Import it using range import. 

In previous versions, this would get cast to 8, which would not be found. This should work currently. 

# Testing

See above.

# Documentation

N/A.