### PR TITLE
mitosheet: cleanup header

### DIFF
--- a/trymito.io/components/Footer/Footer.tsx
+++ b/trymito.io/components/Footer/Footer.tsx
@@ -3,7 +3,7 @@ import Image from "next/image"
 import footerStyle from './Footer.module.css'
 import pageStyle from '../../styles/Page.module.css'
 import { MITO_GITHUB_LINK } from '../GithubButton/GithubButton';
-import { MITO_INSTALLATION_DOCS_LINK } from '../Header/Header';
+import { JOBS_BOARD_LINK, MITO_INSTALLATION_DOCS_LINK } from '../Header/Header';
 
 const Footer = (): JSX.Element => {
 
@@ -45,6 +45,9 @@ const Footer = (): JSX.Element => {
                         <Link href='/security'>Security</Link>
                     </li>
                     <li className='text-nav'>
+                        <Link href='/teams'>Teams</Link>
+                    </li>
+                    <li className='text-nav'>
                         <a href='https://join.slack.com/t/trymito/shared_invite/zt-1h6t163v7-xLPudO7pjQNKccXz7h7GSg' target="_blank" rel="noreferrer">Support</a>
                     </li>
                 </div>
@@ -76,7 +79,7 @@ const Footer = (): JSX.Element => {
                         <a href='https://blog.trymito.io'>Blog</a>
                     </li>
                     <li className='text-nav'>
-                        <a href='https://www.ycombinator.com/companies/mito/jobs' target="_blank" rel="noreferrer">Jobs</a>
+                        <a href={JOBS_BOARD_LINK} target="_blank" rel="noreferrer">Jobs</a>
                     </li>
                     <li className='text-nav'>
                         <a href='https://twitter.com/tryMito' target="_blank" rel="noreferrer">Twitter</a>

--- a/trymito.io/components/Header/Header.module.css
+++ b/trymito.io/components/Header/Header.module.css
@@ -2,7 +2,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-  
+    
     padding: 2rem 4rem;
     background-color: rgba(45, 45, 45, .98);
   
@@ -96,7 +96,7 @@
     }
 
     .desktop_left_nav_bar * + * {
-        margin-left: 1.5rem;
+        margin-left: 2.5rem;
     }
 
     .desktop_menu_items {

--- a/trymito.io/components/Header/Header.module.css
+++ b/trymito.io/components/Header/Header.module.css
@@ -10,13 +10,14 @@
     top: 0; /* Position the navbar at the top of the page */
     box-sizing: border-box;
     width: 100%;
+
     z-index: 1; /* Make sure everything scrolls behind the nav bar */
 }
 
 .header li {
     list-style: none;
     color: var(--color-text-secondary);
-    font-size: 3rem;
+    font-size: 2rem;
     margin-top: 2rem;
 }
 
@@ -67,7 +68,6 @@
     display: none;
 }
 
-.desktop_center_nav_bar,
 .desktop_right_nav_bar {
     display: none;
 }
@@ -76,55 +76,35 @@
 
     .header {
         padding-top: 1.5rem;
-        padding-bottom: 2 rem; 
+        padding-bottom: 2rem; 
     }
 
-    .desktop_center_nav_bar {
+    .desktop_left_nav_bar,
+    .desktop_right_nav_bar {
         display: flex;
-        flex-direction: row;
-        justify-content: center;
-        color: var(--color-text-primary);
     }
 
-    .desktop_center_nav_bar li {
+    .desktop_left_nav_bar {
+        align-items: center;
+    }
+
+    .desktop_left_nav_bar li {
         /* Turns the list horizontal instead of vertical default */
         display: inline;
         font-size: 1.375rem;
         margin-top: 0;
     }
 
-    .desktop_center_nav_bar li + li {
-        margin-left: 2rem;
+    .desktop_left_nav_bar * + * {
+        margin-left: 1.5rem;
     }
 
-    .desktop_center_nav_bar ul {
-        margin: 0;
-    }
-
-    .desktop_right_nav_bar {
+    .desktop_menu_items {
         display: flex;
+        height: 1.75rem;
         flex-direction: row;
-        justify-content: flex-end;
-    }
-}
-
-@media only screen and (min-width: 80em) {
-    /* 
-        We add an additional media query to change the spacing of the
-        left, center, and right nav bar in desktop mode. 
-        When the screen gets big enough, we evenly space all three
-        nav bar elements to ensure that the center nav var is always
-        exactly in the middle of the screen. 
-        When the screen is smaller than this, the center nav bar
-        and right nav bar get too close together when the nav bar
-        is centered in the middle of the screen. So if the screen
-        is any smaller than this, we allow the three components
-        to have a consistent amount of space between them.
-    */
-
-    .desktop_left_nav_bar,
-    .desktop_center_nav_bar,
-    .desktop_right_nav_bar {
-        flex: 1;
+        justify-content: space-between;
+        overflow-x: hidden;
+        overflow-y: hidden;
     }
 }

--- a/trymito.io/components/Header/Header.tsx
+++ b/trymito.io/components/Header/Header.tsx
@@ -37,7 +37,7 @@ const Header = (): JSX.Element => {
                   <a href='https://docs.trymito.io' target="_blank" rel="noreferrer">Docs</a>
                 </li>
                 <li className='text-nav'>
-                  <a href={JOBS_BOARD_LINK} target="_blank" rel="noreferrer">We're hiring!</a>
+                  <a href={JOBS_BOARD_LINK} target="_blank" rel="noreferrer">We&apos;re hiring!</a>
                 </li>
               </ul>
             </nav>
@@ -86,9 +86,6 @@ const Header = (): JSX.Element => {
                   <Link href='/plans'>Plans</Link>
                 </li>
                 <li className='text-nav'>
-                  <Link href='/teams'>Teams</Link>
-                </li>
-                <li className='text-nav'>
                   <Link href='/security'>Security</Link>
                 </li>
                 <li className='text-nav'>
@@ -99,6 +96,9 @@ const Header = (): JSX.Element => {
                 </li>
                 <li className='text-nav'>
                   <a href={MITO_GITHUB_LINK} target="_blank" rel="noreferrer">GitHub</a>
+                </li>
+                <li className='text-nav'>
+                  <a href={JOBS_BOARD_LINK} target="_blank" rel="noreferrer">We&apos;re hiring!</a>
                 </li>
               </ul>
             </nav>

--- a/trymito.io/components/Header/Header.tsx
+++ b/trymito.io/components/Header/Header.tsx
@@ -8,6 +8,7 @@ import TranslucentButton from "../TranslucentButton/TranslucentButton"
 import GithubButton, { MITO_GITHUB_LINK } from "../GithubButton/GithubButton"
 
 export const MITO_INSTALLATION_DOCS_LINK = 'https://docs.trymito.io/getting-started/installing-mito'
+export const JOBS_BOARD_LINK = 'https://www.ycombinator.com/companies/mito/jobs'
 
 const Header = (): JSX.Element => {
 
@@ -21,16 +22,10 @@ const Header = (): JSX.Element => {
                 <Image src="/Mito.svg" alt="Mito Logo" width={50} height={30}/>
               </a>
             </Link>
-          </div>
-
-          <div className={stylesHeader.desktop_center_nav_bar + ' ' + stylesHeader.desktop_header_component}>
-            <nav>
+            <nav className={stylesHeader.desktop_menu_items +' display-desktop-only-inline-block'}>
               <ul>
                 <li className='text-nav'>
                   <Link href='/plans'>Plans</Link>
-                </li>
-                <li className='text-nav'>
-                  <Link href='/teams'>Teams</Link>
                 </li>
                 <li className='text-nav'>
                   <Link href='/security'>Security</Link>
@@ -40,6 +35,9 @@ const Header = (): JSX.Element => {
                 </li>
                 <li className='text-nav'>
                   <a href='https://docs.trymito.io' target="_blank" rel="noreferrer">Docs</a>
+                </li>
+                <li className='text-nav'>
+                  <a href={JOBS_BOARD_LINK} target="_blank" rel="noreferrer">We're hiring!</a>
                 </li>
               </ul>
             </nav>

--- a/trymito.io/components/Header/Header.tsx
+++ b/trymito.io/components/Header/Header.tsx
@@ -46,7 +46,7 @@ const Header = (): JSX.Element => {
           <div className={stylesHeader.desktop_right_nav_bar}>
               <GithubButton 
                 variant='Star'
-                text='Star on Github'
+                text='Github'
               />              
               <TranslucentButton
                 href={MITO_INSTALLATION_DOCS_LINK}

--- a/trymito.io/styles/globals.css
+++ b/trymito.io/styles/globals.css
@@ -250,6 +250,7 @@ a {
 .text-nav {
   color: var(--color-text-primary);
   font-size: 1.25rem;
+  border-radius: 3px;
 }
 
 .text-nav:hover {


### PR DESCRIPTION
# Description

Fixes spacing issues on website by:
1. reducing complexity of header by getting rid of the middle header. It is now left aligned 
2. hiding some of the less important header items when it gets too small
3. removes the teams page from the header, which needs a new pass and doesn't really capture how we want to talk about teams anymore. 

Also, adds "we're hiring" to the header. 

# Testing

Test this with different screens + mobile

# Documentation

No. 