### PR TITLE
mitosheet: stop making infinite divs for dropdowns

### DIFF
--- a/mitosheet/mitosheet/mito_frontend.js
+++ b/mitosheet/mitosheet/mito_frontend.js
@@ -21158,7 +21158,9 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
       left: void 0
     });
     const dropdownAnchor = (0, import_react4.useRef)(null);
-    const dropdownContainerElement = (0, import_react4.useRef)(document.createElement("div"));
+    const [dropdownContainerElement] = (0, import_react4.useState)(() => {
+      return document.createElement("div");
+    });
     const [isNotFullscreen, setIsNotFullscreen] = (0, import_react4.useState)(fscreen_esm_default.fullscreenElement === void 0 || fscreen_esm_default.fullscreenElement === null);
     const mitoContainerRef = (0, import_react4.useRef)(null);
     const width = props.width || "large";
@@ -21167,10 +21169,10 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
       return () => {
         try {
           if (isNotFullscreen) {
-            document.body.removeChild(dropdownContainerElement.current);
+            document.body.removeChild(dropdownContainerElement);
           } else {
             if (mitoContainerRef.current) {
-              mitoContainerRef.current.removeChild(dropdownContainerElement.current);
+              mitoContainerRef.current.removeChild(dropdownContainerElement);
             }
           }
         } catch (e) {
@@ -21181,11 +21183,11 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
       if (unsavedDropdownAnchor !== null) {
         dropdownAnchor.current = unsavedDropdownAnchor;
         if (isNotFullscreen) {
-          document.body.append(dropdownContainerElement.current);
+          document.body.append(dropdownContainerElement);
         } else {
           const mitoContainer = unsavedDropdownAnchor.closest(".mito-container");
           if (mitoContainer) {
-            mitoContainer.appendChild(dropdownContainerElement.current);
+            mitoContainer.appendChild(dropdownContainerElement);
             mitoContainerRef.current = mitoContainer;
           }
         }
@@ -21208,11 +21210,11 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
         var _a;
         setIsNotFullscreen(!fscreen_esm_default.fullscreenElement);
         if (!fscreen_esm_default.fullscreenElement) {
-          document.body.append(dropdownContainerElement.current);
+          document.body.append(dropdownContainerElement);
         } else {
           const mitoContainer = (_a = dropdownAnchor.current) == null ? void 0 : _a.closest(".mito-container");
           if (mitoContainer) {
-            mitoContainer.appendChild(dropdownContainerElement.current);
+            mitoContainer.appendChild(dropdownContainerElement);
             mitoContainerRef.current = mitoContainer;
           }
         }
@@ -21328,7 +21330,7 @@ For more info, visit https://reactjs.org/link/mock-scheduler`);
         childrenToDisplay.length > 0 && /* @__PURE__ */ import_react4.default.createElement("div", { className: "mito-dropdown-items-container" }, childrenToDisplay),
         found === 0 && /* @__PURE__ */ import_react4.default.createElement(Row_default, { justify: "center", style: { paddingTop: "50px" } }, /* @__PURE__ */ import_react4.default.createElement("p", { className: "text-body-2" }, "No options to display"))
       ),
-      dropdownContainerElement.current
+      dropdownContainerElement
     ));
   };
   var Dropdown_default = Dropdown;

--- a/mitosheet/src/components/elements/Dropdown.tsx
+++ b/mitosheet/src/components/elements/Dropdown.tsx
@@ -235,8 +235,11 @@ const Dropdown = (props: DropdownProps): JSX.Element => {
     const dropdownAnchor = useRef<HTMLDivElement | null>(null);
 
     // The div that contains the actual dropdown, and is added to the highest
-    // level of the html, so the dropdown's z-index can be above everything else
-    const dropdownContainerElement = useRef(document.createElement("div"));
+    // level of the html, so the dropdown's z-index can be above everything else.
+    // We onlt need one of these 
+    const [dropdownContainerElement] = useState(() => {
+        return document.createElement("div")
+    })
     // We store if this select was created when the element was in fullscreen or
     // not, which is helpful for cleaning up the select
     const [isNotFullscreen, setIsNotFullscreen] = useState(fscreen.fullscreenElement === undefined || fscreen.fullscreenElement === null);
@@ -253,10 +256,10 @@ const Dropdown = (props: DropdownProps): JSX.Element => {
         return () => {
             try {
                 if (isNotFullscreen) {
-                    document.body.removeChild(dropdownContainerElement.current)
+                    document.body.removeChild(dropdownContainerElement)
                 } else {
                     if (mitoContainerRef.current) {
-                        mitoContainerRef.current.removeChild(dropdownContainerElement.current)
+                        mitoContainerRef.current.removeChild(dropdownContainerElement)
                     }
                 }
             } catch {
@@ -275,13 +278,13 @@ const Dropdown = (props: DropdownProps): JSX.Element => {
             if (isNotFullscreen) {
                 // Add element to the document, if we're not in 
                 // fullscreen mode
-                document.body.append(dropdownContainerElement.current);
+                document.body.append(dropdownContainerElement);
             } else {
                 // If we are in fullscreen mode, then place the dropdownContainerElement in the
                 // mitoContainer so that it is visible in fullscreen mode
                 const mitoContainer = unsavedDropdownAnchor.closest('.mito-container');
                 if (mitoContainer) {
-                    mitoContainer.appendChild(dropdownContainerElement.current)
+                    mitoContainer.appendChild(dropdownContainerElement)
                     mitoContainerRef.current = mitoContainer;
                 }
             }
@@ -318,13 +321,13 @@ const Dropdown = (props: DropdownProps): JSX.Element => {
             if (!fscreen.fullscreenElement) {
                 // Add element to the document, if we're not in 
                 // fullscreen mode
-                document.body.append(dropdownContainerElement.current);
+                document.body.append(dropdownContainerElement);
             } else {
                 // If we are in fullscreen mode, then place the dropdownContainerElement in the
                 // mitoContainer so that it is visible in fullscreen mode
                 const mitoContainer = dropdownAnchor.current?.closest('.mito-container');
                 if (mitoContainer) {
-                    mitoContainer.appendChild(dropdownContainerElement.current)
+                    mitoContainer.appendChild(dropdownContainerElement)
                     mitoContainerRef.current = mitoContainer;
                 }
             }
@@ -498,7 +501,7 @@ const Dropdown = (props: DropdownProps): JSX.Element => {
                             </p>
                         </Row>}
                 </div>,
-                dropdownContainerElement.current
+                dropdownContainerElement
             )}
         </div>
     );


### PR DESCRIPTION
# Description

We had a bug where we were previously creating a _new_ div on every rerender
of every dropdown. This bug has been in Mito for a very long time. It's not
clear that the observered bugs we found were a function of this issue - but 
it is def not good news! This PR fixes it up.

# Testing


First, try the dev branch of Mito. Import some data. Open the console
and run the code `document.body.querySelectorAll('div').length`. Then scroll
around in Mito, and then run `document.body.querySelectorAll('div').length` 
again. You will see the number of divs has increased!

Now, try the same steps on this branch. You will see that here, we do not
increase the number of divs over time.

# Documentation

Note if any new documentation needs to addressed or reviewed.