### PR TITLE
mitosheet: fix up bug with formatting during pivot tables

### DIFF
--- a/mitosheet/src/components/Mito.tsx
+++ b/mitosheet/src/components/Mito.tsx
@@ -530,6 +530,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
                         lastStepIndex={lastStepSummary.step_idx}
                         lastStepType={lastStepSummary.step_type}
                         analysisData={analysisData}
+                        closeOpenEditingPopups={closeOpenEditingPopups}
                     />
                 )
             case TaskpaneType.UPGRADE_TO_PRO: return (
@@ -935,6 +936,7 @@ export const Mito = (props: MitoProps): JSX.Element => {
                     setEditorState={setEditorState}
                     analysisData={analysisData}
                     sheetIndex={uiState.selectedSheetIndex}
+                    closeOpenEditingPopups={closeOpenEditingPopups}
                 />
                 <div className="mito-center-content-container" id="mito-center-content-container"> 
                     <div className={formulaBarAndSheetClassNames}>

--- a/mitosheet/src/components/taskpanes/ControlPanel/ControlPanelTaskpane.tsx
+++ b/mitosheet/src/components/taskpanes/ControlPanel/ControlPanelTaskpane.tsx
@@ -51,6 +51,7 @@ type ControlPanelTaskpaneProps = {
     lastStepIndex: number,
     lastStepType: StepType,
     analysisData: AnalysisData;
+    closeOpenEditingPopups: () => void;
 }
 
 
@@ -170,6 +171,7 @@ export const ControlPanelTaskpane = (props: ControlPanelTaskpaneProps): JSX.Elem
                                 gridState={props.gridState}
                                 columnDtype={columnDtype}
                                 sheetData={props.sheetData}
+                                closeOpenEditingPopups={props.closeOpenEditingPopups}
                             />
                             <SortCard
                                 selectedSheetIndex={props.selectedSheetIndex}

--- a/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/FormatCard.tsx
+++ b/mitosheet/src/components/taskpanes/ControlPanel/FilterAndSortTab/FormatCard.tsx
@@ -21,7 +21,8 @@ function FormatCard(props: {
     gridState: GridState,
     mitoAPI: MitoAPI,
     columnDtype: string
-    sheetData: SheetData | undefined 
+    sheetData: SheetData | undefined,
+    closeOpenEditingPopups: () => void
 }): JSX.Element {
     const formatTypeTitle = getFormatTitle(props.sheetData?.dfFormat.columns[props.columnID])
 
@@ -43,7 +44,7 @@ function FormatCard(props: {
                         <Select
                             value={formatTypeTitle}
                         >
-                            {getColumnFormatDropdownItems(props.gridState.sheetIndex, props.sheetData, [props.columnID], props.mitoAPI)}
+                            {getColumnFormatDropdownItems(props.gridState.sheetIndex, props.sheetData, [props.columnID], props.mitoAPI, props.closeOpenEditingPopups)}
                         </Select>
                     }
                     {!isNumberDtype(props.columnDtype) &&

--- a/mitosheet/src/components/toolbar/Toolbar.tsx
+++ b/mitosheet/src/components/toolbar/Toolbar.tsx
@@ -43,7 +43,8 @@ const Toolbar = (
         userProfile: UserProfile;
         setEditorState: React.Dispatch<React.SetStateAction<EditorState | undefined>>;
         analysisData: AnalysisData,
-        sheetIndex: number
+        sheetIndex: number,
+        closeOpenEditingPopups: () => void
     }): JSX.Element => {  
 
 
@@ -352,7 +353,7 @@ const Toolbar = (
                                 })
                             }
                         >
-                            {getColumnFormatDropdownItems(props.gridState.sheetIndex, props.sheetData, getSelectedNumberSeriesColumnIDs(props.gridState.selections, props.sheetData), props.mitoAPI)}
+                            {getColumnFormatDropdownItems(props.gridState.sheetIndex, props.sheetData, getSelectedNumberSeriesColumnIDs(props.gridState.selections, props.sheetData), props.mitoAPI, props.closeOpenEditingPopups)}
                         </Dropdown>
                     </ToolbarButton>
 

--- a/mitosheet/src/utils/actions.tsx
+++ b/mitosheet/src/utils/actions.tsx
@@ -785,6 +785,8 @@ export const createActions = (
             shortTitle: 'Less',
             longTitle: 'Decrease decimal places displayed',
             actionFunction: async () => {  
+                closeOpenEditingPopups();
+
                 const selectedNumberSeriesColumnIDs = getSelectedNumberSeriesColumnIDs(gridState.selections, sheetData);
                 const newDfFormat: DataframeFormat = window.structuredClone(dfFormat);
                 selectedNumberSeriesColumnIDs.forEach((columnID) => {
@@ -810,6 +812,8 @@ export const createActions = (
             shortTitle: 'More',
             longTitle: 'Increase decimal places displayed',
             actionFunction: async () => {  
+                closeOpenEditingPopups();
+
                 const selectedNumberSeriesColumnIDs = getSelectedNumberSeriesColumnIDs(gridState.selections, sheetData);
                 const newDfFormat: DataframeFormat = window.structuredClone(dfFormat);
                 selectedNumberSeriesColumnIDs.forEach((columnID) => {

--- a/mitosheet/src/utils/format.tsx
+++ b/mitosheet/src/utils/format.tsx
@@ -126,12 +126,16 @@ export const getColumnFormatDropdownItems = (
     sheetData: SheetData | undefined,
     columnIDs: ColumnID[], 
     mitoAPI: MitoAPI, 
+    closeOpenEditingPopups: () => void
 ): JSX.Element[] => {
 
     const numberColumnColumnIDs = getNumberColumnIDs(sheetData, columnIDs);
     const appliedFormatting = sheetData?.dfFormat.columns[numberColumnColumnIDs[0]];
 
     const onClick = (columnFormat: ColumnFormatType | undefined): void => {
+        // Close any open editing taskpanes
+        closeOpenEditingPopups()
+
         void changeFormatOfColumns(
             sheetIndex, 
             sheetData,


### PR DESCRIPTION
# Description

1. Make a pivot that results in number column, keep pivot taskpane open
2. Try and increase or decrease precision of decimals
3. The pivot should close, since it's not the last step id

Previously, this would brick the pivot taskpane.

# Testing

See above.

# Documentation

No.