### PR TITLE
mitosheet: support filenames with single quotes

### DIFF
--- a/mitosheet/mitosheet/code_chunks/step_performers/import_steps/excel_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/import_steps/excel_import_code_chunk.py
@@ -37,7 +37,11 @@ class ExcelImportCodeChunk(CodeChunk):
             self.decimal
         )
 
-        read_excel_line = f'sheet_df_dictonary = pd.read_excel(r\'{self.file_name}\', engine=\'openpyxl\''
+        if "'" in self.file_name:
+            raw_file_name = f'r\"{self.file_name}\"'
+        else:
+            raw_file_name = f"r\'{self.file_name}\'"
+        read_excel_line = f'sheet_df_dictonary = pd.read_excel({raw_file_name}, engine=\'openpyxl\''
         for key, value in read_excel_params.items():
             # We use this slighly misnamed function to make sure values get transpiled right
             read_excel_line += f", {key}={column_header_to_transpiled_code(value)}"

--- a/mitosheet/mitosheet/code_chunks/step_performers/import_steps/simple_import_code_chunk.py
+++ b/mitosheet/mitosheet/code_chunks/step_performers/import_steps/simple_import_code_chunk.py
@@ -50,7 +50,11 @@ def generate_read_csv_code(file_name: str, df_name: str, delimeter: str, encodin
     params = get_read_csv_params(delimeter, encoding, decimal=decimal, skiprows=skiprows, error_bad_lines=error_bad_lines)
     params_string = ', '.join(f'{key}={column_header_to_transpiled_code(value)}' for key, value in params.items())
 
-    return f'{df_name} = pd.read_csv(r\'{file_name}\'{", " if len(params_string) > 0 else ""}{params_string})'
+    if "'" in file_name:
+        raw_file_name = f'r\"{file_name}\"'
+    else:
+        raw_file_name = f"r\'{file_name}\'"
+    return f'{df_name} = pd.read_csv({raw_file_name}{", " if len(params_string) > 0 else ""}{params_string})'
 
 
 class SimpleImportCodeChunk(CodeChunk):

--- a/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_import.py
+++ b/mitosheet/mitosheet/tests/step_performers/import_steps/test_excel_import.py
@@ -34,6 +34,27 @@ def test_can_import_a_single_excel():
 
 @pandas_post_1_only
 @python_post_3_6_only
+def test_can_import_a_single_excel_with_quote_in_file_name():
+    TEST_FILE = "dataQ1'22.xlsx"
+    df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})
+    df.to_excel(TEST_FILE, index=False)
+
+    # Create with no dataframes
+    mito = create_mito_wrapper_dfs()
+    # And then import just a test file
+    mito.excel_import(TEST_FILE, ['Sheet1'], True, 0, DEFAULT_DECIMAL)
+
+    # Make sure a step has been created, and that the dataframe is the correct dataframe
+    assert mito.curr_step.step_type == 'excel_import'
+    assert len(mito.dfs) == 1
+    assert mito.dfs[0].equals(df)
+    assert mito.df_names == ['Sheet1']
+
+    # Remove the test file
+    os.remove(TEST_FILE)
+
+@pandas_post_1_only
+@python_post_3_6_only
 def test_can_import_with_no_headers_and_skiprows():
     df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})
     df.to_excel(TEST_FILE, index=False)

--- a/mitosheet/mitosheet/tests/step_performers/import_steps/test_simple_import_step.py
+++ b/mitosheet/mitosheet/tests/step_performers/import_steps/test_simple_import_step.py
@@ -103,6 +103,24 @@ def test_can_import_a_single_csv_with_a_single_column():
     # Remove the test file
     os.remove(TEST_FILE_PATHS[0])
 
+def test_can_import_csv_with_quote_in_file_name():
+    TEST_FILE = "dataQ1'22.csv"
+    df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})
+    df.to_csv(TEST_FILE, index=False)
+
+    # Create with no dataframes
+    mito = create_mito_wrapper_dfs()
+    # And then import just a test file
+    mito.simple_import([TEST_FILE])
+
+    # Make sure a step has been created, and that the dataframe is the correct dataframe
+    assert mito.curr_step.step_type == 'simple_import'
+    assert len(mito.dfs) == 1
+    assert mito.dfs[0].equals(df)
+
+    # Remove the test file
+    os.remove(TEST_FILE)
+
 def test_creates_valid_name():
     df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4]})
     df.to_csv('1.csv', index=False)


### PR DESCRIPTION
# Description

Supports file names with quotes in them

# Testing

Try importing a file like `dataQ1'22.csv` and  `dataQ1'22.xlsx`. Make sure that the generated code is valid. 

# Documentation

No. 