### PR TITLE
Keyboard Formula Navigation

### DIFF
--- a/mitosheet/src/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/components/endo/EndoGrid.tsx
@@ -570,7 +570,6 @@ function EndoGrid(props: {
 
                     const {startingColumnFormula, arrowKeysScrollInFormula, editingMode} = getStartingFormula(sheetData, undefined, lastSelection.startingRowIndex, lastSelection.startingColumnIndex, e);
                     
-                    console.log(startingColumnFormula)
                     setEditorState({
                         rowIndex: lastSelection.startingRowIndex,
                         columnIndex: lastSelection.startingColumnIndex,

--- a/mitosheet/src/components/endo/EndoGrid.tsx
+++ b/mitosheet/src/components/endo/EndoGrid.tsx
@@ -570,6 +570,7 @@ function EndoGrid(props: {
 
                     const {startingColumnFormula, arrowKeysScrollInFormula, editingMode} = getStartingFormula(sheetData, undefined, lastSelection.startingRowIndex, lastSelection.startingColumnIndex, e);
                     
+                    console.log(startingColumnFormula)
                     setEditorState({
                         rowIndex: lastSelection.startingRowIndex,
                         columnIndex: lastSelection.startingColumnIndex,

--- a/mitosheet/src/components/endo/celleditor/CellEditor.tsx
+++ b/mitosheet/src/components/endo/celleditor/CellEditor.tsx
@@ -363,11 +363,11 @@ const CellEditor = (props: {
                 props.editorState.pendingSelections,
                 props.sheetData,
             );
-                
+
             props.setEditorState({
                 ...props.editorState,
                 formula: fullFormula,
-                pendingSelections: undefined
+                pendingSelections: undefined,
             })
         }
     }
@@ -463,7 +463,8 @@ const CellEditor = (props: {
                             ',',
                             '(', ')',
                             '-', '+', '*', '/',
-                            '='
+                            '=',
+                            ':'
                         ]
 
                         let arrowKeysScrollInFormula = true
@@ -479,6 +480,7 @@ const CellEditor = (props: {
                             arrowKeysScrollInFormula = props.editorState.arrowKeysScrollInFormula !== undefined && !endsInResetCharacter && !isEmpty; 
                         }
                         
+
                         props.setEditorState({
                             ...props.editorState,
                             formula: e.target.value,

--- a/mitosheet/src/components/endo/celleditor/cellEditorUtils.tsx
+++ b/mitosheet/src/components/endo/celleditor/cellEditorUtils.tsx
@@ -89,9 +89,9 @@ export const getCellEditorInputCurrentSelection = (containerDiv: HTMLDivElement 
  * Keys that don't get appended to the cell editing mode when you
  * press them, but still cause the mode to be entered.
  */
-const KEYS_TO_ENTER_CELL_EDITING_MODE_EMPTY = [
+const KEYS_TO_ENTER_CELL_EDITING_WITHOUT_CHANGING_FORMULA = [
     'Enter',
-    'Backspace'
+    'F2'
 ]
 /**
  * Called when cell editing mode is turned on, this gets the starting formula/value for
@@ -153,13 +153,13 @@ export const getStartingFormula = (
     }
     
     // If a key is pressed, we overwrite what is currently there with the key, per excel, sheets, and ag-grid
-    if (e !== undefined) {
+    if (e !== undefined && !KEYS_TO_ENTER_CELL_EDITING_WITHOUT_CHANGING_FORMULA.includes(e.key)) {
         if (e.key === 'Backspace') {
             // If it's a delete, delete only the last character. We do not delete everything, even though excel 
-            // does, because, like ag-grid, we don't support editing by pressing F2
+            // does, because, we don't want to encourage single cell editing like this.
             originalValue = originalValue.substr(0, originalValue.length - 1);
-        } else {
-            originalValue += (KEYS_TO_ENTER_CELL_EDITING_MODE_EMPTY.includes(e.key) ? '' : e.key);
+        } else if (e.key !== 'Enter') {
+            originalValue =  e.key;
         }
     }    
 

--- a/mitosheet/src/components/endo/celleditor/cellEditorUtils.tsx
+++ b/mitosheet/src/components/endo/celleditor/cellEditorUtils.tsx
@@ -158,7 +158,7 @@ export const getStartingFormula = (
             // If it's a delete, delete only the last character. We do not delete everything, even though excel 
             // does, because, we don't want to encourage single cell editing like this.
             originalValue = originalValue.substr(0, originalValue.length - 1);
-        } else if (e.key !== 'Enter') {
+        } else {
             originalValue =  e.key;
         }
     }    


### PR DESCRIPTION
# Description

Implements the keyboard formula navigation improvements from https://www.notion.so/trymito/Cell-Editing-UI-1955396ade8244f58cca4d2c55755de7

# Testing

- Start writing a formula and write `:`, then use arrow keys to scroll in the grid instead of in the formula
- Use `=` to enter cell editing mode and notice that it creates a new formula that starts with `=` instead of appending `=` to the end of the cell editor. Just like Excel
- Press `F2` (function + F2) to enter cell editing mode. Notice that it opens the formula to the current formula without any changes. Just like Excel. However, we also support the same interaction with `Enter`

Tested on Mac + windows

# Documentation

Note if any new documentation needs to addressed or reviewed.