### PR TITLE
mitosheet: don't show AI button on mitosheet-private with mec

### DIFF
--- a/mitosheet/mitosheet/enterprise/mito_config.py
+++ b/mitosheet/mitosheet/enterprise/mito_config.py
@@ -11,6 +11,7 @@ from mitosheet.types import CodeSnippetEnvVars
 from mitosheet.user.utils import is_enterprise
 from mitosheet._version import package_name
 
+
 # Note: Do not change these keys, we need them for looking up 
 # the environment variables from previous mito_config_versions.
 MITO_CONFIG_VERSION = 'MITO_CONFIG_VERSION'
@@ -183,12 +184,11 @@ class MitoConfig:
             if raw_display_ai_transform is not None:
                 return display_ai_transform
             
-        else:
-            on_enterprise = is_enterprise()
-            on_mitosheet_private = package_name == 'mitosheet-private'
+        on_enterprise = is_enterprise()
+        on_mitosheet_private = package_name == 'mitosheet-private'
 
-            if on_enterprise or on_mitosheet_private:
-                return False
+        if on_enterprise or on_mitosheet_private:
+            return False
         
         return True
     


### PR DESCRIPTION
# Description

There was a bug where mitosheet-private and enterprise users who set any mito config environment variable fell into the TRUE default case for `get_display_ai_transform`.

# Testing

- At the top of the the mito_config file, set the package_name variable = 'mitosheet-private'
- Set the `MITO_CONFIG_SUPPORT_EMAIL` environment variable. 
- Create a mitosheet and make sure that AI button is not displayed. 

# Documentation

No. 