### PR TITLE
mitosheet: fix bug with column headers in wrong order

### DIFF
--- a/mitosheet/mitosheet/parser.py
+++ b/mitosheet/mitosheet/parser.py
@@ -703,22 +703,40 @@ def replace_column_headers_and_indexes(
         elif match_type == '{HEADER}:{HEADER}':
             (column_header_one, column_header_two) = match['parsed']
 
+            # Ensure that the column headers are in the order they appear in the dataframe
+            if df.columns.get_loc(column_header_one) <= df.columns.get_loc(column_header_two):
+                first_column_header = column_header_one
+                second_column_header = column_header_two  
+            else:
+                first_column_header = column_header_two
+                second_column_header = column_header_one  
+
             # We add all of the column headers that are between these two headers
-            cols = df.loc[:, column_header_one:column_header_two].columns.tolist()
+            cols = df.loc[:, first_column_header:second_column_header].columns.tolist()
             column_headers.update(cols)
             
-            replace_string = f'{df_name}{get_header_header_selection_code(column_header_one, column_header_two)}'
+            replace_string = f'{df_name}{get_header_header_selection_code(first_column_header, second_column_header)}'
 
         elif match_type == '{HEADER}{INDEX}:{HEADER}{INDEX}':
             ((column_header_one, index_label_one), (column_header_two, index_label_two)) = match['parsed']
             (row_offset_one, row_offset_two) = match['row_offset'] # type: ignore
 
-            column_headers.add(column_header_one)
-            column_headers.add(column_header_two)
+            # Ensure that the column headers are in the order they appear in the dataframe
+            if df.columns.get_loc(column_header_one) <= df.columns.get_loc(column_header_two):
+                first_column_header = column_header_one
+                second_column_header = column_header_two  
+            else:
+                first_column_header = column_header_two
+                second_column_header = column_header_one            
+            
+            # We add all of the column headers that are between these two headers
+            cols = df.loc[:, first_column_header:second_column_header].columns.tolist()
+            column_headers.update(cols)
+
             index_labels.add(index_label_one)
             index_labels.add(index_label_two)
 
-            replace_string = f'RollingRange({df_name}{get_header_header_selection_code(column_header_one, column_header_two)}, {row_offset_one - row_offset_two + 1}, {-1 * row_offset_one})'
+            replace_string = f'RollingRange({df_name}{get_header_header_selection_code(first_column_header, second_column_header)}, {row_offset_one - row_offset_two + 1}, {-1 * row_offset_one})'
         
         formula = formula[:start] + replace_string + formula[end:]
 

--- a/mitosheet/mitosheet/parser.py
+++ b/mitosheet/mitosheet/parser.py
@@ -704,12 +704,7 @@ def replace_column_headers_and_indexes(
             (column_header_one, column_header_two) = match['parsed']
 
             # Ensure that the column headers are in the order they appear in the dataframe
-            if df.columns.get_loc(column_header_one) <= df.columns.get_loc(column_header_two):
-                first_column_header = column_header_one
-                second_column_header = column_header_two  
-            else:
-                first_column_header = column_header_two
-                second_column_header = column_header_one  
+            first_column_header, second_column_header = (column_header_one, column_header_two) if df.columns.get_loc(column_header_one) <= df.columns.get_loc(column_header_two) else (column_header_two, column_header_one) 
 
             # We add all of the column headers that are between these two headers
             cols = df.loc[:, first_column_header:second_column_header].columns.tolist()
@@ -722,12 +717,7 @@ def replace_column_headers_and_indexes(
             (row_offset_one, row_offset_two) = match['row_offset'] # type: ignore
 
             # Ensure that the column headers are in the order they appear in the dataframe
-            if df.columns.get_loc(column_header_one) <= df.columns.get_loc(column_header_two):
-                first_column_header = column_header_one
-                second_column_header = column_header_two  
-            else:
-                first_column_header = column_header_two
-                second_column_header = column_header_one            
+            first_column_header, second_column_header = (column_header_one, column_header_two) if df.columns.get_loc(column_header_one) <= df.columns.get_loc(column_header_two) else (column_header_two, column_header_one)           
             
             # We add all of the column headers that are between these two headers
             cols = df.loc[:, first_column_header:second_column_header].columns.tolist()

--- a/mitosheet/mitosheet/public/v3/rolling_range.py
+++ b/mitosheet/mitosheet/public/v3/rolling_range.py
@@ -46,7 +46,7 @@ class RollingRange():
         start = 0 + self.offset
         end = start + self.window
 
-        while (start - self.offset) < len(self.obj):            
+        while (start - self.offset) < len(self.obj): 
             df_subset = self.obj[max(0, start):end] # avoid negative start, as this wraps around to the end
 
             # We manually detect the default value case, as it messes up types otherwise (e.g. .sum().sum() returns a float with an empty df)

--- a/mitosheet/mitosheet/public/v3/sheet_functions/utils.py
+++ b/mitosheet/mitosheet/public/v3/sheet_functions/utils.py
@@ -129,7 +129,6 @@ def get_final_result_series_or_primitive(
     result: ResultType = default_value
 
     for arg in argv:
-
         result = __get_new_result_series_or_primitive(
             default_value,
             result,

--- a/mitosheet/mitosheet/tests/step_performers/column_steps/test_set_column_formula.py
+++ b/mitosheet/mitosheet/tests/step_performers/column_steps/test_set_column_formula.py
@@ -570,13 +570,19 @@ def test_set_formula_rolling_range_reference_unsorted_indexes_refences_not_next_
 
     assert mito.dfs[0].equals(pd.DataFrame({'A': [1, 2, 3], 'B': [6, 5, 3]}, index=[2, 1, 0]))
 
-def test_set_formula_wrong_order():
+def test_set_formula_wrong_index_order():
     mito = create_mito_wrapper_dfs(pd.DataFrame({'A': [1, 2, 3]}))
     mito.add_column(0, 'B')
     mito.set_formula('=SUM(A1:A0)', 0, 'B')
 
     assert mito.dfs[0].equals(pd.DataFrame({'A': [1, 2, 3], 'B': [3, 5, 3]}))
 
+def test_set_formula_wrong_column_order():
+    mito = create_mito_wrapper_dfs(pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3], 'C': [1, 2, 3]}))
+    mito.add_column(0, 'D')
+    mito.set_formula('=SUM(C:A)', 0, 'D')
+
+    assert mito.dfs[0].equals(pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3], 'C': [1, 2, 3], 'D': [18, 18, 18]}))
 
 def test_set_formula_wrong_column_order_wrong_index_order():
     mito = create_mito_wrapper_dfs(pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3], 'C': [1, 2, 3]}))
@@ -584,11 +590,3 @@ def test_set_formula_wrong_column_order_wrong_index_order():
     mito.set_formula('=SUM(C1:A0)', 0, 'D')
 
     assert mito.dfs[0].equals(pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3], 'C': [1, 2, 3], 'D': [9, 15, 9]}))
-
-
-def test_set_formula_wrong_column_order_wrong_index_order():
-    mito = create_mito_wrapper_dfs(pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3], 'C': [1, 2, 3]}))
-    mito.add_column(0, 'D')
-    mito.set_formula('=SUM(C:A)', 0, 'D')
-
-    assert mito.dfs[0].equals(pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3], 'C': [1, 2, 3], 'D': [18, 18, 18]}))

--- a/mitosheet/mitosheet/tests/step_performers/column_steps/test_set_column_formula.py
+++ b/mitosheet/mitosheet/tests/step_performers/column_steps/test_set_column_formula.py
@@ -576,3 +576,19 @@ def test_set_formula_wrong_order():
     mito.set_formula('=SUM(A1:A0)', 0, 'B')
 
     assert mito.dfs[0].equals(pd.DataFrame({'A': [1, 2, 3], 'B': [3, 5, 3]}))
+
+
+def test_set_formula_wrong_column_order_wrong_index_order():
+    mito = create_mito_wrapper_dfs(pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3], 'C': [1, 2, 3]}))
+    mito.add_column(0, 'D')
+    mito.set_formula('=SUM(C1:A0)', 0, 'D')
+
+    assert mito.dfs[0].equals(pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3], 'C': [1, 2, 3], 'D': [9, 15, 9]}))
+
+
+def test_set_formula_wrong_column_order_wrong_index_order():
+    mito = create_mito_wrapper_dfs(pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3], 'C': [1, 2, 3]}))
+    mito.add_column(0, 'D')
+    mito.set_formula('=SUM(C:A)', 0, 'D')
+
+    assert mito.dfs[0].equals(pd.DataFrame({'A': [1, 2, 3], 'B': [1, 2, 3], 'C': [1, 2, 3], 'D': [18, 18, 18]}))

--- a/mitosheet/mitosheet/tests/test_parse.py
+++ b/mitosheet/mitosheet/tests/test_parse.py
@@ -849,7 +849,7 @@ HEADER_HEADER_RANGE_TEST_CASES = [
         pd.DataFrame(get_number_data_for_df(['A', 'B', 'C'], 2), index=pd.RangeIndex(0, 2)),
         "df[\'D\'] = SUM(df.loc[:, \'A\':\'C\'])",
         set(['SUM']),
-        set(['A', "B", "C"])
+        set(["A", "B", "C"])
     ),
 ]
 
@@ -923,6 +923,26 @@ HEADER_INDEX_HEADER_INDEX_MATCHES = [
         "df['B'] = RollingRange(df[['A']], 5, -2)",
         set([]),
         set(['A'])
+    ),
+    # Headers in incorrect direction in rolling range
+    (
+        '=SUM(B0:A0)',
+        'C',
+        0,
+        pd.DataFrame(get_number_data_for_df(['A', 'B'], 3), index=pd.RangeIndex(0, 3)),
+        "df['C'] = SUM(RollingRange(df.loc[:, 'A':'B'], 1, 0))",
+        set(['SUM']),
+        set(['B', 'A'])
+    ),
+    # One range across three headers, includes the middle one
+    (
+        '=SUM(C0:A0)',
+        'D',
+        0,
+        pd.DataFrame(get_number_data_for_df(['A', 'B', 'C'], 2), index=pd.RangeIndex(0, 2)),
+        "df[\'D\'] = SUM(RollingRange(df.loc[:, 'A':'C'], 1, 0))",
+        set(['SUM']),
+        set(["A", "B", "C"])
     ),
 ]
 


### PR DESCRIPTION
# Description

If we had the dataframe `df = pd.DataFrame({'A': [1,2,3], 'B': [4,5,6]})`, and we wrote the formula `=CONCAT(C:A)`, it would error because the dataframe sent to the rolling range would be empty. This occurred because we selected columns between C and A in the dataframe (which is none)

# Testing

See tests

# Documentation

Note if any new documentation needs to addressed or reviewed.