### PR TITLE
Financial formulas

### DIFF
--- a/mitosheet/mitosheet/pro/public/v3/sheet_functions/financial_formulas.py
+++ b/mitosheet/mitosheet/pro/public/v3/sheet_functions/financial_formulas.py
@@ -46,13 +46,17 @@ def NPV(rate: NumberRestrictedInputType, *argv: NumberInputType) -> NumberFuncti
             }
         ]
     """
-    
     if rate is None:
         return 0
 
     # Create the list in the same order Excel does, nice!
+    # Note: This does not work for rolling ranges. In order to support rolling ranges, we need to recalculate this list
+    # for every index because the list should be different. ie: If the argv are (.1, RollingRange(A1:A2)), then index 1
+    # should be .1, A1, A2, index two should be .1, A2, A3, etc.
     cash_flows = get_list_from_primitive_series_and_dataframes(list(argv))
-    # Remove pd.NaN values from cash_flows
+    
+    
+    # Remove pd.NaN values from cash_flows because that is how Excel handles them. 
     cash_flows = [cash_flow for cash_flow in cash_flows if not is_value_nan_or_none(cash_flow)]
 
     def npv(rate, cash_flows):

--- a/mitosheet/mitosheet/pro/public/v3/sheet_functions/financial_formulas.py
+++ b/mitosheet/mitosheet/pro/public/v3/sheet_functions/financial_formulas.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GPL License.
+"""
+Contains all financial formulas.
+
+All functions describe their behavior with a function documentation object
+in the function docstring. Function documentation objects are described
+in more detail in docs/README.md.
+
+NOTE: This file is alphabetical order!
+"""
+import math
+from typing import Optional, Union
+import sys
+import numpy as np
+
+import pandas as pd
+
+from mitosheet.public.v3.errors import handle_sheet_function_errors
+from mitosheet.public.v3.rolling_range import RollingRange
+from mitosheet.public.v3.sheet_functions.utils import get_final_result_series_or_primitive, get_index_from_series, get_list_from_primitive_series_and_dataframes, get_series_from_primitive_or_series, is_value_nan_or_none
+from mitosheet.public.v3.types.decorators import cast_values_in_all_args_to_type, cast_values_in_arg_to_type
+from mitosheet.public.v3.types.sheet_function_types import FloatFunctonReturnType, IntFunctionReturnType, IntRestrictedInputType, NumberFunctionReturnType, NumberInputType, NumberRestrictedInputType
+
+@cast_values_in_all_args_to_type('number')
+@handle_sheet_function_errors
+def NPV(rate: NumberRestrictedInputType, *argv: NumberInputType) -> NumberFunctionReturnType:
+    """
+        "function": "NPV",
+        "description": "Calculates the net present value of a series of cash flows.",
+        "search_terms": ["npv", "net present value"],
+        "examples": [
+            "NPV(0.1, 100, 200, 300, 400)",
+            "NPV(A1, A2:A5)"
+        ],
+        "syntax": "NPV(rate, value1, [value2, ...])",
+        "syntax_elements": [{
+                "element": "rate",
+                "description": "The discount rate."
+            }, {
+                "element": "value1, value2, ...",
+                "description": "The cash flows."
+            }
+        ]
+    """
+    
+    if rate is None:
+        return 0
+
+    # Create the list in the same order Excel does, nice!
+    cash_flows = get_list_from_primitive_series_and_dataframes(list(argv))
+    # Remove pd.NaN values from cash_flows
+    cash_flows = [cash_flow for cash_flow in cash_flows if not is_value_nan_or_none(cash_flow)]
+
+    def npv(rate, cash_flows):
+        return sum([cash_flow / ((1 + rate) ** i) for i, cash_flow in enumerate(cash_flows, 1)])
+
+    if isinstance(rate, pd.Series):
+        return rate.apply(lambda rate: npv(rate, cash_flows))
+
+    return npv(rate, cash_flows)
+
+
+FINANCIAL_FORMULAS = {
+    'NPV': NPV,
+}

--- a/mitosheet/mitosheet/public/v3/sheet_functions/__init__.py
+++ b/mitosheet/mitosheet/public/v3/sheet_functions/__init__.py
@@ -6,8 +6,14 @@ from mitosheet.public.v3.sheet_functions.string_functions import *
 from mitosheet.public.v3.sheet_functions.date_functions import *
 from mitosheet.public.v3.sheet_functions.bool_functions import *
 from mitosheet.public.v3.sheet_functions.misc_functions import *
+from mitosheet.user.utils import is_pro
 
 FUNCTIONS = dict(NUMBER_FUNCTIONS, **STRING_FUNCTIONS, **DATE_FUNCTIONS, **CONTROL_FUNCTIONS, **MISC_FUNCTIONS)
+
+is_pro = is_pro()
+if is_pro:
+    from mitosheet.pro.public.v3.sheet_functions.financial_formulas import *
+    FUNCTIONS = dict(FUNCTIONS, **FINANCIAL_FORMULAS)
 
 # Overwrite __all__ so when you run from mitosheet.sheet_functions import *, it just imports the functions themselves!
 __all__ = [

--- a/mitosheet/mitosheet/public/v3/sheet_functions/number_functions.py
+++ b/mitosheet/mitosheet/public/v3/sheet_functions/number_functions.py
@@ -22,7 +22,7 @@ import pandas as pd
 
 from mitosheet.public.v3.errors import handle_sheet_function_errors
 from mitosheet.public.v3.rolling_range import RollingRange
-from mitosheet.public.v3.sheet_functions.utils import get_final_result_series_or_primitive, get_index_from_series, get_series_from_primitive_or_series
+from mitosheet.public.v3.sheet_functions.utils import get_final_result_series_or_primitive, get_index_from_series, get_list_from_primitive_series_and_dataframes, get_series_from_primitive_or_series
 from mitosheet.public.v3.types.decorators import cast_values_in_all_args_to_type, cast_values_in_arg_to_type
 from mitosheet.public.v3.types.sheet_function_types import FloatFunctonReturnType, IntFunctionReturnType, IntRestrictedInputType, NumberFunctionReturnType, NumberInputType, NumberRestrictedInputType
 
@@ -493,7 +493,7 @@ def VAR(arg: NumberInputType) -> NumberFunctionReturnType:
         return arg.stack().var() # type: ignore
     else:
         return arg.apply(lambda x: x.stack().var()) # type: ignore
-
+    
 
 NUMBER_FUNCTIONS = {
     'ABS': ABS,
@@ -513,5 +513,5 @@ NUMBER_FUNCTIONS = {
     'SUM': SUM,
     'STDEV': STDEV,
     'VALUE': VALUE,
-    'VAR': VAR
+    'VAR': VAR,
 }

--- a/mitosheet/mitosheet/public/v3/sheet_functions/utils.py
+++ b/mitosheet/mitosheet/public/v3/sheet_functions/utils.py
@@ -14,13 +14,14 @@ PrimitiveType = TypeVar('PrimitiveType', bound=Union[str, float, int, bool, date
 
 ResultType = Union[pd.Series, PrimitiveType]
 
+def is_value_nan_or_none(value: PrimitiveType) -> bool:
+    return value is None or (isinstance(value, float) and np.isnan(value))
 
 def __get_default_value_if_value_is_none_or_nan(value: PrimitiveType, default_value: PrimitiveType) -> PrimitiveType:
-    if value is None or (isinstance(value, float) and np.isnan(value)):
+    if is_value_nan_or_none(value):
         return default_value
     
     return value
-
 
 def __get_new_result_series_or_primitive_helper(
         default_value: PrimitiveType,
@@ -157,3 +158,17 @@ def get_series_from_primitive_or_series(
         return arg
     else:
         return pd.Series([arg] * len(index), index=index)
+
+def get_list_from_primitive_series_and_dataframes(argv: Union[PrimitiveType, pd.Series, pd.DataFrame]) -> List[PrimitiveType]:
+    values = []
+
+    for arg in argv:
+        print(arg)
+        if isinstance(arg, pd.Series):
+            values.extend(arg.values)
+        elif isinstance(arg, pd.DataFrame):
+            values.extend(arg.values.flatten())
+        else:
+            values.append(arg)
+
+    return values

--- a/mitosheet/mitosheet/tests/public/v3/sheet_functions/financial_functions/test_npv.py
+++ b/mitosheet/mitosheet/tests/public/v3/sheet_functions/financial_functions/test_npv.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Saga Inc.
+# Distributed under the terms of the GPL License.
+"""
+Contains tests for the NPV function.
+"""
+
+import numpy as np
+import pytest
+import pandas as pd
+
+from mitosheet.pro.public.v3.sheet_functions.financial_formulas import NPV
+
+# Raw function tests
+
+NPV_TESTS = [
+    ([.1, 1, 3, 2, 4], 7.623113175329552),
+    ([.1, pd.Series([1,3,2,4])], 7.623113175329552),
+    ([.1, pd.DataFrame({"A": [1,3,2,4]})], 7.623113175329552),
+    ([.1, pd.DataFrame({"A": [1,2], 'B': [3,4]})], 7.623113175329552),
+    ([.1, pd.Series([1,None,2,4])], 5.56724267468069),
+    ([pd.Series([.1, .1]), pd.Series([1,3,2,4])], pd.Series([7.623113175329552, 7.623113175329552])),
+    ([pd.Series([.1, .2]), pd.Series([1,3,2,4])], pd.Series([7.623113175329552, 6.003086419753087])),
+]
+
+@pytest.mark.parametrize("_argv, expected", NPV_TESTS)
+def test_NPV_works_on_inputs(_argv, expected):
+    result = NPV(*_argv)
+    if isinstance(result, pd.Series):
+        assert result.equals(expected)
+    else: 
+        assert result == expected


### PR DESCRIPTION
# Description

It's a bit tricky to add these formulas with our existing infrastructure. See this explanation, in particular the comments in the NPV function. 

This is working except for range support.

One idea:

Use our existing infrastructure, where the `_previous_result` in the `get_new_result` function is a list of discounted cashflows or a series of lists of discounted cashflows (ie: cash flow / ((1+rate)^period). Then when we get the result back, calculate the total npv by summing them together. 

To figure out the period, we could take the length of the list in the  `_previous_result`

# Testing



# Documentation
